### PR TITLE
fix: correct typo SOURCE_GET_SOURCE_PUBLIC_KEY → GET_SOURCE_PUBLIC_KEY

### DIFF
--- a/src/PureMyHA/MySQL/Query.hs
+++ b/src/PureMyHA/MySQL/Query.hs
@@ -126,7 +126,7 @@ changeReplicationSourceTo conn host port replUser replPassword = do
             <> ", SOURCE_USER='" <> replUser <> "'"
             <> ", SOURCE_PASSWORD='" <> replPassword <> "'"
             <> ", SOURCE_AUTO_POSITION=1"
-            <> ", SOURCE_GET_SOURCE_PUBLIC_KEY=1"
+            <> ", GET_SOURCE_PUBLIC_KEY=1"
   _ <- execute_ conn (toQuery (BL.fromStrict (TE.encodeUtf8 sql)))
   pure ()
 


### PR DESCRIPTION
  ## Summary

  - Fix a typo in the `CHANGE REPLICATION SOURCE TO` SQL statement inside `changeReplicationSourceTo` (`src/PureMyHA/MySQL/Query.hs`)
  - `SOURCE_GET_SOURCE_PUBLIC_KEY` is not a valid MySQL 8.4 option — the correct name is `GET_SOURCE_PUBLIC_KEY`
  - This typo caused a SQL syntax error 1064 when running `purermyha demote`
