### PR TITLE
docs: add pause-replica / resume-replica to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,12 @@ puremyha fix-errant-gtid [--cluster=<name>]
 # Demote a node to replica under a specified source (resolve split-brain)
 puremyha demote --host db1 --source db2 [--cluster=<name>]
 
+# Pause replication on a replica (STOP REPLICA + stop monitoring)
+puremyha pause-replica --host db2 [--cluster=<name>]
+
+# Resume replication on a paused replica (START REPLICA + resume monitoring)
+puremyha resume-replica --host db2 [--cluster=<name>]
+
 # Trigger manual topology discovery
 puremyha discovery [--cluster=<name>]
 


### PR DESCRIPTION
## Summary
- Add `pause-replica` and `resume-replica` CLI subcommands to the README CLI commands section
- These commands were introduced in PR #10 but the documentation was not updated

## Test plan
- [x] Verify new entries match existing CLI documentation style
- [x] Confirm placement is consistent with command ordering (after `demote`, before `discovery`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)