### PR TITLE
fix: rename purermyha → puremyha (remove extra 'r' typo)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/.cabal/store
-          key: cabal-${{ matrix.arch }}-${{ hashFiles('purermyha.cabal', 'cabal.project') }}
+          key: cabal-${{ matrix.arch }}-${{ hashFiles('puremyha.cabal', 'cabal.project') }}
           restore-keys: cabal-${{ matrix.arch }}-
 
       - name: Build and test in Docker

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ${{ github.workspace }}/.cabal-store
-          key: cabal-${{ matrix.arch }}-${{ hashFiles('purermyha.cabal', 'cabal.project') }}
+          key: cabal-${{ matrix.arch }}-${{ hashFiles('puremyha.cabal', 'cabal.project') }}
           restore-keys: cabal-${{ matrix.arch }}-
 
       - name: Build and test in Docker
@@ -42,7 +42,7 @@ jobs:
               cabal build all &&
               cabal test --test-show-details=always &&
               mkdir -p dist-bins &&
-              cabal install exe:purermyhad exe:purermyha \
+              cabal install exe:puremyhad exe:puremyha \
                 --installdir=dist-bins \
                 --install-method=copy \
                 --overwrite-policy=always
@@ -78,7 +78,7 @@ jobs:
           path: dist-bins/
 
       - name: Make binaries executable
-        run: chmod +x dist-bins/purermyhad dist-bins/purermyha
+        run: chmod +x dist-bins/puremyhad dist-bins/puremyha
 
       - name: Install nfpm
         run: |
@@ -106,10 +106,10 @@ jobs:
           PKG_TYPE="${{ matrix.pkg_type }}"
 
           if [ "${PKG_TYPE}" = "deb" ]; then
-            PKG_NAME="purermyha_${VERSION}_${NFPM_ARCH}.deb"
+            PKG_NAME="puremyha_${VERSION}_${NFPM_ARCH}.deb"
           else
             if [ "${NFPM_ARCH}" = "amd64" ]; then RPM_ARCH="x86_64"; else RPM_ARCH="aarch64"; fi
-            PKG_NAME="purermyha-${VERSION}-1.${RPM_ARCH}.rpm"
+            PKG_NAME="puremyha-${VERSION}-1.${RPM_ARCH}.rpm"
           fi
 
           nfpm pkg \
@@ -121,7 +121,7 @@ jobs:
         uses: actions/upload-artifact@v6
         with:
           name: pkg-${{ matrix.arch }}-${{ matrix.pkg_type }}
-          path: "purermyha*.${{ matrix.pkg_type }}"
+          path: "puremyha*.${{ matrix.pkg_type }}"
           if-no-files-found: error
 
   release:

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM haskell:9.6 AS build
 WORKDIR /build
 
 # Copy dependency metadata first for layer caching
-COPY purermyha.cabal cabal.project ./
+COPY puremyha.cabal cabal.project ./
 
 # Build only dependencies (cached unless .cabal or cabal.project changes)
 RUN cabal update && cabal build --only-dependencies all
@@ -20,8 +20,8 @@ RUN cabal test
 
 # Stage binaries to a known location
 RUN mkdir -p /staging && \
-    cp "$(cabal list-bin purermyhad)" /staging/purermyhad && \
-    cp "$(cabal list-bin purermyha)"  /staging/purermyha
+    cp "$(cabal list-bin puremyhad)" /staging/puremyhad && \
+    cp "$(cabal list-bin puremyha)"  /staging/puremyha
 
 # Stage 2: runtime
 FROM debian:bookworm-slim
@@ -31,11 +31,11 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Copy binaries
-COPY --from=build /staging/purermyhad /usr/sbin/purermyhad
-COPY --from=build /staging/purermyha  /usr/bin/purermyha
+COPY --from=build /staging/puremyhad /usr/sbin/puremyhad
+COPY --from=build /staging/puremyha  /usr/bin/puremyha
 
 # Copy config example and systemd service
-COPY config/config.yaml.example /etc/purermyha/config.yaml.example
-COPY packaging/purermyhad.service /usr/lib/systemd/system/purermyhad.service
+COPY config/config.yaml.example /etc/puremyha/config.yaml.example
+COPY packaging/puremyhad.service /usr/lib/systemd/system/puremyhad.service
 
-CMD ["purermyhad"]
+CMD ["puremyhad"]

--- a/README.md
+++ b/README.md
@@ -33,17 +33,17 @@ PureMyHA uses two distinct MySQL users.
 Connects to every node for health checks, topology discovery, and failover operations.
 
 ```sql
-CREATE USER 'purermyha'@'%' IDENTIFIED BY '...';
+CREATE USER 'puremyha'@'%' IDENTIFIED BY '...';
 
 -- Fine-grained privileges (MySQL 8.0+, recommended):
-GRANT REPLICATION CLIENT      ON *.* TO 'purermyha'@'%';  -- SHOW REPLICA STATUS, SHOW REPLICAS
-GRANT PROCESS                 ON *.* TO 'purermyha'@'%';  -- SHOW PROCESSLIST (topology discovery)
-GRANT REPLICATION_SLAVE_ADMIN ON *.* TO 'purermyha'@'%';  -- STOP/START REPLICA, RESET REPLICA ALL, CHANGE REPLICATION SOURCE TO
-GRANT SYSTEM_VARIABLES_ADMIN  ON *.* TO 'purermyha'@'%';  -- SET GLOBAL read_only
-GRANT REPLICATION_APPLIER     ON *.* TO 'purermyha'@'%';  -- SET GTID_NEXT (errant GTID repair)
+GRANT REPLICATION CLIENT      ON *.* TO 'puremyha'@'%';  -- SHOW REPLICA STATUS, SHOW REPLICAS
+GRANT PROCESS                 ON *.* TO 'puremyha'@'%';  -- SHOW PROCESSLIST (topology discovery)
+GRANT REPLICATION_SLAVE_ADMIN ON *.* TO 'puremyha'@'%';  -- STOP/START REPLICA, RESET REPLICA ALL, CHANGE REPLICATION SOURCE TO
+GRANT SYSTEM_VARIABLES_ADMIN  ON *.* TO 'puremyha'@'%';  -- SET GLOBAL read_only
+GRANT REPLICATION_APPLIER     ON *.* TO 'puremyha'@'%';  -- SET GTID_NEXT (errant GTID repair)
 
 -- Or with the legacy SUPER privilege:
--- GRANT REPLICATION CLIENT, SUPER ON *.* TO 'purermyha'@'%';
+-- GRANT REPLICATION CLIENT, SUPER ON *.* TO 'puremyha'@'%';
 ```
 
 #### Replication user
@@ -61,17 +61,17 @@ GRANT REPLICATION SLAVE ON *.* TO 'repl'@'%';
 
 ```mermaid
 graph LR
-    CLI["purermyha (CLI)"] <-->|"Unix socket\n/run/purermyhad.sock"| Daemon["purermyhad (daemon)"]
+    CLI["puremyha (CLI)"] <-->|"Unix socket\n/run/puremyhad.sock"| Daemon["puremyhad (daemon)"]
     Daemon -->|"per-node threads (STM)"| db1["db1 (source)"]
     db1 -->|replication| db2["db2 (replica)"]
 ```
 
 | Component    | Role |
 |-------------|------|
-| `purermyhad` | Long-running daemon. Topology monitoring, failure detection, automatic failover |
-| `purermyha`  | CLI tool. Status display and manual operations |
+| `puremyhad` | Long-running daemon. Topology monitoring, failure detection, automatic failover |
+| `puremyha`  | CLI tool. Status display and manual operations |
 
-Daemon and CLI communicate over a Unix domain socket (`/run/purermyhad.sock`) using newline-delimited JSON.
+Daemon and CLI communicate over a Unix domain socket (`/run/puremyhad.sock`) using newline-delimited JSON.
 
 ### Daemon HA with Pacemaker
 
@@ -93,26 +93,26 @@ Download the latest release from the [Releases page](https://github.com/ikaro119
 #### Debian / Ubuntu
 
 ```bash
-sudo dpkg -i purermyha_<VERSION>_amd64.deb    # x86_64
-sudo dpkg -i purermyha_<VERSION>_arm64.deb    # aarch64
+sudo dpkg -i puremyha_<VERSION>_amd64.deb    # x86_64
+sudo dpkg -i puremyha_<VERSION>_arm64.deb    # aarch64
 ```
 
 #### RHEL / Rocky / AlmaLinux
 
 ```bash
-sudo rpm -ivh purermyha-<VERSION>-1.x86_64.rpm   # x86_64
-sudo rpm -ivh purermyha-<VERSION>-1.aarch64.rpm  # aarch64
+sudo rpm -ivh puremyha-<VERSION>-1.x86_64.rpm   # x86_64
+sudo rpm -ivh puremyha-<VERSION>-1.aarch64.rpm  # aarch64
 ```
 
 #### Post-install setup
 
 ```bash
 # Copy the example config and edit it
-sudo cp /etc/purermyha/config.yaml.example /etc/purermyha/config.yaml
-sudo vi /etc/purermyha/config.yaml
+sudo cp /etc/puremyha/config.yaml.example /etc/puremyha/config.yaml
+sudo vi /etc/puremyha/config.yaml
 
 # Enable and start the daemon
-sudo systemctl enable --now purermyhad
+sudo systemctl enable --now puremyhad
 ```
 
 ### From source
@@ -123,7 +123,7 @@ sudo systemctl enable --now purermyhad
 git clone https://github.com/ikaro1192/PureMyHA
 cd PureMyHA
 cabal build all
-cabal install purermyhad purermyha
+cabal install puremyhad puremyha
 ```
 
 ### Docker build (Linux binary)
@@ -132,19 +132,19 @@ Build Linux binaries without installing GHC locally.
 
 ```bash
 # Build (tests run automatically during build)
-docker build -t purermyha .
+docker build -t puremyha .
 
 # Extract binaries
 mkdir -p dist-bins
-docker create --name tmp purermyha
-docker cp tmp:/usr/bin/purermyha ./dist-bins/
-docker cp tmp:/usr/sbin/purermyhad ./dist-bins/
+docker create --name tmp puremyha
+docker cp tmp:/usr/bin/puremyha ./dist-bins/
+docker cp tmp:/usr/sbin/puremyhad ./dist-bins/
 docker rm tmp
 ```
 
 ## Configuration
 
-Default path: `/etc/purermyha/config.yaml`
+Default path: `/etc/puremyha/config.yaml`
 
 ```yaml
 clusters:
@@ -155,11 +155,11 @@ clusters:
       - host: db2
         port: 3306
     credentials:
-      user: purermyha
-      password_file: /etc/purermyha/mysql.pass
+      user: puremyha
+      password_file: /etc/puremyha/mysql.pass
     replication_credentials:           # Optional; falls back to credentials if omitted
       user: repl
-      password_file: /etc/purermyha/repl.pass
+      password_file: /etc/puremyha/repl.pass
 
 monitoring:
   interval: 3s
@@ -179,12 +179,12 @@ failover:
     - host: db2
 
 hooks:
-  pre_failover: /etc/purermyha/hooks/pre_failover.sh
-  post_failover: /etc/purermyha/hooks/post_failover.sh
-  pre_switchover: /etc/purermyha/hooks/pre_switchover.sh
-  post_switchover: /etc/purermyha/hooks/post_switchover.sh
-  on_failure_detection: /etc/purermyha/hooks/on_failure_detection.sh    # Optional
-  post_unsuccessful_failover: /etc/purermyha/hooks/post_unsuccessful_failover.sh  # Optional
+  pre_failover: /etc/puremyha/hooks/pre_failover.sh
+  post_failover: /etc/puremyha/hooks/post_failover.sh
+  pre_switchover: /etc/puremyha/hooks/pre_switchover.sh
+  post_switchover: /etc/puremyha/hooks/post_switchover.sh
+  on_failure_detection: /etc/puremyha/hooks/on_failure_detection.sh    # Optional
+  post_unsuccessful_failover: /etc/puremyha/hooks/post_unsuccessful_failover.sh  # Optional
 
 logging:
   log_file: /var/log/puremyha.log  # Optional; defaults to /var/log/puremyha.log
@@ -199,7 +199,7 @@ See `config/config.yaml.example` for a full annotated example.
 ### Start the daemon
 
 ```bash
-purermyhad --config /etc/purermyha/config.yaml
+puremyhad --config /etc/puremyha/config.yaml
 ```
 
 ### Daemon management
@@ -211,18 +211,18 @@ purermyhad --config /etc/purermyha/config.yaml
 
 ```bash
 # Reload config (e.g. after editing intervals or hooks)
-systemctl reload purermyhad        # via systemd (preferred)
-kill -HUP $(pidof purermyhad)      # direct signal (non-systemd)
+systemctl reload puremyhad        # via systemd (preferred)
+kill -HUP $(pidof puremyhad)      # direct signal (non-systemd)
 
 # Graceful stop
-kill -TERM $(pidof purermyhad)
+kill -TERM $(pidof puremyhad)
 ```
 
 ### Global flags
 
 | Flag | Short | Default | Description |
 |------|-------|---------|-------------|
-| `--socket PATH` | — | `/run/purermyhad.sock` | Daemon socket path |
+| `--socket PATH` | — | `/run/puremyhad.sock` | Daemon socket path |
 | `--cluster NAME` | `-C` | — | Target cluster (omit to apply to all) |
 | `--json` | `-j` | — | Output in JSON format instead of text |
 
@@ -230,41 +230,41 @@ kill -TERM $(pidof purermyhad)
 
 ```bash
 # Show topology and node health
-purermyha status
+puremyha status
 
 # Show replication tree
-purermyha topology
+puremyha topology
 
 # Manual switchover (planned maintenance)
-purermyha switchover [--to=<host>] [--cluster=<name>]
+puremyha switchover [--to=<host>] [--cluster=<name>]
 
 # Dry-run: show which replica would be promoted without executing
-purermyha switchover --dry-run [--to=<host>]
+puremyha switchover --dry-run [--to=<host>]
 
 # Acknowledge recovery block (re-enable auto-failover after anti-flap period)
-purermyha ack-recovery [--cluster=<name>]
+puremyha ack-recovery [--cluster=<name>]
 
 # Detect errant GTIDs
-purermyha errant-gtid [--cluster=<name>]
+puremyha errant-gtid [--cluster=<name>]
 
 # Fix errant GTIDs by injecting empty transactions
-purermyha fix-errant-gtid [--cluster=<name>]
+puremyha fix-errant-gtid [--cluster=<name>]
 
 # Demote a node to replica under a specified source (resolve split-brain)
-purermyha demote --host db1 --source db2 [--cluster=<name>]
+puremyha demote --host db1 --source db2 [--cluster=<name>]
 
 # Trigger manual topology discovery
-purermyha discovery [--cluster=<name>]
+puremyha discovery [--cluster=<name>]
 
 # JSON output (for scripting / Prometheus exporters)
-purermyha --json status
-purermyha -j topology
-purermyha -j errant-gtid
-purermyha -j switchover --to db2
+puremyha --json status
+puremyha -j topology
+puremyha -j errant-gtid
+puremyha -j switchover --to db2
 
 # Pipe to jq
-purermyha -j status | jq '.[0].health'
-purermyha -j topology | jq '.[0].nodes[].host'
+puremyha -j status | jq '.[0].health'
+puremyha -j topology | jq '.[0].nodes[].host'
 ```
 
 ## Logging
@@ -288,7 +288,7 @@ PureMyHA writes structured, timestamped logs via [katip](https://hackage.haskell
 ### Example output
 
 ```
-[2026-03-17 12:34:56 UTC] [Info] purermyhad started
+[2026-03-17 12:34:56 UTC] [Info] puremyhad started
 [2026-03-17 12:35:01 UTC] [Warn] [main] Node db1 unreachable: Connection refused
 [2026-03-17 12:35:10 UTC] [Info] [main] Auto-failover started
 [2026-03-17 12:35:12 UTC] [Info] [main] Auto-failover completed: new source is db2
@@ -338,7 +338,7 @@ cabal build all
 cabal test
 
 # Run with a local config
-cabal run purermyhad -- --config config/config.yaml.example
+cabal run puremyhad -- --config config/config.yaml.example
 ```
 
 ## License

--- a/app/CLI/Main.hs
+++ b/app/CLI/Main.hs
@@ -80,7 +80,7 @@ switchoverCmd = CmdSwitchover
 main :: IO ()
 main = do
   opts <- execParser (info (cliOptions <**> helper)
-    (fullDesc <> progDesc "PureMyHA CLI" <> header "purermyha"))
+    (fullDesc <> progDesc "PureMyHA CLI" <> header "puremyha"))
 
   let socketPath = optSocketPath opts
       mCluster   = optCluster opts

--- a/app/Daemon/Main.hs
+++ b/app/Daemon/Main.hs
@@ -34,7 +34,7 @@ daemonOptions = DaemonOptions
         ( long "config"
         <> short 'c'
         <> metavar "FILE"
-        <> value "/etc/purermyha/config.yaml"
+        <> value "/etc/puremyha/config.yaml"
         <> help "Path to configuration file" )
   <*> strOption
         ( long "socket"
@@ -45,7 +45,7 @@ daemonOptions = DaemonOptions
 main :: IO ()
 main = do
   opts <- execParser (info (daemonOptions <**> helper)
-    (fullDesc <> progDesc "PureMyHA daemon" <> header "purermyhad"))
+    (fullDesc <> progDesc "PureMyHA daemon" <> header "puremyhad"))
 
   eCfg <- loadConfig (optConfigPath opts)
   cfg <- case eCfg of
@@ -109,7 +109,7 @@ main = do
 
   ipcAsync <- async $ startIPCServer tvar clusterMap discoveryMap (optSocketPath opts) logger
 
-  logInfo logger "purermyhad started"
+  logInfo logger "puremyhad started"
 
   let allWorkers = ipcAsync : monitorWorkers <> refreshWorkers
 
@@ -118,7 +118,7 @@ main = do
     (atomically (takeTMVar shutdownVar))
     (void (waitAnyCancel allWorkers))
 
-  logInfo logger "purermyhad shutting down"
+  logInfo logger "puremyhad shutting down"
   mapM_ cancel allWorkers
   closeLogger logger
 

--- a/config/config.yaml.example
+++ b/config/config.yaml.example
@@ -6,11 +6,11 @@ clusters:
       - host: db2
         port: 3306
     credentials:
-      user: purermyha
-      password_file: /etc/purermyha/mysql.pass
+      user: puremyha
+      password_file: /etc/puremyha/mysql.pass
     replication_credentials:           # optional; falls back to credentials if omitted
       user: repl
-      password_file: /etc/purermyha/repl.pass
+      password_file: /etc/puremyha/repl.pass
 
 monitoring:
   interval: 3s
@@ -29,7 +29,7 @@ failover:
     - host: db2
 
 hooks:
-  pre_failover: /etc/purermyha/hooks/pre_failover.sh
-  post_failover: /etc/purermyha/hooks/post_failover.sh
-  pre_switchover: /etc/purermyha/hooks/pre_switchover.sh
-  post_switchover: /etc/purermyha/hooks/post_switchover.sh
+  pre_failover: /etc/puremyha/hooks/pre_failover.sh
+  post_failover: /etc/puremyha/hooks/post_failover.sh
+  pre_switchover: /etc/puremyha/hooks/pre_switchover.sh
+  post_switchover: /etc/puremyha/hooks/post_switchover.sh

--- a/packaging/nfpm.yaml
+++ b/packaging/nfpm.yaml
@@ -1,4 +1,4 @@
-name: purermyha
+name: puremyha
 arch: ${NFPM_ARCH}
 platform: linux
 version: ${VERSION}
@@ -8,19 +8,19 @@ homepage: https://github.com/shokashimizu/PureMyHA
 license: MIT
 
 contents:
-  - src: dist-bins/purermyha
-    dst: /usr/bin/purermyha
+  - src: dist-bins/puremyha
+    dst: /usr/bin/puremyha
     file_info:
       mode: 0755
-  - src: dist-bins/purermyhad
-    dst: /usr/sbin/purermyhad
+  - src: dist-bins/puremyhad
+    dst: /usr/sbin/puremyhad
     file_info:
       mode: 0755
   - src: config/config.yaml.example
-    dst: /etc/purermyha/config.yaml.example
+    dst: /etc/puremyha/config.yaml.example
     type: config|noreplace
-  - src: packaging/purermyhad.service
-    dst: /lib/systemd/system/purermyhad.service
+  - src: packaging/puremyhad.service
+    dst: /lib/systemd/system/puremyhad.service
 
 scripts:
   postinstall: packaging/postinstall.sh

--- a/packaging/puremyhad.service
+++ b/packaging/puremyhad.service
@@ -4,7 +4,7 @@ After=network.target
 
 [Service]
 Type=simple
-ExecStart=/usr/sbin/purermyhad --config /etc/purermyha/config.yaml
+ExecStart=/usr/sbin/puremyhad --config /etc/puremyha/config.yaml
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=on-failure
 RestartSec=5s

--- a/puremyha.cabal
+++ b/puremyha.cabal
@@ -1,11 +1,11 @@
 cabal-version:      3.0
-name:               purermyha
+name:               puremyha
 version:            0.2.0.0
 synopsis:           MySQL 8.4 HA tool in Haskell
 description:        PureMyHA is a simple HA tool for MySQL 8.4 replication topologies.
 license:            MIT
 author:             PureMyHA Authors
-maintainer:         purermyha@example.com
+maintainer:         puremyha@example.com
 build-type:         Simple
 
 common common-options
@@ -69,25 +69,25 @@ library
     asn1-encoding    >= 0.9,
     asn1-types       >= 0.3
 
-executable purermyhad
+executable puremyhad
   import:          common-options
   hs-source-dirs:  app/Daemon
   main-is:         Main.hs
   build-depends:
-    purermyha,
+    puremyha,
     optparse-applicative >= 0.16,
     katip            >= 0.8,
     unix             >= 2.7
 
-executable purermyha
+executable puremyha
   import:          common-options
   hs-source-dirs:  app/CLI
   main-is:         Main.hs
   build-depends:
-    purermyha,
+    puremyha,
     optparse-applicative >= 0.16
 
-test-suite purermyha-test
+test-suite puremyha-test
   import:          common-options
   type:            exitcode-stdio-1.0
   hs-source-dirs:  test
@@ -105,7 +105,7 @@ test-suite purermyha-test
     PureMyHA.DiscoverySpec
     PureMyHA.ErrantGtidSpec
   build-depends:
-    purermyha,
+    puremyha,
     hspec            >= 2.9,
     QuickCheck       >= 2.14,
     hspec-discover   >= 0.8

--- a/src/PureMyHA/Hook.hs
+++ b/src/PureMyHA/Hook.hs
@@ -32,12 +32,12 @@ getCurrentTimestamp =
 runHook :: FilePath -> HookEnv -> IO (Either Text ())
 runHook scriptPath hookEnv = do
   let envVars =
-        [ ("PURERMYHA_CLUSTER", T.unpack (hookClusterName hookEnv))
+        [ ("PUREMYHA_CLUSTER", T.unpack (hookClusterName hookEnv))
         ] ++
-        maybe [] (\h -> [("PURERMYHA_NEW_SOURCE", T.unpack h)]) (hookNewSource hookEnv) ++
-        maybe [] (\h -> [("PURERMYHA_OLD_SOURCE", T.unpack h)]) (hookOldSource hookEnv) ++
-        maybe [] (\ft -> [("PURERMYHA_FAILURE_TYPE", T.unpack ft)]) (hookFailureType hookEnv) ++
-        [("PURERMYHA_TIMESTAMP", T.unpack (hookTimestamp hookEnv))]
+        maybe [] (\h -> [("PUREMYHA_NEW_SOURCE", T.unpack h)]) (hookNewSource hookEnv) ++
+        maybe [] (\h -> [("PUREMYHA_OLD_SOURCE", T.unpack h)]) (hookOldSource hookEnv) ++
+        maybe [] (\ft -> [("PUREMYHA_FAILURE_TYPE", T.unpack ft)]) (hookFailureType hookEnv) ++
+        [("PUREMYHA_TIMESTAMP", T.unpack (hookTimestamp hookEnv))]
   result <- try @SomeException $ do
     (_, _, _, ph) <- createProcess (proc scriptPath [T.unpack (hookClusterName hookEnv)])
       { env = Just envVars }

--- a/src/PureMyHA/IPC/Server.hs
+++ b/src/PureMyHA/IPC/Server.hs
@@ -29,7 +29,7 @@ import PureMyHA.Topology.State
 import PureMyHA.Types
 
 defaultSocketPath :: FilePath
-defaultSocketPath = "/run/purermyhad.sock"
+defaultSocketPath = "/run/puremyhad.sock"
 
 type ClusterEntry = (FailoverLock, ClusterConfig, FailoverConfig, FailureDetectionConfig, ClusterPasswords, Maybe HooksConfig)
 type ClusterMap   = Map ClusterName ClusterEntry

--- a/src/PureMyHA/Logger.hs
+++ b/src/PureMyHA/Logger.hs
@@ -18,7 +18,7 @@ initLogger logFile = do
   h <- openFile logFile AppendMode
   hSetBuffering h LineBuffering
   scribe <- mkHandleScribe ColorIfTerminal h (permitItem InfoS) V2
-  le <- initLogEnv "purermyha" "production"
+  le <- initLogEnv "puremyha" "production"
   le' <- registerScribe "file" scribe defaultScribeSettings le
   pure (Logger le')
 
@@ -29,7 +29,7 @@ closeLogger (Logger le) = do
 
 logAt :: Logger -> Severity -> Text -> IO ()
 logAt (Logger le) sev msg =
-  runKatipT le $ logMsg "purermyha" sev (logStr msg)
+  runKatipT le $ logMsg "puremyha" sev (logStr msg)
 
 logInfo :: Logger -> Text -> IO ()
 logInfo l = logAt l InfoS


### PR DESCRIPTION
## Summary

- Rename all `purermyha`/`purermyhad` identifiers to `puremyha`/`puremyhad` to fix a typo introduced during initial implementation
- File renames: `purermyha.cabal` → `puremyha.cabal`, `packaging/purermyhad.service` → `packaging/puremyhad.service`
- String replacements across 13 files: cabal, Haskell source, config, packaging, Dockerfile, CI/release workflows, README

Note: Haskell module names (`PureMyHA.*`) and the GitHub project title (`PureMyHA`) are unchanged.

## Test plan

- [x] `grep -rn "purermyha"` returns no results across all relevant files
- [x] `cabal build all` passes
- [x] `cabal test` passes (141 examples, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)