### PR TITLE
Add pause/resume failover capabilities for maintenance

### DIFF
--- a/app/CLI/Main.hs
+++ b/app/CLI/Main.hs
@@ -28,6 +28,8 @@ data Command
   | CmdDiscovery
   | CmdPauseReplica  Text
   | CmdResumeReplica Text
+  | CmdPauseFailover
+  | CmdResumeFailover
 
 cliOptions :: Parser CLIOptions
 cliOptions = CLIOptions
@@ -66,6 +68,10 @@ cliOptions = CLIOptions
             (info pauseReplicaCmd (progDesc "Pause replication on a node for maintenance"))
         <> command "resume-replica"
             (info resumeReplicaCmd (progDesc "Resume replication on a paused node"))
+        <> command "pause-failover"
+            (info (pure CmdPauseFailover) (progDesc "Pause automatic failover for maintenance"))
+        <> command "resume-failover"
+            (info (pure CmdResumeFailover) (progDesc "Resume automatic failover"))
         )
 
 demoteCmd :: Parser Command
@@ -108,6 +114,8 @@ main = do
         CmdDiscovery        -> ReqDiscovery mCluster
         CmdPauseReplica  host -> ReqPauseReplica  mCluster host
         CmdResumeReplica host -> ReqResumeReplica mCluster host
+        CmdPauseFailover     -> ReqPauseFailover  mCluster
+        CmdResumeFailover    -> ReqResumeFailover mCluster
 
   eResp <- sendRequest socketPath req
   case eResp of

--- a/e2e/lib/helpers.sh
+++ b/e2e/lib/helpers.sh
@@ -98,6 +98,14 @@ ipc_resume_replica() {
   ipc_request "{\"type\":\"resume-replica\",\"host\":\"${host}\"}"
 }
 
+ipc_pause_failover() {
+  ipc_request '{"type":"pause-failover"}'
+}
+
+ipc_resume_failover() {
+  ipc_request '{"type":"resume-failover"}'
+}
+
 ipc_errant_gtid() {
   ipc_request '{"type":"errant-gtid"}'
 }
@@ -117,6 +125,10 @@ get_source_host() {
 
 get_node_count() {
   ipc_status | jq -r '.data[0].nodeCount // empty' 2>/dev/null || echo ""
+}
+
+get_paused() {
+  ipc_status | jq -r '.data[0].paused // empty' 2>/dev/null || echo ""
 }
 
 get_recovery_blocked() {
@@ -324,8 +336,9 @@ reset_cluster() {
   wait_for_replication mysql-replica1 60 || true
   wait_for_replication mysql-replica2 60 || true
 
-  # Clear recovery block via IPC
+  # Clear recovery block and resume failover via IPC
   ipc_ack_recovery >/dev/null 2>&1 || true
+  ipc_resume_failover >/dev/null 2>&1 || true
 
   # Clear hook marker files
   $COMPOSE exec -T puremyhad rm -f /tmp/hook_*.log 2>/dev/null || true

--- a/e2e/tests/10-pause-resume-failover.sh
+++ b/e2e/tests/10-pause-resume-failover.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Test: Pause/Resume Failover
+# Verifies that pause-failover prevents auto-failover and resume-failover re-enables it.
+set -euo pipefail
+source "$(dirname "$0")/../lib/helpers.sh"
+echo "=== Test 10: Pause/Resume Failover ==="
+
+wait_for_health "Healthy" 60
+
+# 1. Verify cluster is healthy with expected source
+orig_source=$(get_source_host)
+echo "  Original source: $orig_source"
+assert_eq "Original source is mysql-source" "mysql-source" "$orig_source"
+
+# 2. Pause failover
+echo "  Sending pause-failover..."
+pause_result=$(ipc_pause_failover)
+pause_success=$(echo "$pause_result" | jq -r '.data.success // empty')
+assert_eq "Pause failover succeeds" "Failover paused" "$pause_success"
+
+# 3. Verify paused=true in status
+paused=$(get_paused)
+assert_eq "Cluster is paused" "true" "$paused"
+
+# 4. Kill the source
+echo "  Stopping mysql-source..."
+$COMPOSE stop mysql-source
+
+# 5. Wait for DeadSource detection, then verify failover does NOT happen
+wait_for_health "DeadSource" 60
+
+echo "  Waiting 15s to confirm failover is blocked..."
+sleep 15
+
+health_after=$(get_health)
+source_after=$(get_source_host)
+assert_eq "Health still DeadSource (failover blocked)" "DeadSource" "$health_after"
+assert_eq "Source unchanged (failover blocked)" "$orig_source" "$source_after"
+
+# 6. Resume failover
+echo "  Sending resume-failover..."
+resume_result=$(ipc_resume_failover)
+resume_success=$(echo "$resume_result" | jq -r '.data.success // empty')
+assert_eq "Resume failover succeeds" "Failover resumed" "$resume_success"
+
+# 7. Wait for failover to complete
+echo "  Waiting for auto-failover after resume..."
+wait_for_health "Healthy" 60
+
+# 8. Verify new source
+new_source=$(get_source_host)
+echo "  New source after failover: $new_source"
+assert_neq "Source changed from original" "$orig_source" "$new_source"
+assert_eq "New source is mysql-replica1" "mysql-replica1" "$new_source"
+
+test_summary

--- a/src/PureMyHA/Failover/Auto.hs
+++ b/src/PureMyHA/Failover/Auto.hs
@@ -4,6 +4,7 @@ module PureMyHA.Failover.Auto
   ) where
 
 import Control.Concurrent.STM
+import Control.Monad (when)
 import qualified Data.Map.Strict as Map
 import Data.Text (Text)
 import qualified Data.Text as T
@@ -46,6 +47,7 @@ checkAutoFailoverPreconditions
   -> Int               -- ^ fcMinReplicasForFailover
   -> Either Text ()
 checkAutoFailoverPreconditions now topo minReplicas = do
+  when (ctPaused topo) $ Left "Failover paused by operator (pause-failover)"
   case ctRecoveryBlockedUntil topo of
     Just deadline | now < deadline ->
       Left "Failover blocked by anti-flap period"

--- a/src/PureMyHA/IPC/Client.hs
+++ b/src/PureMyHA/IPC/Client.hs
@@ -61,8 +61,8 @@ recvResponse sock = go []
 printStatus :: Bool -> [ClusterStatus] -> IO ()
 printStatus True  statuses = BLC.putStrLn (encode statuses)
 printStatus False statuses = do
-  putStrLn $ padR 20 "CLUSTER" <> padR 25 "HEALTH" <> padR 20 "SOURCE" <> padR 6 "NODES" <> "RECOVERY BLOCKED"
-  putStrLn (replicate 80 '-')
+  putStrLn $ padR 20 "CLUSTER" <> padR 25 "HEALTH" <> padR 20 "SOURCE" <> padR 6 "NODES" <> padR 8 "PAUSED" <> "RECOVERY BLOCKED"
+  putStrLn (replicate 88 '-')
   mapM_ printClusterStatus statuses
 
 printClusterStatus :: ClusterStatus -> IO ()
@@ -70,11 +70,13 @@ printClusterStatus cs = do
   let health      = showHealth (csHealth cs)
       source      = maybe "-" T.unpack (csSourceHost cs)
       nodes       = show (csNodeCount cs)
+      paused      = if csPaused cs then "yes" else "no"
       blocked     = maybe "-" showTime (csRecoveryBlockedUntil cs)
   putStrLn $ padR 20 (T.unpack (csClusterName cs))
            <> padR 25 health
            <> padR 20 source
            <> padR 6  nodes
+           <> padR 8  paused
            <> blocked
 
 -- | Print topology in tree format

--- a/src/PureMyHA/IPC/Protocol.hs
+++ b/src/PureMyHA/IPC/Protocol.hs
@@ -55,6 +55,7 @@ instance ToJSON ClusterStatus where
     , "sourceHost"            .= csSourceHost
     , "nodeCount"             .= csNodeCount
     , "recoveryBlockedUntil"  .= csRecoveryBlockedUntil
+    , "paused"                .= csPaused
     ]
 
 instance FromJSON ClusterStatus where
@@ -65,6 +66,7 @@ instance FromJSON ClusterStatus where
       <*> o .: "sourceHost"
       <*> o .: "nodeCount"
       <*> o .: "recoveryBlockedUntil"
+      <*> o .: "paused"
 
 instance ToJSON NodeStateView where
   toJSON NodeStateView{..} = object
@@ -137,6 +139,8 @@ data Request
   | ReqDiscovery { reqCluster :: Maybe ClusterName }
   | ReqPauseReplica  { reqCluster :: Maybe ClusterName, reqPauseHost  :: Text }
   | ReqResumeReplica { reqCluster :: Maybe ClusterName, reqResumeHost :: Text }
+  | ReqPauseFailover  { reqCluster :: Maybe ClusterName }
+  | ReqResumeFailover { reqCluster :: Maybe ClusterName }
   deriving (Show, Eq, Generic)
 
 instance ToJSON Request where
@@ -150,6 +154,8 @@ instance ToJSON Request where
   toJSON (ReqDiscovery mc)       = object ["type" .= ("discovery" :: Text),       "cluster" .= mc]
   toJSON (ReqPauseReplica  mc h) = object ["type" .= ("pause-replica"  :: Text), "cluster" .= mc, "host" .= h]
   toJSON (ReqResumeReplica mc h) = object ["type" .= ("resume-replica" :: Text), "cluster" .= mc, "host" .= h]
+  toJSON (ReqPauseFailover  mc)  = object ["type" .= ("pause-failover"  :: Text), "cluster" .= mc]
+  toJSON (ReqResumeFailover mc)  = object ["type" .= ("resume-failover" :: Text), "cluster" .= mc]
 
 instance FromJSON Request where
   parseJSON = withObject "Request" $ \o -> do
@@ -165,6 +171,8 @@ instance FromJSON Request where
       "discovery"       -> ReqDiscovery    <$> o .:? "cluster"
       "pause-replica"   -> ReqPauseReplica  <$> o .:? "cluster" <*> o .: "host"
       "resume-replica"  -> ReqResumeReplica <$> o .:? "cluster" <*> o .: "host"
+      "pause-failover"  -> ReqPauseFailover  <$> o .:? "cluster"
+      "resume-failover" -> ReqResumeFailover <$> o .:? "cluster"
       _                 -> fail $ "Unknown request type: " <> show t
 
 -- | IPC Response types

--- a/src/PureMyHA/IPC/Server.hs
+++ b/src/PureMyHA/IPC/Server.hs
@@ -183,6 +183,20 @@ handleRequest tvar clusterMap discoveryMap logger req = case req of
           Left err -> OperationFailure err
           Right () -> OperationSuccess ("Replication resumed on " <> host)
 
+  ReqPauseFailover mCluster ->
+    case lookupCluster mCluster clusterMap of
+      Nothing -> pure (RespError "Cluster not found")
+      Just (_, cc, _, _, _, _) -> do
+        atomically $ setClusterPause tvar (ccName cc)
+        pure $ RespOperation (OperationSuccess "Failover paused")
+
+  ReqResumeFailover mCluster ->
+    case lookupCluster mCluster clusterMap of
+      Nothing -> pure (RespError "Cluster not found")
+      Just (_, cc, _, _, _, _) -> do
+        atomically $ clearClusterPause tvar (ccName cc)
+        pure $ RespOperation (OperationSuccess "Failover resumed")
+
 filterClusters :: Maybe ClusterName -> Map ClusterName ClusterTopology -> [ClusterTopology]
 filterClusters Nothing  m = Map.elems m
 filterClusters (Just n) m = maybe [] pure (Map.lookup n m)
@@ -202,6 +216,7 @@ toClusterStatus ct = ClusterStatus
   , csSourceHost           = fmap nodeHost (ctSourceNodeId ct)
   , csNodeCount            = Map.size (ctNodes ct)
   , csRecoveryBlockedUntil = ctRecoveryBlockedUntil ct
+  , csPaused               = ctPaused ct
   }
 
 toClusterTopologyView :: ClusterTopology -> ClusterTopologyView

--- a/src/PureMyHA/Monitor/Worker.hs
+++ b/src/PureMyHA/Monitor/Worker.hs
@@ -274,8 +274,9 @@ recomputeClusterHealth tvar cc mc lock fc fdc pws mHooks logger = do
         logInfo logger $ "[" <> ccName cc <> "] Cluster health: "
           <> T.pack (show (ctHealth topo)) <> " \x2192 " <> T.pack (show newHealth)
       atomically $ updateClusterTopology tvar topo'
-      -- Trigger auto-failover on transition to DeadSource only after cluster was observed healthy
-      when (transitioned && newHealth == DeadSource && fcAutoFailover fc && observedHealthy) $ do
+      -- Trigger auto-failover when DeadSource (not just on transition, so resume-failover works)
+      -- The failover lock prevents concurrent execution; anti-flap block prevents repeated failovers
+      when (newHealth == DeadSource && fcAutoFailover fc && observedHealthy) $ do
         _ <- async (runAutoFailover tvar lock cc fc fdc pws mHooks logger)
         pure ()
       -- Emergency re-check on first transition to UnreachableSource

--- a/src/PureMyHA/Topology/Discovery.hs
+++ b/src/PureMyHA/Topology/Discovery.hs
@@ -52,6 +52,7 @@ buildClusterTopology name nodeStates =
        , ctObservedHealthy      = health == Healthy
        , ctRecoveryBlockedUntil = Nothing
        , ctLastFailoverAt       = Nothing
+       , ctPaused               = False
        }
 
 -- | Recursively discover nodes
@@ -172,4 +173,5 @@ buildInitialTopology cc = ClusterTopology
   , ctObservedHealthy      = False
   , ctRecoveryBlockedUntil = Nothing
   , ctLastFailoverAt       = Nothing
+  , ctPaused               = False
   }

--- a/src/PureMyHA/Topology/State.hs
+++ b/src/PureMyHA/Topology/State.hs
@@ -7,6 +7,8 @@ module PureMyHA.Topology.State
   , setRecoveryBlock
   , clearRecoveryBlock
   , recordFailover
+  , setClusterPause
+  , clearClusterPause
   , TVarDaemonState
   , FailoverLock
   , newFailoverLock
@@ -54,7 +56,9 @@ updateClusterTopology tvar ct = do
       ctVar <- newTVar ct
       writeTVar tvar (Map.insert name ctVar clusters)
     Just ctVar -> modifyTVar' ctVar $ \prevCt ->
-      ct { ctObservedHealthy = ctObservedHealthy prevCt || ctObservedHealthy ct }
+      ct { ctObservedHealthy = ctObservedHealthy prevCt || ctObservedHealthy ct
+         , ctPaused = ctPaused prevCt
+         }
 
 getClusterTopology :: TVarDaemonState -> ClusterName -> IO (Maybe ClusterTopology)
 getClusterTopology tvar name = do
@@ -93,3 +97,17 @@ acquireFailoverLock :: FailoverLock -> STM Bool
 acquireFailoverLock lock = do
   mt <- tryTakeTMVar lock
   pure (mt /= Nothing)
+
+setClusterPause :: TVarDaemonState -> ClusterName -> STM ()
+setClusterPause tvar clusterName = do
+  mctVar <- lookupClusterTVar tvar clusterName
+  case mctVar of
+    Nothing    -> pure ()
+    Just ctVar -> modifyTVar' ctVar $ \ct -> ct { ctPaused = True }
+
+clearClusterPause :: TVarDaemonState -> ClusterName -> STM ()
+clearClusterPause tvar clusterName = do
+  mctVar <- lookupClusterTVar tvar clusterName
+  case mctVar of
+    Nothing    -> pure ()
+    Just ctVar -> modifyTVar' ctVar $ \ct -> ct { ctPaused = False }

--- a/src/PureMyHA/Types.hs
+++ b/src/PureMyHA/Types.hs
@@ -70,6 +70,7 @@ data ClusterTopology = ClusterTopology
   , ctObservedHealthy       :: Bool             -- True if cluster has ever been Healthy since daemon start
   , ctRecoveryBlockedUntil  :: Maybe UTCTime
   , ctLastFailoverAt        :: Maybe UTCTime
+  , ctPaused                :: Bool
   } deriving (Show, Generic)
 
 data DaemonState = DaemonState
@@ -83,6 +84,7 @@ data ClusterStatus = ClusterStatus
   , csSourceHost  :: Maybe Text
   , csNodeCount   :: Int
   , csRecoveryBlockedUntil :: Maybe UTCTime
+  , csPaused    :: Bool
   } deriving (Show, Eq, Generic)
 
 data ClusterTopologyView = ClusterTopologyView

--- a/test/PureMyHA/AutoSpec.hs
+++ b/test/PureMyHA/AutoSpec.hs
@@ -19,6 +19,7 @@ deadSourceTopo = ClusterTopology
   , ctObservedHealthy      = True
   , ctRecoveryBlockedUntil = Nothing
   , ctLastFailoverAt       = Nothing
+  , ctPaused               = False
   }
 
 healthyTopo :: ClusterTopology
@@ -62,6 +63,10 @@ spec = describe "checkAutoFailoverPreconditions" $ do
 
   it "returns Left when minReplicas=2 but only one replica present" $
     checkAutoFailoverPreconditions now deadSourceTopo 2
+      `shouldSatisfy` isLeft
+
+  it "returns Left when cluster is paused" $
+    checkAutoFailoverPreconditions now (deadSourceTopo { ctPaused = True }) 1
       `shouldSatisfy` isLeft
 
 isLeft :: Either a b -> Bool

--- a/test/PureMyHA/IPCSpec.hs
+++ b/test/PureMyHA/IPCSpec.hs
@@ -41,6 +41,12 @@ spec = do
     it "round-trips ReqResumeReplica" $
       roundTrip (ReqResumeReplica Nothing "db3") `shouldBe` Just (ReqResumeReplica Nothing "db3")
 
+    it "round-trips ReqPauseFailover" $
+      roundTrip (ReqPauseFailover (Just "main")) `shouldBe` Just (ReqPauseFailover (Just "main"))
+
+    it "round-trips ReqResumeFailover" $
+      roundTrip (ReqResumeFailover Nothing) `shouldBe` Just (ReqResumeFailover Nothing)
+
   describe "Response JSON round-trip" $ do
     it "round-trips RespError" $
       roundTripResp (RespError "something went wrong")


### PR DESCRIPTION
## Overview
This PR introduces `pause-failover` and `resume-failover` functionality to temporarily block automatic failovers during maintenance windows, while still allowing manual switchovers. 

For safety, the pause state is stored **in-memory only**. This ensures that if a maintenance pause is forgotten, simply restarting the daemon will automatically resume normal auto-failover operations.

## Key Changes
**Core Logic & State Management:**
- Added the `ctPaused` field to `ClusterTopology`, ensuring the state is preserved across topology refreshes.
- Updated `checkAutoFailoverPreconditions` to block automatic failovers when the cluster is in a paused state.
- Modified the auto-failover trigger to evaluate on *any* `DeadSource` cycle rather than just upon transition. This ensures that failover resumes immediately upon unpausing if the source is already dead.

**CLI & IPC Updates:**
- Added `pause-failover` and `resume-failover` IPC commands and their corresponding CLI subcommands.
- Updated the CLI status output to include a `PAUSED` column.
- Added a `paused` boolean field to the JSON status output.

**Testing:**
- Added unit tests for pause preconditions and IPC round-trips.
- Added an End-to-End (E2E) test verifying that the pause state successfully blocks an auto-failover, and that resuming correctly re-enables it.

## How to Test
1. Run the cluster and verify normal status.
2. Execute the `[cli-command] pause-failover` command.
3. Check the CLI status output to confirm the `PAUSED` column indicates the paused state.
4. Stop the source node to trigger a `DeadSource` cycle and confirm that auto-failover is **blocked**.
5. Execute the `[cli-command] resume-failover` command.
6. Confirm that the auto-failover immediately triggers and resolves the dead source.