### PR TITLE
fix: set read_only on replicas reconnected after switchover/auto-failover

### DIFF
--- a/src/PureMyHA/Failover/Auto.hs
+++ b/src/PureMyHA/Failover/Auto.hs
@@ -163,6 +163,7 @@ reconnectReplica user monPassword replUser replPassword newSourceId ns = do
   _ <- withNodeConn ci $ \conn -> do
     stopReplica conn
     changeReplicationSourceTo conn (nodeHost newSourceId) (nodePort newSourceId) replUser replPassword
+    setReadOnly conn
     startReplica conn
   pure ()
 

--- a/src/PureMyHA/Failover/Switchover.hs
+++ b/src/PureMyHA/Failover/Switchover.hs
@@ -160,6 +160,7 @@ reconnectToNew user pws newSourceId ns = do
   _ <- withNodeConn ci $ \conn -> do
     _ <- try @SomeException (stopReplica conn)
     changeReplicationSourceTo conn (nodeHost newSourceId) (nodePort newSourceId) (cpReplUser pws) (cpReplPassword pws)
+    setReadOnly conn
     startReplica conn
   pure ()
 


### PR DESCRIPTION
## Summary

- `reconnectToNew` (switchover) and `reconnectReplica` (auto-failover) were reconnecting nodes as replicas without setting `read_only = ON`, leaving them writable
- Add `setReadOnly conn` after `changeReplicationSourceTo` and before `startReplica` in both paths

## Root Cause

The manual `runDemote` command correctly called `setReadOnly`, but the reconnect helpers used by switchover and auto-failover did not.

## Test plan

- [x] `cabal build all` passes without errors
- [x] `cabal test` — all 141 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)