### PR TITLE
feat: add pause-replica and resume-replica commands

### DIFF
--- a/app/CLI/Main.hs
+++ b/app/CLI/Main.hs
@@ -26,6 +26,8 @@ data Command
   | CmdFixErrantGtid
   | CmdDemote Text Text   -- host, source
   | CmdDiscovery
+  | CmdPauseReplica  Text
+  | CmdResumeReplica Text
 
 cliOptions :: Parser CLIOptions
 cliOptions = CLIOptions
@@ -60,12 +62,22 @@ cliOptions = CLIOptions
             (info demoteCmd (progDesc "Demote a node to replica under specified source"))
         <> command "discovery"
             (info (pure CmdDiscovery) (progDesc "Trigger manual topology discovery"))
+        <> command "pause-replica"
+            (info pauseReplicaCmd (progDesc "Pause replication on a node for maintenance"))
+        <> command "resume-replica"
+            (info resumeReplicaCmd (progDesc "Resume replication on a paused node"))
         )
 
 demoteCmd :: Parser Command
 demoteCmd = CmdDemote
   <$> strOption (long "host"   <> metavar "HOST" <> help "Node to demote")
   <*> strOption (long "source" <> metavar "HOST" <> help "New replication source host")
+
+pauseReplicaCmd :: Parser Command
+pauseReplicaCmd = CmdPauseReplica <$> strOption (long "host" <> metavar "HOST" <> help "Node to pause")
+
+resumeReplicaCmd :: Parser Command
+resumeReplicaCmd = CmdResumeReplica <$> strOption (long "host" <> metavar "HOST" <> help "Node to resume")
 
 switchoverCmd :: Parser Command
 switchoverCmd = CmdSwitchover
@@ -94,6 +106,8 @@ main = do
         CmdFixErrantGtid    -> ReqFixErrantGtid mCluster
         CmdDemote host src  -> ReqDemote mCluster host src
         CmdDiscovery        -> ReqDiscovery mCluster
+        CmdPauseReplica  host -> ReqPauseReplica  mCluster host
+        CmdResumeReplica host -> ReqResumeReplica mCluster host
 
   eResp <- sendRequest socketPath req
   case eResp of

--- a/puremyha.cabal
+++ b/puremyha.cabal
@@ -49,6 +49,7 @@ library
     PureMyHA.Failover.Candidate
     PureMyHA.Failover.Auto
     PureMyHA.Failover.Demote
+    PureMyHA.Failover.PauseReplica
     PureMyHA.Failover.ErrantGtid
     PureMyHA.Failover.Switchover
     PureMyHA.IPC.Protocol

--- a/src/PureMyHA/Failover/PauseReplica.hs
+++ b/src/PureMyHA/Failover/PauseReplica.hs
@@ -1,0 +1,75 @@
+module PureMyHA.Failover.PauseReplica (runPauseReplica, runResumeReplica) where
+
+import Control.Concurrent.STM (atomically)
+import qualified Data.Map.Strict as Map
+import Data.Text (Text)
+import PureMyHA.Config (ClusterConfig (..), Credentials (..), ClusterPasswords (..))
+import PureMyHA.Logger (Logger, logInfo, logError)
+import PureMyHA.MySQL.Connection (makeConnectInfo, withNodeConn)
+import PureMyHA.MySQL.Query (stopReplica, startReplica)
+import PureMyHA.Topology.State (TVarDaemonState, getClusterTopology, updateNodeState)
+import PureMyHA.Types
+
+-- | Pause replication on a replica node for maintenance
+runPauseReplica
+  :: TVarDaemonState
+  -> ClusterConfig
+  -> ClusterPasswords
+  -> Text       -- ^ host to pause
+  -> Logger
+  -> IO (Either Text ())
+runPauseReplica tvar cc pws targetHost logger = do
+  mTopo <- getClusterTopology tvar (ccName cc)
+  case mTopo of
+    Nothing -> pure (Left "Cluster not found")
+    Just topo -> do
+      let nodes = Map.elems (ctNodes topo)
+          user  = credUser (ccCredentials cc)
+          findByHost h = filter (\ns -> nodeHost (nsNodeId ns) == h) nodes
+      case findByHost targetHost of
+        [] -> pure (Left $ "Node not found: " <> targetHost)
+        (targetNs : _) -> do
+          let ci = makeConnectInfo (nsNodeId targetNs) user (cpPassword pws)
+          logInfo logger $ "[" <> ccName cc <> "] Pausing replication on " <> targetHost
+          result <- withNodeConn ci $ \conn -> stopReplica conn
+          case result of
+            Left err -> do
+              logError logger $ "[" <> ccName cc <> "] Pause failed: " <> err
+              pure (Left err)
+            Right () -> do
+              atomically $ updateNodeState tvar (ccName cc)
+                (targetNs { nsPaused = True })
+              logInfo logger $ "[" <> ccName cc <> "] Replication paused on " <> targetHost
+              pure (Right ())
+
+-- | Resume replication on a paused replica node
+runResumeReplica
+  :: TVarDaemonState
+  -> ClusterConfig
+  -> ClusterPasswords
+  -> Text       -- ^ host to resume
+  -> Logger
+  -> IO (Either Text ())
+runResumeReplica tvar cc pws targetHost logger = do
+  mTopo <- getClusterTopology tvar (ccName cc)
+  case mTopo of
+    Nothing -> pure (Left "Cluster not found")
+    Just topo -> do
+      let nodes = Map.elems (ctNodes topo)
+          user  = credUser (ccCredentials cc)
+          findByHost h = filter (\ns -> nodeHost (nsNodeId ns) == h) nodes
+      case findByHost targetHost of
+        [] -> pure (Left $ "Node not found: " <> targetHost)
+        (targetNs : _) -> do
+          let ci = makeConnectInfo (nsNodeId targetNs) user (cpPassword pws)
+          logInfo logger $ "[" <> ccName cc <> "] Resuming replication on " <> targetHost
+          result <- withNodeConn ci $ \conn -> startReplica conn
+          case result of
+            Left err -> do
+              logError logger $ "[" <> ccName cc <> "] Resume failed: " <> err
+              pure (Left err)
+            Right () -> do
+              atomically $ updateNodeState tvar (ccName cc)
+                (targetNs { nsPaused = False })
+              logInfo logger $ "[" <> ccName cc <> "] Replication resumed on " <> targetHost
+              pure (Right ())

--- a/src/PureMyHA/IPC/Client.hs
+++ b/src/PureMyHA/IPC/Client.hs
@@ -96,12 +96,14 @@ printNode :: Bool -> NodeStateView -> IO ()
 printNode isSource nsv = do
   let prefix = if isSource then "[SOURCE] " else "  [REPLICA] "
       host   = T.unpack (nsvHost nsv) <> ":" <> show (nsvPort nsv)
-      health = showHealth (nsvHealth nsv)
+      status = if nsvPaused nsv
+                 then "[PAUSED]"
+                 else "[" <> showHealth (nsvHealth nsv) <> "]"
       lag    = case nsvLagSeconds nsv of
         Nothing -> ""
         Just s  -> " lag=" <> show s <> "s"
       errant = if nsvErrantGtids nsv == "" then "" else " ERRANT_GTID"
-  putStrLn $ prefix <> host <> " [" <> health <> "]" <> lag <> errant
+  putStrLn $ prefix <> host <> " " <> status <> lag <> errant
 
 -- | Print an operation result
 printOperationResult :: Bool -> OperationResult -> IO ()

--- a/src/PureMyHA/IPC/Protocol.hs
+++ b/src/PureMyHA/IPC/Protocol.hs
@@ -75,6 +75,7 @@ instance ToJSON NodeStateView where
     , "lagSeconds"   .= nsvLagSeconds
     , "errantGtids"  .= nsvErrantGtids
     , "connectError" .= nsvConnectError
+    , "paused"       .= nsvPaused
     ]
 
 instance FromJSON NodeStateView where
@@ -87,6 +88,7 @@ instance FromJSON NodeStateView where
       <*> o .: "lagSeconds"
       <*> o .: "errantGtids"
       <*> o .: "connectError"
+      <*> o .: "paused"
 
 instance ToJSON ClusterTopologyView where
   toJSON ClusterTopologyView{..} = object
@@ -133,6 +135,8 @@ data Request
   | ReqFixErrantGtid { reqCluster :: Maybe ClusterName }
   | ReqDemote { reqCluster :: Maybe ClusterName, reqDemoteHost :: Text, reqDemoteSourceHost :: Text }
   | ReqDiscovery { reqCluster :: Maybe ClusterName }
+  | ReqPauseReplica  { reqCluster :: Maybe ClusterName, reqPauseHost  :: Text }
+  | ReqResumeReplica { reqCluster :: Maybe ClusterName, reqResumeHost :: Text }
   deriving (Show, Eq, Generic)
 
 instance ToJSON Request where
@@ -144,6 +148,8 @@ instance ToJSON Request where
   toJSON (ReqFixErrantGtid mc)   = object ["type" .= ("fix-errant-gtid" :: Text), "cluster" .= mc]
   toJSON (ReqDemote mc h s)      = object ["type" .= ("demote" :: Text), "cluster" .= mc, "host" .= h, "sourceHost" .= s]
   toJSON (ReqDiscovery mc)       = object ["type" .= ("discovery" :: Text),       "cluster" .= mc]
+  toJSON (ReqPauseReplica  mc h) = object ["type" .= ("pause-replica"  :: Text), "cluster" .= mc, "host" .= h]
+  toJSON (ReqResumeReplica mc h) = object ["type" .= ("resume-replica" :: Text), "cluster" .= mc, "host" .= h]
 
 instance FromJSON Request where
   parseJSON = withObject "Request" $ \o -> do
@@ -157,6 +163,8 @@ instance FromJSON Request where
       "fix-errant-gtid" -> ReqFixErrantGtid <$> o .:? "cluster"
       "demote"          -> ReqDemote        <$> o .:? "cluster" <*> o .: "host" <*> o .: "sourceHost"
       "discovery"       -> ReqDiscovery    <$> o .:? "cluster"
+      "pause-replica"   -> ReqPauseReplica  <$> o .:? "cluster" <*> o .: "host"
+      "resume-replica"  -> ReqResumeReplica <$> o .:? "cluster" <*> o .: "host"
       _                 -> fail $ "Unknown request type: " <> show t
 
 -- | IPC Response types

--- a/src/PureMyHA/IPC/Server.hs
+++ b/src/PureMyHA/IPC/Server.hs
@@ -20,6 +20,7 @@ import Network.Socket
 import qualified Network.Socket.ByteString as NSB
 import PureMyHA.Config
 import PureMyHA.Failover.Demote (runDemote)
+import PureMyHA.Failover.PauseReplica (runPauseReplica, runResumeReplica)
 import PureMyHA.Failover.ErrantGtid (runFixErrantGtid)
 import PureMyHA.Failover.Switchover (runSwitchover, dryRunSwitchover)
 import System.Posix.Files (removeLink)
@@ -164,6 +165,24 @@ handleRequest tvar clusterMap discoveryMap logger req = case req of
           Left err  -> OperationFailure err
           Right msg -> OperationSuccess msg
 
+  ReqPauseReplica mCluster host ->
+    case lookupCluster mCluster clusterMap of
+      Nothing -> pure (RespError "Cluster not found")
+      Just (_, cc, _, _, pws, _) -> do
+        result <- runPauseReplica tvar cc pws host logger
+        pure $ RespOperation $ case result of
+          Left err -> OperationFailure err
+          Right () -> OperationSuccess ("Replication paused on " <> host)
+
+  ReqResumeReplica mCluster host ->
+    case lookupCluster mCluster clusterMap of
+      Nothing -> pure (RespError "Cluster not found")
+      Just (_, cc, _, _, pws, _) -> do
+        result <- runResumeReplica tvar cc pws host logger
+        pure $ RespOperation $ case result of
+          Left err -> OperationFailure err
+          Right () -> OperationSuccess ("Replication resumed on " <> host)
+
 filterClusters :: Maybe ClusterName -> Map ClusterName ClusterTopology -> [ClusterTopology]
 filterClusters Nothing  m = Map.elems m
 filterClusters (Just n) m = maybe [] pure (Map.lookup n m)
@@ -200,6 +219,7 @@ toNodeStateView ns = NodeStateView
   , nsvLagSeconds  = nsReplicaStatus ns >>= rsSecondsBehindSource
   , nsvErrantGtids = nsErrantGtids ns
   , nsvConnectError = nsConnectError ns
+  , nsvPaused      = nsPaused ns
   }
 
 clusterErrantGtids :: ClusterTopology -> [ErrantGtidInfo]

--- a/src/PureMyHA/Monitor/Worker.hs
+++ b/src/PureMyHA/Monitor/Worker.hs
@@ -175,6 +175,7 @@ monitorNode tvar cc mc lock fc fdc pws mHooks nid logger = do
         , nsLastSeen        = Nothing
         , nsConnectError    = Just err
         , nsErrantGtids     = ""
+        , nsPaused          = maybe False nsPaused mOldNs
         }
     Right (mRs, gtidExec) ->
       pure NodeState
@@ -186,6 +187,7 @@ monitorNode tvar cc mc lock fc fdc pws mHooks nid logger = do
         , nsLastSeen        = Just now
         , nsConnectError    = Nothing
         , nsErrantGtids     = ""
+        , nsPaused          = maybe False nsPaused mOldNs
         }
   -- Update errant GTIDs by querying MySQL
   ns' <- enrichErrantGtids tvar (ccName cc) ns user (cpPassword pws)
@@ -198,14 +200,16 @@ monitorNode tvar cc mc lock fc fdc pws mHooks nid logger = do
 logHealthChange :: Logger -> ClusterName -> NodeId -> Maybe NodeState -> NodeState -> IO ()
 logHealthChange logger clusterName nid mOld new = do
   let host = nodeHost nid
-  case (fmap nsHealth mOld, nsHealth new) of
-    (Just Healthy, NeedsAttention err) ->
-      logWarn logger $ "[" <> clusterName <> "] Node " <> host <> " unreachable: " <> err
-    (Just (NeedsAttention _), Healthy) ->
-      logInfo logger $ "[" <> clusterName <> "] Node " <> host <> " recovered"
-    (Nothing, NeedsAttention err) ->
-      logWarn logger $ "[" <> clusterName <> "] Node " <> host <> " initial connect failed: " <> err
-    _ -> pure ()
+  if nsPaused new
+    then pure ()
+    else case (fmap nsHealth mOld, nsHealth new) of
+      (Just Healthy, NeedsAttention err) ->
+        logWarn logger $ "[" <> clusterName <> "] Node " <> host <> " unreachable: " <> err
+      (Just (NeedsAttention _), Healthy) ->
+        logInfo logger $ "[" <> clusterName <> "] Node " <> host <> " recovered"
+      (Nothing, NeedsAttention err) ->
+        logWarn logger $ "[" <> clusterName <> "] Node " <> host <> " initial connect failed: " <> err
+      _ -> pure ()
 
 enrichErrantGtids :: TVarDaemonState -> ClusterName -> NodeState -> Text -> Text -> IO NodeState
 enrichErrantGtids tvar clusterName ns user password = do

--- a/src/PureMyHA/Topology/Discovery.hs
+++ b/src/PureMyHA/Topology/Discovery.hs
@@ -133,6 +133,7 @@ buildNodeStateFromProbe nid _ (Left err) = NodeState
   , nsLastSeen      = Nothing
   , nsConnectError  = Just err
   , nsErrantGtids   = ""
+  , nsPaused        = False
   }
 buildNodeStateFromProbe nid now (Right (mRs, gtidExec)) = NodeState
   { nsNodeId        = nid
@@ -143,6 +144,7 @@ buildNodeStateFromProbe nid now (Right (mRs, gtidExec)) = NodeState
   , nsLastSeen      = Just now
   , nsConnectError  = Nothing
   , nsErrantGtids   = ""
+  , nsPaused        = False
   }
 
 -- | Calculate next nodes to probe from a discovered node's replica status (pure)

--- a/src/PureMyHA/Types.hs
+++ b/src/PureMyHA/Types.hs
@@ -59,6 +59,7 @@ data NodeState = NodeState
   , nsLastSeen      :: Maybe UTCTime
   , nsConnectError  :: Maybe Text
   , nsErrantGtids   :: Text
+  , nsPaused        :: Bool
   } deriving (Eq, Show, Generic)
 
 data ClusterTopology = ClusterTopology
@@ -97,6 +98,7 @@ data NodeStateView = NodeStateView
   , nsvLagSeconds   :: Maybe Int
   , nsvErrantGtids  :: Text
   , nsvConnectError :: Maybe Text
+  , nsvPaused       :: Bool
   } deriving (Show, Eq, Generic)
 
 data OperationResult

--- a/test/Fixtures.hs
+++ b/test/Fixtures.hs
@@ -47,6 +47,7 @@ mkNodeState nid isSource mRs health = NodeState
   , nsLastSeen        = Just fixedTime
   , nsConnectError    = Nothing
   , nsErrantGtids     = ""
+  , nsPaused          = False
   }
 
 healthySource :: NodeState
@@ -78,6 +79,7 @@ unreachableNode nid = NodeState
   , nsLastSeen        = Nothing
   , nsConnectError    = Just "Connection refused"
   , nsErrantGtids     = ""
+  , nsPaused          = False
   }
 
 unreachableReplica :: NodeState
@@ -96,6 +98,7 @@ clusterWithDeadSource = Map.fromList
       , nsLastSeen  = Just fixedTime
       , nsConnectError = Nothing
       , nsErrantGtids = ""
+      , nsPaused = False
       })
   ]
 

--- a/test/PureMyHA/DetectorSpec.hs
+++ b/test/PureMyHA/DetectorSpec.hs
@@ -47,6 +47,7 @@ spec = do
                 , nsLastSeen      = Just fixedTime
                 , nsConnectError  = Nothing
                 , nsErrantGtids   = ""
+                , nsPaused        = False
                 })
             ]
       detectClusterHealth cluster `shouldBe` DeadSource
@@ -63,6 +64,7 @@ spec = do
                 , nsLastSeen      = Just fixedTime
                 , nsConnectError  = Nothing
                 , nsErrantGtids   = ""
+                , nsPaused        = False
                 })
             ]
       detectClusterHealth cluster `shouldBe` UnreachableSource

--- a/test/PureMyHA/IPCSpec.hs
+++ b/test/PureMyHA/IPCSpec.hs
@@ -35,6 +35,12 @@ spec = do
     it "round-trips ReqFixErrantGtid" $
       roundTrip (ReqFixErrantGtid Nothing) `shouldBe` Just (ReqFixErrantGtid Nothing)
 
+    it "round-trips ReqPauseReplica" $
+      roundTrip (ReqPauseReplica (Just "main") "db2") `shouldBe` Just (ReqPauseReplica (Just "main") "db2")
+
+    it "round-trips ReqResumeReplica" $
+      roundTrip (ReqResumeReplica Nothing "db3") `shouldBe` Just (ReqResumeReplica Nothing "db3")
+
   describe "Response JSON round-trip" $ do
     it "round-trips RespError" $
       roundTripResp (RespError "something went wrong")


### PR DESCRIPTION
## Summary

- Add `nsPaused :: Bool` field to `NodeState` and `NodeStateView` to track per-node maintenance state
- Introduce `PureMyHA.Failover.PauseReplica` module with `runPauseReplica` / `runResumeReplica`, which issue `STOP REPLICA` / `START REPLICA` and persist the flag via STM
- Wire up `ReqPauseReplica` / `ReqResumeReplica` in IPC protocol, server handler, and CLI (`pause-replica --host` / `resume-replica --host`)
- Suppress health-change log warnings while a node is paused
- Show `[PAUSED]` instead of the health label in `puremyha status` output for paused nodes

## Test plan

- [ ] `cabal build all` passes with no errors
- [ ] `cabal test` passes (143/143)
- [ ] `puremyha pause-replica --host <replica>` stops replication and sets paused flag
- [ ] `puremyha resume-replica --host <replica>` resumes replication and clears paused flag
- [ ] `puremyha status` shows `[PAUSED]` for a paused node
- [ ] No health-change warnings are logged while a node is paused
- [ ] IPC round-trip tests for `ReqPauseReplica` / `ReqResumeReplica` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)