### PR TITLE
feat: suppress auto-failover until cluster has been observed healthy

### DIFF
--- a/src/PureMyHA/Monitor/Worker.hs
+++ b/src/PureMyHA/Monitor/Worker.hs
@@ -247,10 +247,12 @@ recomputeClusterHealth tvar cc mc lock fc fdc pws mHooks logger = do
       let newHealth = detectClusterHealth (ctNodes topo)
           newSrcId  = identifySource (Map.elems (ctNodes topo))
           topo' = topo
-            { ctHealth       = newHealth
-            , ctSourceNodeId = newSrcId
+            { ctHealth          = newHealth
+            , ctSourceNodeId    = newSrcId
+            , ctObservedHealthy = newHealth == Healthy
             }
-      let transitioned = ctHealth topo /= newHealth
+      let transitioned     = ctHealth topo /= newHealth
+          observedHealthy  = ctObservedHealthy topo || newHealth == Healthy
       -- Fire on_failure_detection hook on transition to a dead state
       when transitioned $
         case newHealth of
@@ -263,9 +265,13 @@ recomputeClusterHealth tvar cc mc lock fc fdc pws mHooks logger = do
             let env = HookEnv (ccName cc) Nothing Nothing (Just "DeadSourceAndAllReplicas") ts
             runHookFireForget mHooks hcOnFailureDetection env
           _ -> pure ()
+      -- Log all health transitions for observability
+      when transitioned $
+        logInfo logger $ "[" <> ccName cc <> "] Cluster health: "
+          <> T.pack (show (ctHealth topo)) <> " \x2192 " <> T.pack (show newHealth)
       atomically $ updateClusterTopology tvar topo'
-      -- Trigger auto-failover on transition to DeadSource
-      when (transitioned && newHealth == DeadSource && fcAutoFailover fc) $ do
+      -- Trigger auto-failover on transition to DeadSource only after cluster was observed healthy
+      when (transitioned && newHealth == DeadSource && fcAutoFailover fc && observedHealthy) $ do
         _ <- async (runAutoFailover tvar lock cc fc fdc pws mHooks logger)
         pure ()
       -- Emergency re-check on first transition to UnreachableSource

--- a/src/PureMyHA/Topology/Discovery.hs
+++ b/src/PureMyHA/Topology/Discovery.hs
@@ -49,6 +49,7 @@ buildClusterTopology name nodeStates =
        , ctNodes                = nodeStates'
        , ctSourceNodeId         = sourceId
        , ctHealth               = health
+       , ctObservedHealthy      = health == Healthy
        , ctRecoveryBlockedUntil = Nothing
        , ctLastFailoverAt       = Nothing
        }
@@ -166,6 +167,7 @@ buildInitialTopology cc = ClusterTopology
   , ctNodes                = Map.empty
   , ctSourceNodeId         = Nothing
   , ctHealth               = NeedsAttention "Initializing"
+  , ctObservedHealthy      = False
   , ctRecoveryBlockedUntil = Nothing
   , ctLastFailoverAt       = Nothing
   }

--- a/src/PureMyHA/Topology/State.hs
+++ b/src/PureMyHA/Topology/State.hs
@@ -41,8 +41,9 @@ updateNodeState tvar clusterName ns = do
 updateClusterTopology :: TVarDaemonState -> ClusterTopology -> STM ()
 updateClusterTopology tvar ct = do
   ds <- readTVar tvar
-  writeTVar tvar ds
-    { dsClusters = Map.insert (ctClusterName ct) ct (dsClusters ds) }
+  let prevObserved = maybe False ctObservedHealthy (Map.lookup (ctClusterName ct) (dsClusters ds))
+      ct' = ct { ctObservedHealthy = prevObserved || ctObservedHealthy ct }
+  writeTVar tvar ds { dsClusters = Map.insert (ctClusterName ct) ct' (dsClusters ds) }
 
 getClusterTopology :: TVarDaemonState -> ClusterName -> IO (Maybe ClusterTopology)
 getClusterTopology tvar name = do

--- a/src/PureMyHA/Types.hs
+++ b/src/PureMyHA/Types.hs
@@ -66,6 +66,7 @@ data ClusterTopology = ClusterTopology
   , ctNodes                 :: Map NodeId NodeState
   , ctSourceNodeId          :: Maybe NodeId
   , ctHealth                :: NodeHealth
+  , ctObservedHealthy       :: Bool             -- True if cluster has ever been Healthy since daemon start
   , ctRecoveryBlockedUntil  :: Maybe UTCTime
   , ctLastFailoverAt        :: Maybe UTCTime
   } deriving (Show, Generic)

--- a/test/PureMyHA/AutoSpec.hs
+++ b/test/PureMyHA/AutoSpec.hs
@@ -16,6 +16,7 @@ deadSourceTopo = ClusterTopology
   , ctNodes                = clusterWithDeadSource
   , ctSourceNodeId         = Just (NodeId "db1" 3306)
   , ctHealth               = DeadSource
+  , ctObservedHealthy      = True
   , ctRecoveryBlockedUntil = Nothing
   , ctLastFailoverAt       = Nothing
   }

--- a/test/PureMyHA/DiscoverySpec.hs
+++ b/test/PureMyHA/DiscoverySpec.hs
@@ -62,12 +62,14 @@ spec = do
 
     it "healthy cluster has Healthy health and correct source" $ do
       let topo = buildClusterTopology "prod" clusterHealthy
-      ctHealth       topo `shouldBe` Healthy
-      ctSourceNodeId topo `shouldBe` Just (NodeId "db1" 3306)
+      ctHealth          topo `shouldBe` Healthy
+      ctSourceNodeId    topo `shouldBe` Just (NodeId "db1" 3306)
+      ctObservedHealthy topo `shouldBe` True
 
     it "cluster with dead source has DeadSource health" $ do
       let topo = buildClusterTopology "prod" clusterWithDeadSource
-      ctHealth topo `shouldBe` DeadSource
+      ctHealth          topo `shouldBe` DeadSource
+      ctObservedHealthy topo `shouldBe` False
 
     it "empty cluster has NeedsAttention health and no source" $ do
       let topo = buildClusterTopology "empty" Map.empty


### PR DESCRIPTION
## Summary

- Add `ctObservedHealthy :: Bool` to `ClusterTopology` to track whether the cluster has ever been seen in a `Healthy` state since daemon start
- Gate auto-failover on this flag to prevent spurious failovers when the daemon starts with the source already dead, or when the source fails within the first monitoring cycle before a healthy baseline is established
- `updateClusterTopology` (STM) merges the flag monotonically (`True` once set, never reverts), so all update paths — topology refresh, discovery, and monitor — are covered automatically

## Background

When the daemon started with the source already down (or dying immediately), the `transitioned && newHealth == DeadSource` condition in `recomputeClusterHealth` was satisfied and auto-failover fired without any operator intent. This is unsafe because the daemon had no prior history of the cluster's state.

## Changes

| File | Change |
|------|--------|
| `src/PureMyHA/Types.hs` | Add `ctObservedHealthy :: Bool` field to `ClusterTopology` |
| `src/PureMyHA/Topology/Discovery.hs` | Set initial value in `buildClusterTopology` and `buildInitialTopology` |
| `src/PureMyHA/Topology/State.hs` | Preserve `True` monotonically in `updateClusterTopology` |
| `src/PureMyHA/Monitor/Worker.hs` | Compute `observedHealthy` and gate auto-failover on it (+ health transition logging) |
| `test/PureMyHA/AutoSpec.hs` | Add `ctObservedHealthy = True` to `deadSourceTopo` fixture |
| `test/PureMyHA/DiscoverySpec.hs` | Add assertions for `ctObservedHealthy` in healthy and dead-source cases |

## Test plan

- [ ] `cabal build all` passes
- [ ] `cabal test` shows 141 examples, 0 failures
- [ ] `buildClusterTopology` with healthy cluster → `ctObservedHealthy = True`
- [ ] `buildClusterTopology` with dead source → `ctObservedHealthy = False`
- [ ] `updateClusterTopology` preserves `True` once set (even if new topology has `False`)
- [ ] Auto-failover fires on `DeadSource` transition when `ctObservedHealthy = True`
- [ ] Auto-failover is suppressed when `ctObservedHealthy = False` (source dead at daemon start)

🤖 Generated with [Claude Code](https://claude.com/claude-code)