### PR TITLE
refactor: introduce ReaderT ClusterEnv (App monad) to eliminate repeated parameter passing

### DIFF
--- a/app/Daemon/Main.hs
+++ b/app/Daemon/Main.hs
@@ -16,6 +16,7 @@ import System.IO (hPutStrLn, stderr)
 import System.Posix.Signals (installHandler, sigTERM, sigINT, sigHUP, Handler(..))
 
 import PureMyHA.Config
+import PureMyHA.Env (ClusterEnv (..), runApp)
 import PureMyHA.IPC.Server (startIPCServer, defaultSocketPath, DiscoveryAction)
 import PureMyHA.Logger (Logger, initLogger, logInfo, logWarn, closeLogger)
 import PureMyHA.Monitor.Worker (startMonitorWorkers, startTopologyRefreshWorker, WorkerRegistry, runWorker)
@@ -82,32 +83,30 @@ main = do
 
   clusterPasswords <- mapM (\cc -> (cc,) <$> loadClusterPasswords cc) (cfgClusters cfg)
 
-  clusterEntries <- mapM (initCluster tvar cfg logger) clusterPasswords
+  clusterEnvs <- mapM (initCluster tvar cfg mcVar hooksVar logger) clusterPasswords
   let clusterMap = Map.fromList
-        [ (ccName cc, entry)
-        | ((cc, _), entry) <- zip clusterPasswords clusterEntries
+        [ (ccName (envCluster env), env)
+        | env <- clusterEnvs
         ]
 
   -- Start monitor workers (returns registry per cluster)
   (registries, workerLists) <- fmap unzip $ mapM
-    (\((cc, pws), (lock, _, fc, fdc, _, _)) ->
-        startMonitorWorkers tvar cc mcVar hooksVar lock fc fdc pws logger)
-    (zip clusterPasswords clusterEntries)
+    (\env -> runApp env startMonitorWorkers)
+    clusterEnvs
   let monitorWorkers = concat workerLists
 
   -- Start topology refresh workers
   refreshWorkers <- mapM
-    (\((cc, pws), (lock, _, fc, fdc, _, _), reg) ->
-        startTopologyRefreshWorker tvar cc mcVar hooksVar lock fc fdc pws reg logger)
-    (zip3 clusterPasswords clusterEntries registries)
+    (\(env, reg) -> runApp env (startTopologyRefreshWorker reg))
+    (zip clusterEnvs registries)
 
   -- Build discovery callbacks per cluster
   let discoveryMap = Map.fromList
-        [ (ccName cc, makeDiscoveryAction tvar cc pws mcVar hooksVar lock fc fdc reg logger)
-        | ((cc, pws), (lock, _, fc, fdc, _, _), reg) <- zip3 clusterPasswords clusterEntries registries
+        [ (ccName (envCluster env), makeDiscoveryAction env reg)
+        | (env, reg) <- zip clusterEnvs registries
         ]
 
-  ipcAsync <- async $ startIPCServer tvar clusterMap discoveryMap (optSocketPath opts) logger
+  ipcAsync <- async $ startIPCServer tvar clusterMap discoveryMap (optSocketPath opts)
 
   logInfo logger "puremyhad started"
 
@@ -125,10 +124,12 @@ main = do
 initCluster
   :: TVarDaemonState
   -> Config
+  -> TVar MonitoringConfig
+  -> TVar (Maybe HooksConfig)
   -> Logger
   -> (ClusterConfig, ClusterPasswords)
-  -> IO (FailoverLock, ClusterConfig, FailoverConfig, FailureDetectionConfig, ClusterPasswords, Maybe HooksConfig)
-initCluster tvar cfg logger (cc, pws) = do
+  -> IO ClusterEnv
+initCluster tvar cfg mcVar hooksVar logger (cc, pws) = do
   let initTopo = buildInitialTopology cc
   atomically $ updateClusterTopology tvar initTopo
   topo <- discoverTopology cc (cpPassword pws) logger
@@ -136,7 +137,17 @@ initCluster tvar cfg logger (cc, pws) = do
     <> T.pack (show (Map.size (ctNodes topo))) <> " node(s)"
   atomically $ updateClusterTopology tvar topo
   lock <- newFailoverLock
-  pure (lock, cc, cfgFailover cfg, cfgFailureDetection cfg, pws, cfgHooks cfg)
+  pure ClusterEnv
+    { envDaemonState = tvar
+    , envCluster     = cc
+    , envFailover    = cfgFailover cfg
+    , envDetection   = cfgFailureDetection cfg
+    , envPasswords   = pws
+    , envMonitoring  = mcVar
+    , envHooks       = hooksVar
+    , envLock        = lock
+    , envLogger      = logger
+    }
 
 loadClusterPasswords :: ClusterConfig -> IO ClusterPasswords
 loadClusterPasswords cc = do
@@ -152,19 +163,19 @@ loadPassword creds = do
     Left err  -> die $ "Failed to read password file: " <> show err
     Right pwd -> pure pwd
 
-makeDiscoveryAction
-  :: TVarDaemonState -> ClusterConfig -> ClusterPasswords
-  -> TVar MonitoringConfig -> TVar (Maybe HooksConfig)
-  -> FailoverLock -> FailoverConfig -> FailureDetectionConfig
-  -> WorkerRegistry -> Logger -> DiscoveryAction
-makeDiscoveryAction tvar cc pws mcVar hooksVar lock fc fdc reg logger = do
+makeDiscoveryAction :: ClusterEnv -> WorkerRegistry -> DiscoveryAction
+makeDiscoveryAction env reg = do
+  let tvar   = envDaemonState env
+      cc     = envCluster env
+      pws    = envPasswords env
+      logger = envLogger env
   newTopo <- discoverTopology cc (cpPassword pws) logger
   atomically $ updateClusterTopology tvar newTopo
   knownNodes <- Map.keysSet <$> readTVarIO reg
   let discovered = Map.keysSet (ctNodes newTopo)
       newNodes   = Set.difference discovered knownNodes
   forM_ newNodes $ \nid -> do
-    a <- async (runWorker tvar cc mcVar hooksVar lock fc fdc pws nid logger)
+    a <- async (runApp env (runWorker nid))
     atomically $ modifyTVar' reg (Map.insert nid a)
   pure $ Right $ "Discovery complete: " <> T.pack (show (Map.size (ctNodes newTopo)))
     <> " node(s) found, " <> T.pack (show (Set.size newNodes)) <> " new"

--- a/puremyha.cabal
+++ b/puremyha.cabal
@@ -38,6 +38,7 @@ library
     PureMyHA.Types
     PureMyHA.Config
     PureMyHA.Logger
+    PureMyHA.Env
     PureMyHA.Hook
     PureMyHA.MySQL.Auth
     PureMyHA.MySQL.Connection

--- a/src/PureMyHA/Env.hs
+++ b/src/PureMyHA/Env.hs
@@ -1,0 +1,60 @@
+module PureMyHA.Env
+  ( ClusterEnv (..)
+  , App
+  , runApp
+  , getMonitoringConfig
+  , getHooksConfig
+  , getClusterName
+  , getMySQLUser
+  , getMonPassword
+  , appLogInfo
+  , appLogWarn
+  , appLogError
+  ) where
+
+import Control.Concurrent.STM (TVar, readTVarIO)
+import Control.Monad.Reader (ReaderT, asks, runReaderT)
+import Control.Monad.IO.Class (liftIO)
+import Data.Text (Text)
+import PureMyHA.Config
+import PureMyHA.Logger (Logger, logInfo, logWarn, logError)
+import PureMyHA.Topology.State (TVarDaemonState, FailoverLock)
+import PureMyHA.Types (ClusterName)
+
+data ClusterEnv = ClusterEnv
+  { envDaemonState :: TVarDaemonState
+  , envCluster     :: ClusterConfig
+  , envFailover    :: FailoverConfig
+  , envDetection   :: FailureDetectionConfig
+  , envPasswords   :: ClusterPasswords
+  , envMonitoring  :: TVar MonitoringConfig
+  , envHooks       :: TVar (Maybe HooksConfig)
+  , envLock        :: FailoverLock
+  , envLogger      :: Logger
+  }
+
+type App a = ReaderT ClusterEnv IO a
+
+runApp :: ClusterEnv -> App a -> IO a
+runApp = flip runReaderT
+
+-- Helpers
+getMonitoringConfig :: App MonitoringConfig
+getMonitoringConfig = asks envMonitoring >>= liftIO . readTVarIO
+
+getHooksConfig :: App (Maybe HooksConfig)
+getHooksConfig = asks envHooks >>= liftIO . readTVarIO
+
+getClusterName :: App ClusterName
+getClusterName = asks (ccName . envCluster)
+
+getMySQLUser :: App Text
+getMySQLUser = asks (credUser . ccCredentials . envCluster)
+
+getMonPassword :: App Text
+getMonPassword = asks (cpPassword . envPasswords)
+
+appLogInfo, appLogWarn, appLogError :: Text -> App ()
+appLogInfo  msg = asks envLogger >>= \l -> liftIO (logInfo l msg)
+appLogWarn  msg = asks envLogger >>= \l -> liftIO (logWarn l msg)
+appLogError msg = asks envLogger >>= \l -> liftIO (logError l msg)

--- a/src/PureMyHA/Failover/Auto.hs
+++ b/src/PureMyHA/Failover/Auto.hs
@@ -6,40 +6,34 @@ module PureMyHA.Failover.Auto
 import Control.Concurrent.STM
 import Control.Monad (when)
 import Control.Monad.Except (ExceptT (..), runExceptT)
+import Control.Monad.IO.Class (liftIO)
+import Control.Monad.Reader (asks)
 import Control.Monad.Trans.Class (lift)
 import qualified Data.Map.Strict as Map
 import Data.Text (Text)
 import qualified Data.Text as T
 import Data.Time (UTCTime, getCurrentTime)
 import PureMyHA.Config
+import PureMyHA.Env
 import PureMyHA.Failover.Candidate (selectCandidate)
 import PureMyHA.Hook
   ( runHookFireForget, runHookOrAbort, getCurrentTimestamp, HookEnv (..) )
-import PureMyHA.Logger (Logger, logInfo, logError)
+import PureMyHA.Logger (logInfo, logError)
 import PureMyHA.MySQL.Connection (makeConnectInfo, withNodeConn)
 import PureMyHA.MySQL.Query
 import PureMyHA.Topology.State
 import PureMyHA.Types
 
 -- | Execute automatic failover for a cluster
-runAutoFailover
-  :: TVarDaemonState
-  -> FailoverLock
-  -> ClusterConfig
-  -> FailoverConfig
-  -> FailureDetectionConfig
-  -> ClusterPasswords
-  -> Maybe HooksConfig
-  -> Logger
-  -> IO (Either Text ())
-runAutoFailover tvar lock cc fc fdc pws mHooks logger = do
-  -- Try to acquire failover lock (prevent concurrent failovers)
-  acquired <- atomically $ tryTakeTMVar lock
+runAutoFailover :: App (Either Text ())
+runAutoFailover = do
+  lock <- asks envLock
+  acquired <- liftIO $ atomically $ tryTakeTMVar lock
   case acquired of
     Nothing -> pure (Left "Failover already in progress")
     Just () -> do
-      result <- doFailover tvar cc fc fdc pws mHooks logger
-      atomically $ putTMVar lock ()
+      result <- doFailover
+      liftIO $ atomically $ putTMVar lock ()
       pure result
 
 -- | Check preconditions for auto failover (pure)
@@ -62,130 +56,126 @@ checkAutoFailoverPreconditions now topo minReplicas = do
     then Left $ "Not enough replicas for failover (need " <> T.pack (show minReplicas) <> ")"
     else Right ()
 
-doFailover
-  :: TVarDaemonState
-  -> ClusterConfig
-  -> FailoverConfig
-  -> FailureDetectionConfig
-  -> ClusterPasswords
-  -> Maybe HooksConfig
-  -> Logger
-  -> IO (Either Text ())
-doFailover tvar cc fc fdc pws mHooks logger = do
-  mTopo <- getClusterTopology tvar (ccName cc)
+doFailover :: App (Either Text ())
+doFailover = do
+  tvar <- asks envDaemonState
+  cc   <- asks envCluster
+  fc   <- asks envFailover
+  mTopo <- liftIO $ getClusterTopology tvar (ccName cc)
   case mTopo of
     Nothing -> do
-      logError logger $ "[" <> ccName cc <> "] Auto-failover failed: Cluster not found"
+      appLogError $ "[" <> ccName cc <> "] Auto-failover failed: Cluster not found"
       pure (Left "Cluster not found")
     Just topo -> do
-      now <- getCurrentTime
+      now <- liftIO getCurrentTime
       case checkAutoFailoverPreconditions now topo (fcMinReplicasForFailover fc) of
         Left err -> do
-          logError logger $ "[" <> ccName cc <> "] Auto-failover failed: " <> err
+          appLogError $ "[" <> ccName cc <> "] Auto-failover failed: " <> err
           pure (Left err)
         Right () -> do
-          logInfo logger $ "[" <> ccName cc <> "] Auto-failover started"
-          executeFailover tvar cc fc fdc pws mHooks logger topo
+          appLogInfo $ "[" <> ccName cc <> "] Auto-failover started"
+          executeFailover topo
 
-executeFailover
-  :: TVarDaemonState
-  -> ClusterConfig
-  -> FailoverConfig
-  -> FailureDetectionConfig
-  -> ClusterPasswords
-  -> Maybe HooksConfig
-  -> Logger
-  -> ClusterTopology
-  -> IO (Either Text ())
-executeFailover tvar cc fc fdc pws mHooks logger topo = runExceptT $ do
-  candidateId <- ExceptT $ case selectCandidate (ctNodes topo) (fcCandidatePriority fc) Nothing of
-    Left err -> logError logger (prefix <> "Auto-failover failed: " <> err) >> pure (Left err)
-    Right c  -> pure (Right c)
+executeFailover :: ClusterTopology -> App (Either Text ())
+executeFailover topo = runExceptT $ do
+  cc <- lift $ asks envCluster
+  fc <- lift $ asks envFailover
+  let prefix = "[" <> ccName cc <> "] "
+  candidateId <- ExceptT $ do
+    case selectCandidate (ctNodes topo) (fcCandidatePriority fc) Nothing of
+      Left err -> do
+        appLogError (prefix <> "Auto-failover failed: " <> err)
+        pure (Left err)
+      Right c -> pure (Right c)
   let oldSourceHost = fmap nodeHost (ctSourceNodeId topo)
-      user          = credUser (ccCredentials cc)
       waitTimeout   = truncate (fcWaitRelayLogTimeout fc) :: Int
-  ExceptT $ runPreFailoverHook mHooks cc candidateId oldSourceHost logger
-  lift $ logInfo logger $ prefix <> "Waiting for relay log apply on " <> nodeHost candidateId <> "..."
-  ExceptT $ promoteWithOnFailureHook user pws candidateId waitTimeout logger (ccName cc) mHooks oldSourceHost
-  lift $ reconnectOtherReplicas user pws candidateId topo
-  now <- lift getCurrentTime
-  lift $ commitFailoverState tvar cc fdc topo now
-  ts <- lift getCurrentTimestamp
+  ExceptT $ runPreFailoverHook candidateId oldSourceHost
+  lift $ appLogInfo $ prefix <> "Waiting for relay log apply on " <> nodeHost candidateId <> "..."
+  ExceptT $ promoteWithOnFailureHook candidateId waitTimeout oldSourceHost
+  lift $ reconnectOtherReplicas candidateId topo
+  now <- liftIO getCurrentTime
+  lift $ commitFailoverState topo now
+  ts <- liftIO getCurrentTimestamp
+  mHooks <- lift getHooksConfig
   let postEnv = HookEnv (ccName cc) (Just (nodeHost candidateId)) oldSourceHost (Just "DeadSource") ts
-  lift $ runHookFireForget mHooks hcPostFailover postEnv
-  lift $ logInfo logger $ prefix <> "Auto-failover completed: new source is " <> nodeHost candidateId
-  where
-    prefix = "[" <> ccName cc <> "] "
+  liftIO $ runHookFireForget mHooks hcPostFailover postEnv
+  lift $ appLogInfo $ prefix <> "Auto-failover completed: new source is " <> nodeHost candidateId
 
-runPreFailoverHook
-  :: Maybe HooksConfig -> ClusterConfig -> NodeId -> Maybe Text -> Logger
-  -> IO (Either Text ())
-runPreFailoverHook mHooks cc candidateId oldSourceHost logger = do
-  ts <- getCurrentTimestamp
+runPreFailoverHook :: NodeId -> Maybe Text -> App (Either Text ())
+runPreFailoverHook candidateId oldSourceHost = do
+  cc     <- asks envCluster
+  mHooks <- getHooksConfig
+  ts <- liftIO getCurrentTimestamp
   let preEnv = HookEnv (ccName cc) (Just (nodeHost candidateId)) oldSourceHost (Just "DeadSource") ts
-  preResult <- runHookOrAbort mHooks hcPreFailover preEnv
+  preResult <- liftIO $ runHookOrAbort mHooks hcPreFailover preEnv
   case preResult of
     Left err -> do
-      logError logger $ "[" <> ccName cc <> "] Pre-failover hook aborted failover: " <> err
+      appLogError $ "[" <> ccName cc <> "] Pre-failover hook aborted failover: " <> err
       pure (Left $ "Pre-failover hook failed: " <> err)
     Right () -> pure (Right ())
 
-promoteWithOnFailureHook
-  :: Text -> ClusterPasswords -> NodeId -> Int -> Logger -> Text
-  -> Maybe HooksConfig -> Maybe Text
-  -> IO (Either Text ())
-promoteWithOnFailureHook user pws candidateId waitTimeout logger clusterName mHooks oldSourceHost = do
-  promoteResult <- promoteCandidate user (cpPassword pws) candidateId waitTimeout logger clusterName
+promoteWithOnFailureHook :: NodeId -> Int -> Maybe Text -> App (Either Text ())
+promoteWithOnFailureHook candidateId waitTimeout oldSourceHost = do
+  clusterName <- getClusterName
+  promoteResult <- promoteCandidate candidateId waitTimeout
   case promoteResult of
     Left err -> do
-      logError logger $ "[" <> clusterName <> "] Auto-failover failed: Promote failed: " <> err
-      ts <- getCurrentTimestamp
+      appLogError $ "[" <> clusterName <> "] Auto-failover failed: Promote failed: " <> err
+      ts <- liftIO getCurrentTimestamp
+      mHooks <- getHooksConfig
       let failEnv = HookEnv clusterName (Just (nodeHost candidateId)) oldSourceHost (Just "PromoteFailed") ts
-      runHookFireForget mHooks hcPostUnsuccessfulFailover failEnv
+      liftIO $ runHookFireForget mHooks hcPostUnsuccessfulFailover failEnv
       pure (Left $ "Promote failed: " <> err)
     Right () -> pure (Right ())
 
-reconnectOtherReplicas
-  :: Text -> ClusterPasswords -> NodeId -> ClusterTopology -> IO ()
-reconnectOtherReplicas user pws candidateId topo = do
+reconnectOtherReplicas :: NodeId -> ClusterTopology -> App ()
+reconnectOtherReplicas candidateId topo = do
   let otherReplicas = filter
         (\ns -> nsNodeId ns /= candidateId && not (nsIsSource ns))
         (Map.elems (ctNodes topo))
-  mapM_ (reconnectReplica user (cpPassword pws) (cpReplUser pws) (cpReplPassword pws) candidateId) otherReplicas
+  mapM_ (reconnectReplica candidateId) otherReplicas
 
-commitFailoverState
-  :: TVarDaemonState -> ClusterConfig -> FailureDetectionConfig
-  -> ClusterTopology -> UTCTime -> IO ()
-commitFailoverState tvar cc fdc topo now = do
+commitFailoverState :: ClusterTopology -> UTCTime -> App ()
+commitFailoverState topo now = do
+  tvar <- asks envDaemonState
+  cc   <- asks envCluster
+  fdc  <- asks envDetection
   let oldSources = filter nsIsSource (Map.elems (ctNodes topo))
-  atomically $ do
+  liftIO $ atomically $ do
     recordFailover tvar (ccName cc) now
     setRecoveryBlock tvar (ccName cc) now (fdcRecoveryBlockPeriod fdc)
     mapM_ (\ns -> updateNodeState tvar (ccName cc) (ns { nsIsSource = False })) oldSources
 
-promoteCandidate :: Text -> Text -> NodeId -> Int -> Logger -> Text -> IO (Either Text ())
-promoteCandidate user password nid waitTimeout logger clusterName = do
+promoteCandidate :: NodeId -> Int -> App (Either Text ())
+promoteCandidate nid waitTimeout = do
+  user <- getMySQLUser
+  password <- getMonPassword
+  clusterName <- getClusterName
+  logger <- asks envLogger
   let ci = makeConnectInfo nid user password
-  result <- withNodeConn ci $ \conn -> do
-    caughtUp <- waitForRelayLogApply conn waitTimeout
-    if caughtUp
-      then logInfo logger $ "[" <> clusterName <> "] Relay log apply completed on " <> nodeHost nid
-      else logError logger $ "[" <> clusterName <> "] WARNING: Relay log apply timed out on " <> nodeHost nid <> ", proceeding with promotion"
-    stopReplica conn
-    resetReplicaAll conn
-    setReadWrite conn
-  pure $ case result of
-    Left err -> Left err
-    Right () -> Right ()
+  liftIO $ do
+    result <- withNodeConn ci $ \conn -> do
+      caughtUp <- waitForRelayLogApply conn waitTimeout
+      if caughtUp
+        then logInfo logger $ "[" <> clusterName <> "] Relay log apply completed on " <> nodeHost nid
+        else logError logger $ "[" <> clusterName <> "] WARNING: Relay log apply timed out on " <> nodeHost nid <> ", proceeding with promotion"
+      stopReplica conn
+      resetReplicaAll conn
+      setReadWrite conn
+    pure $ case result of
+      Left err -> Left err
+      Right () -> Right ()
 
-reconnectReplica :: Text -> Text -> Text -> Text -> NodeId -> NodeState -> IO ()
-reconnectReplica user monPassword replUser replPassword newSourceId ns = do
-  let ci = makeConnectInfo (nsNodeId ns) user monPassword
-  _ <- withNodeConn ci $ \conn -> do
-    stopReplica conn
-    changeReplicationSourceTo conn (nodeHost newSourceId) (nodePort newSourceId) replUser replPassword
-    setReadOnly conn
-    startReplica conn
-  pure ()
-
-
+reconnectReplica :: NodeId -> NodeState -> App ()
+reconnectReplica newSourceId ns = do
+  user <- getMySQLUser
+  password <- getMonPassword
+  pws <- asks envPasswords
+  let ci = makeConnectInfo (nsNodeId ns) user password
+  liftIO $ do
+    _ <- withNodeConn ci $ \conn -> do
+      stopReplica conn
+      changeReplicationSourceTo conn (nodeHost newSourceId) (nodePort newSourceId) (cpReplUser pws) (cpReplPassword pws)
+      setReadOnly conn
+      startReplica conn
+    pure ()

--- a/src/PureMyHA/Failover/Demote.hs
+++ b/src/PureMyHA/Failover/Demote.hs
@@ -1,32 +1,34 @@
 module PureMyHA.Failover.Demote (runDemote) where
 
 import Control.Concurrent.STM (atomically)
+import Control.Monad.IO.Class (liftIO)
+import Control.Monad.Reader (asks)
 import qualified Data.Map.Strict as Map
 import Data.Text (Text)
-import PureMyHA.Config (ClusterConfig (..), Credentials (..), ClusterPasswords (..))
-import PureMyHA.Logger (Logger, logInfo, logError)
+import PureMyHA.Config (ClusterConfig (..), ClusterPasswords (..))
+import PureMyHA.Env (App, ClusterEnv (..), getMySQLUser, getMonPassword, appLogInfo, appLogError)
 import PureMyHA.MySQL.Connection (makeConnectInfo, withNodeConn)
 import PureMyHA.MySQL.Query
   ( stopReplica, setReadOnly, changeReplicationSourceTo, startReplica )
-import PureMyHA.Topology.State (TVarDaemonState, getClusterTopology, updateNodeState)
+import PureMyHA.Topology.State (getClusterTopology, updateNodeState)
 import PureMyHA.Types
 
 -- | Demote a node to replica under a specified source
 runDemote
-  :: TVarDaemonState
-  -> ClusterConfig
-  -> ClusterPasswords
-  -> Text       -- ^ host to demote
+  :: Text       -- ^ host to demote
   -> Text       -- ^ new source host
-  -> Logger
-  -> IO (Either Text ())
-runDemote tvar cc pws demoteHost srcHost logger = do
-  mTopo <- getClusterTopology tvar (ccName cc)
+  -> App (Either Text ())
+runDemote demoteHost srcHost = do
+  tvar <- asks envDaemonState
+  cc   <- asks envCluster
+  pws  <- asks envPasswords
+  user <- getMySQLUser
+  password <- getMonPassword
+  mTopo <- liftIO $ getClusterTopology tvar (ccName cc)
   case mTopo of
     Nothing -> pure (Left "Cluster not found")
     Just topo -> do
       let nodes = Map.elems (ctNodes topo)
-          user  = credUser (ccCredentials cc)
           findByHost h = filter (\ns -> nodeHost (nsNodeId ns) == h) nodes
       case (findByHost demoteHost, findByHost srcHost) of
         ([], _) -> pure (Left $ "Node not found: " <> demoteHost)
@@ -34,21 +36,21 @@ runDemote tvar cc pws demoteHost srcHost logger = do
         (demoteNs : _, srcNs : _) -> do
           let demoteId = nsNodeId demoteNs
               srcId    = nsNodeId srcNs
-              ci       = makeConnectInfo demoteId user (cpPassword pws)
-          logInfo logger $ "[" <> ccName cc <> "] Demoting " <> demoteHost
-                        <> " to replica under " <> srcHost
-          result <- withNodeConn ci $ \conn -> do
+              ci       = makeConnectInfo demoteId user password
+          appLogInfo $ "[" <> ccName cc <> "] Demoting " <> demoteHost
+                    <> " to replica under " <> srcHost
+          result <- liftIO $ withNodeConn ci $ \conn -> do
             stopReplica conn
             setReadOnly conn
             changeReplicationSourceTo conn (nodeHost srcId) (nodePort srcId) (cpReplUser pws) (cpReplPassword pws)
             startReplica conn
           case result of
             Left err -> do
-              logError logger $ "[" <> ccName cc <> "] Demote failed: " <> err
+              appLogError $ "[" <> ccName cc <> "] Demote failed: " <> err
               pure (Left err)
             Right () -> do
-              atomically $ updateNodeState tvar (ccName cc)
+              liftIO $ atomically $ updateNodeState tvar (ccName cc)
                 (demoteNs { nsIsSource = False })
-              logInfo logger $ "[" <> ccName cc <> "] Demote completed: "
-                            <> demoteHost <> " is now a replica"
+              appLogInfo $ "[" <> ccName cc <> "] Demote completed: "
+                        <> demoteHost <> " is now a replica"
               pure (Right ())

--- a/src/PureMyHA/Failover/ErrantGtid.hs
+++ b/src/PureMyHA/Failover/ErrantGtid.hs
@@ -4,15 +4,18 @@ module PureMyHA.Failover.ErrantGtid
   , collectErrantGtids
   ) where
 
+import Control.Monad.IO.Class (liftIO)
+import Control.Monad.Reader (asks)
 import Data.List (nub)
 import qualified Data.Map.Strict as Map
 import Data.Text (Text)
 import qualified Data.Text as T
-import PureMyHA.Config (ClusterConfig (..), Credentials (..))
+import PureMyHA.Config (ClusterConfig (..))
+import PureMyHA.Env (App, ClusterEnv (..), getMySQLUser, getMonPassword)
 import PureMyHA.MySQL.Connection (makeConnectInfo, withNodeConn)
 import PureMyHA.MySQL.GTID (GtidEntry (..), GtidInterval (..), parseGtidIntervals)
 import PureMyHA.MySQL.Query (injectEmptyTransaction)
-import PureMyHA.Topology.State (TVarDaemonState, getClusterTopology)
+import PureMyHA.Topology.State (getClusterTopology)
 import PureMyHA.Types
 
 -- | Expand one GtidEntry to individual "uuid:N" strings
@@ -28,29 +31,33 @@ collectErrantGtids :: [[GtidEntry]] -> [Text]
 collectErrantGtids = nub . concatMap (concatMap expandGtidEntry)
 
 -- | Fix errant GTIDs by injecting empty transactions on the source
-runFixErrantGtid :: TVarDaemonState -> ClusterConfig -> Text -> IO (Either Text ())
-runFixErrantGtid tvar cc password = do
-  mTopo <- getClusterTopology tvar (ccName cc)
-  case mTopo of
-    Nothing -> pure (Left "Cluster not found")
-    Just topo ->
-      case ctSourceNodeId topo of
-        Nothing -> pure (Left "No source node found in cluster topology")
-        Just srcId -> do
-          let user        = credUser (ccCredentials cc)
-              allNodes    = Map.elems (ctNodes topo)
-              errantNodes = filter (\ns -> nsErrantGtids ns /= "") allNodes
-          case errantNodes of
-            [] -> pure (Right ())
-            _  -> do
-              let parseResults = map (parseGtidIntervals . nsErrantGtids) errantNodes
-              case sequence parseResults of
-                Left err -> pure (Left ("GTID parse error: " <> T.pack err))
-                Right entryLists -> do
-                  let gtids = collectErrantGtids entryLists
-                  let srcCi = makeConnectInfo srcId user password
-                  result <- withNodeConn srcCi $ \conn ->
-                    mapM_ (injectEmptyTransaction conn) gtids
-                  case result of
-                    Left err -> pure (Left ("Connection to source failed: " <> err))
-                    Right () -> pure (Right ())
+runFixErrantGtid :: App (Either Text ())
+runFixErrantGtid = do
+  tvar <- asks (envDaemonState)
+  cc   <- asks (envCluster)
+  user <- getMySQLUser
+  password <- getMonPassword
+  liftIO $ do
+    mTopo <- getClusterTopology tvar (ccName cc)
+    case mTopo of
+      Nothing -> pure (Left "Cluster not found")
+      Just topo ->
+        case ctSourceNodeId topo of
+          Nothing -> pure (Left "No source node found in cluster topology")
+          Just srcId -> do
+            let allNodes    = Map.elems (ctNodes topo)
+                errantNodes = filter (\ns -> nsErrantGtids ns /= "") allNodes
+            case errantNodes of
+              [] -> pure (Right ())
+              _  -> do
+                let parseResults = map (parseGtidIntervals . nsErrantGtids) errantNodes
+                case sequence parseResults of
+                  Left err -> pure (Left ("GTID parse error: " <> T.pack err))
+                  Right entryLists -> do
+                    let gtids = collectErrantGtids entryLists
+                    let srcCi = makeConnectInfo srcId user password
+                    result <- withNodeConn srcCi $ \conn ->
+                      mapM_ (injectEmptyTransaction conn) gtids
+                    case result of
+                      Left err -> pure (Left ("Connection to source failed: " <> err))
+                      Right () -> pure (Right ())

--- a/src/PureMyHA/Failover/PauseReplica.hs
+++ b/src/PureMyHA/Failover/PauseReplica.hs
@@ -1,75 +1,75 @@
 module PureMyHA.Failover.PauseReplica (runPauseReplica, runResumeReplica) where
 
 import Control.Concurrent.STM (atomically)
+import Control.Monad.IO.Class (liftIO)
+import Control.Monad.Reader (asks)
 import qualified Data.Map.Strict as Map
 import Data.Text (Text)
-import PureMyHA.Config (ClusterConfig (..), Credentials (..), ClusterPasswords (..))
-import PureMyHA.Logger (Logger, logInfo, logError)
+import PureMyHA.Config (ClusterConfig (..))
+import PureMyHA.Env (App, ClusterEnv (..), getMySQLUser, getMonPassword, appLogInfo, appLogError)
 import PureMyHA.MySQL.Connection (makeConnectInfo, withNodeConn)
 import PureMyHA.MySQL.Query (stopReplica, startReplica)
-import PureMyHA.Topology.State (TVarDaemonState, getClusterTopology, updateNodeState)
+import PureMyHA.Topology.State (getClusterTopology, updateNodeState)
 import PureMyHA.Types
 
 -- | Pause replication on a replica node for maintenance
 runPauseReplica
-  :: TVarDaemonState
-  -> ClusterConfig
-  -> ClusterPasswords
-  -> Text       -- ^ host to pause
-  -> Logger
-  -> IO (Either Text ())
-runPauseReplica tvar cc pws targetHost logger = do
-  mTopo <- getClusterTopology tvar (ccName cc)
+  :: Text       -- ^ host to pause
+  -> App (Either Text ())
+runPauseReplica targetHost = do
+  tvar <- asks envDaemonState
+  cc   <- asks envCluster
+  user <- getMySQLUser
+  password <- getMonPassword
+  mTopo <- liftIO $ getClusterTopology tvar (ccName cc)
   case mTopo of
     Nothing -> pure (Left "Cluster not found")
     Just topo -> do
       let nodes = Map.elems (ctNodes topo)
-          user  = credUser (ccCredentials cc)
           findByHost h = filter (\ns -> nodeHost (nsNodeId ns) == h) nodes
       case findByHost targetHost of
         [] -> pure (Left $ "Node not found: " <> targetHost)
         (targetNs : _) -> do
-          let ci = makeConnectInfo (nsNodeId targetNs) user (cpPassword pws)
-          logInfo logger $ "[" <> ccName cc <> "] Pausing replication on " <> targetHost
-          result <- withNodeConn ci $ \conn -> stopReplica conn
+          let ci = makeConnectInfo (nsNodeId targetNs) user password
+          appLogInfo $ "[" <> ccName cc <> "] Pausing replication on " <> targetHost
+          result <- liftIO $ withNodeConn ci $ \conn -> stopReplica conn
           case result of
             Left err -> do
-              logError logger $ "[" <> ccName cc <> "] Pause failed: " <> err
+              appLogError $ "[" <> ccName cc <> "] Pause failed: " <> err
               pure (Left err)
             Right () -> do
-              atomically $ updateNodeState tvar (ccName cc)
+              liftIO $ atomically $ updateNodeState tvar (ccName cc)
                 (targetNs { nsPaused = True })
-              logInfo logger $ "[" <> ccName cc <> "] Replication paused on " <> targetHost
+              appLogInfo $ "[" <> ccName cc <> "] Replication paused on " <> targetHost
               pure (Right ())
 
 -- | Resume replication on a paused replica node
 runResumeReplica
-  :: TVarDaemonState
-  -> ClusterConfig
-  -> ClusterPasswords
-  -> Text       -- ^ host to resume
-  -> Logger
-  -> IO (Either Text ())
-runResumeReplica tvar cc pws targetHost logger = do
-  mTopo <- getClusterTopology tvar (ccName cc)
+  :: Text       -- ^ host to resume
+  -> App (Either Text ())
+runResumeReplica targetHost = do
+  tvar <- asks envDaemonState
+  cc   <- asks envCluster
+  user <- getMySQLUser
+  password <- getMonPassword
+  mTopo <- liftIO $ getClusterTopology tvar (ccName cc)
   case mTopo of
     Nothing -> pure (Left "Cluster not found")
     Just topo -> do
       let nodes = Map.elems (ctNodes topo)
-          user  = credUser (ccCredentials cc)
           findByHost h = filter (\ns -> nodeHost (nsNodeId ns) == h) nodes
       case findByHost targetHost of
         [] -> pure (Left $ "Node not found: " <> targetHost)
         (targetNs : _) -> do
-          let ci = makeConnectInfo (nsNodeId targetNs) user (cpPassword pws)
-          logInfo logger $ "[" <> ccName cc <> "] Resuming replication on " <> targetHost
-          result <- withNodeConn ci $ \conn -> startReplica conn
+          let ci = makeConnectInfo (nsNodeId targetNs) user password
+          appLogInfo $ "[" <> ccName cc <> "] Resuming replication on " <> targetHost
+          result <- liftIO $ withNodeConn ci $ \conn -> startReplica conn
           case result of
             Left err -> do
-              logError logger $ "[" <> ccName cc <> "] Resume failed: " <> err
+              appLogError $ "[" <> ccName cc <> "] Resume failed: " <> err
               pure (Left err)
             Right () -> do
-              atomically $ updateNodeState tvar (ccName cc)
+              liftIO $ atomically $ updateNodeState tvar (ccName cc)
                 (targetNs { nsPaused = False })
-              logInfo logger $ "[" <> ccName cc <> "] Replication resumed on " <> targetHost
+              appLogInfo $ "[" <> ccName cc <> "] Replication resumed on " <> targetHost
               pure (Right ())

--- a/src/PureMyHA/Failover/Switchover.hs
+++ b/src/PureMyHA/Failover/Switchover.hs
@@ -6,15 +6,17 @@ module PureMyHA.Failover.Switchover
 
 import Control.Concurrent (threadDelay)
 import Control.Exception (try, SomeException)
+import Control.Monad.IO.Class (liftIO)
+import Control.Monad.Reader (asks)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Text (Text)
 import Database.MySQL.Base (ConnectInfo)
 import PureMyHA.Config
+import PureMyHA.Env
 import PureMyHA.Failover.Candidate (selectCandidate)
 import PureMyHA.Hook
   ( runHookFireForget, runHookOrAbort, getCurrentTimestamp, HookEnv (..) )
-import PureMyHA.Logger (Logger, logInfo, logError)
 import PureMyHA.MySQL.Connection (makeConnectInfo, withNodeConn)
 import PureMyHA.MySQL.Query
 import PureMyHA.Topology.State
@@ -33,106 +35,102 @@ switchoverReconnectTargets nodes candidateId =
 
 -- | Execute a manual switchover
 runSwitchover
-  :: TVarDaemonState
-  -> ClusterConfig
-  -> FailoverConfig
-  -> ClusterPasswords
-  -> Maybe Text        -- ^ --to host
-  -> Maybe HooksConfig
-  -> Logger
-  -> IO (Either Text ())
-runSwitchover tvar cc fc pws mToHost mHooks logger = do
-  mTopo <- getClusterTopology tvar (ccName cc)
+  :: Maybe Text        -- ^ --to host
+  -> App (Either Text ())
+runSwitchover mToHost = do
+  tvar <- asks envDaemonState
+  cc   <- asks envCluster
+  fc   <- asks envFailover
+  mTopo <- liftIO $ getClusterTopology tvar (ccName cc)
   case mTopo of
     Nothing -> do
-      logError logger $ "[" <> ccName cc <> "] Switchover failed: Cluster not found"
+      appLogError $ "[" <> ccName cc <> "] Switchover failed: Cluster not found"
       pure (Left "Cluster not found")
-    Just topo -> do
-      -- Select target
+    Just topo ->
       case selectCandidate (ctNodes topo) (fcCandidatePriority fc) mToHost of
         Left err -> do
-          logError logger $ "[" <> ccName cc <> "] Switchover failed: " <> err
+          appLogError $ "[" <> ccName cc <> "] Switchover failed: " <> err
           pure (Left err)
         Right candidateId -> do
-          let user          = credUser (ccCredentials cc)
-              oldSourceId   = ctSourceNodeId topo
+          let oldSourceId   = ctSourceNodeId topo
               oldSourceHost = fmap nodeHost oldSourceId
 
-          logInfo logger $ "[" <> ccName cc <> "] Switchover started"
+          appLogInfo $ "[" <> ccName cc <> "] Switchover started"
 
           -- Pre-switchover hook (blocking: non-zero exit aborts)
-          ts <- getCurrentTimestamp
+          mHooks <- getHooksConfig
+          ts <- liftIO getCurrentTimestamp
           let preEnv = HookEnv (ccName cc) (Just (nodeHost candidateId)) oldSourceHost Nothing ts
-          preResult <- runHookOrAbort mHooks hcPreSwitchover preEnv
+          preResult <- liftIO $ runHookOrAbort mHooks hcPreSwitchover preEnv
           case preResult of
             Left err -> do
-              logError logger $ "[" <> ccName cc <> "] Pre-switchover hook aborted: " <> err
+              appLogError $ "[" <> ccName cc <> "] Pre-switchover hook aborted: " <> err
               pure (Left $ "Pre-switchover hook failed: " <> err)
             Right () ->
-              doSwitchover cc user pws mHooks logger candidateId oldSourceId oldSourceHost topo
+              doSwitchover candidateId oldSourceId oldSourceHost topo
 
 doSwitchover
-  :: ClusterConfig
-  -> Text
-  -> ClusterPasswords
-  -> Maybe HooksConfig
-  -> Logger
-  -> NodeId
+  :: NodeId
   -> Maybe NodeId
   -> Maybe Text
   -> ClusterTopology
-  -> IO (Either Text ())
-doSwitchover cc user pws mHooks logger candidateId oldSourceId oldSourceHost topo = do
+  -> App (Either Text ())
+doSwitchover candidateId oldSourceId oldSourceHost topo = do
+  cc   <- asks envCluster
+  pws  <- asks envPasswords
+  user <- getMySQLUser
+  password <- getMonPassword
   -- Step 1: Set old source to read_only (abort on failure to prevent split-brain)
-  readOnlyResult <- case oldSourceId of
+  readOnlyResult <- liftIO $ case oldSourceId of
     Nothing -> pure (Right ())
     Just srcId -> do
-      let srcCi = makeConnectInfo srcId user (cpPassword pws)
+      let srcCi = makeConnectInfo srcId user password
       withNodeConn srcCi setReadOnly
   case readOnlyResult of
     Left err -> do
-      logError logger $ "[" <> ccName cc <> "] Switchover aborted: cannot set old source read_only: " <> err
+      appLogError $ "[" <> ccName cc <> "] Switchover aborted: cannot set old source read_only: " <> err
       pure (Left $ "Cannot set old source read_only: " <> err)
     Right () -> do
       -- Step 2: Get old source GTID set
-      mOldGtid <- case oldSourceId of
+      mOldGtid <- liftIO $ case oldSourceId of
         Nothing -> pure Nothing
         Just srcId -> do
-          let srcCi = makeConnectInfo srcId user (cpPassword pws)
+          let srcCi = makeConnectInfo srcId user password
           result <- withNodeConn srcCi getGtidExecuted
           pure $ case result of
             Right gtid -> Just gtid
             Left _     -> Nothing
 
       -- Step 3: Wait for candidate to catch up
-      let candidateCi = makeConnectInfo candidateId user (cpPassword pws)
-      caught <- waitForCatchup candidateCi mOldGtid maxWaitSeconds
+      let candidateCi = makeConnectInfo candidateId user password
+      caught <- liftIO $ waitForCatchup candidateCi mOldGtid maxWaitSeconds
 
       if not caught
         then do
-          logError logger $ "[" <> ccName cc <> "] Switchover failed: Candidate did not catch up within timeout"
+          appLogError $ "[" <> ccName cc <> "] Switchover failed: Candidate did not catch up within timeout"
           pure (Left "Candidate did not catch up within timeout")
         else do
           -- Step 4: Promote candidate
-          promoteResult <- withNodeConn candidateCi $ \conn -> do
+          promoteResult <- liftIO $ withNodeConn candidateCi $ \conn -> do
             stopReplica conn
             resetReplicaAll conn
             setReadWrite conn
           case promoteResult of
             Left err -> do
-              logError logger $ "[" <> ccName cc <> "] Switchover failed: Promote failed: " <> err
+              appLogError $ "[" <> ccName cc <> "] Switchover failed: Promote failed: " <> err
               pure (Left $ "Promote failed: " <> err)
             Right () -> do
               -- Step 5: Reconnect remaining replicas (including old source)
               let others = switchoverReconnectTargets (ctNodes topo) candidateId
-              mapM_ (reconnectToNew user pws candidateId) others
+              mapM_ (reconnectToNew candidateId) others
 
               -- Post-switchover hook (fire-and-forget)
-              ts <- getCurrentTimestamp
+              mHooks <- getHooksConfig
+              ts <- liftIO getCurrentTimestamp
               let postEnv = HookEnv (ccName cc) (Just (nodeHost candidateId)) oldSourceHost Nothing ts
-              runHookFireForget mHooks hcPostSwitchover postEnv
+              liftIO $ runHookFireForget mHooks hcPostSwitchover postEnv
 
-              logInfo logger $ "[" <> ccName cc <> "] Switchover completed: new source is " <> nodeHost candidateId
+              appLogInfo $ "[" <> ccName cc <> "] Switchover completed: new source is " <> nodeHost candidateId
               pure (Right ())
 
 waitForCatchup :: ConnectInfo -> Maybe Text -> Int -> IO Bool
@@ -154,25 +152,29 @@ waitForCatchup ci (Just targetGtid) secondsLeft
           threadDelay 1_000_000
           waitForCatchup ci (Just targetGtid) (secondsLeft - 1)
 
-reconnectToNew :: Text -> ClusterPasswords -> NodeId -> NodeState -> IO ()
-reconnectToNew user pws newSourceId ns = do
-  let ci = makeConnectInfo (nsNodeId ns) user (cpPassword pws)
-  _ <- withNodeConn ci $ \conn -> do
-    _ <- try @SomeException (stopReplica conn)
-    changeReplicationSourceTo conn (nodeHost newSourceId) (nodePort newSourceId) (cpReplUser pws) (cpReplPassword pws)
-    setReadOnly conn
-    startReplica conn
-  pure ()
+reconnectToNew :: NodeId -> NodeState -> App ()
+reconnectToNew newSourceId ns = do
+  user <- getMySQLUser
+  password <- getMonPassword
+  pws <- asks envPasswords
+  let ci = makeConnectInfo (nsNodeId ns) user password
+  liftIO $ do
+    _ <- withNodeConn ci $ \conn -> do
+      _ <- try @SomeException (stopReplica conn)
+      changeReplicationSourceTo conn (nodeHost newSourceId) (nodePort newSourceId) (cpReplUser pws) (cpReplPassword pws)
+      setReadOnly conn
+      startReplica conn
+    pure ()
 
 -- | Dry-run switchover: validate and select candidate without executing SQL
 dryRunSwitchover
-  :: TVarDaemonState
-  -> ClusterConfig
-  -> FailoverConfig
-  -> Maybe Text          -- ^ --to host
-  -> IO (Either Text Text)
-dryRunSwitchover tvar cc fc mToHost = do
-  mTopo <- getClusterTopology tvar (ccName cc)
+  :: Maybe Text          -- ^ --to host
+  -> App (Either Text Text)
+dryRunSwitchover mToHost = do
+  tvar <- asks envDaemonState
+  cc   <- asks envCluster
+  fc   <- asks envFailover
+  mTopo <- liftIO $ getClusterTopology tvar (ccName cc)
   case mTopo of
     Nothing   -> pure (Left "Cluster not found")
     Just topo ->

--- a/src/PureMyHA/IPC/Server.hs
+++ b/src/PureMyHA/IPC/Server.hs
@@ -19,21 +19,20 @@ import qualified Data.Text as T
 import Network.Socket
 import qualified Network.Socket.ByteString as NSB
 import PureMyHA.Config
+import PureMyHA.Env (ClusterEnv (..), runApp)
 import PureMyHA.Failover.Demote (runDemote)
 import PureMyHA.Failover.PauseReplica (runPauseReplica, runResumeReplica)
 import PureMyHA.Failover.ErrantGtid (runFixErrantGtid)
 import PureMyHA.Failover.Switchover (runSwitchover, dryRunSwitchover)
 import System.Posix.Files (removeLink)
 import PureMyHA.IPC.Protocol
-import PureMyHA.Logger (Logger)
 import PureMyHA.Topology.State
 import PureMyHA.Types
 
 defaultSocketPath :: FilePath
 defaultSocketPath = "/run/puremyhad.sock"
 
-type ClusterEntry = (FailoverLock, ClusterConfig, FailoverConfig, FailureDetectionConfig, ClusterPasswords, Maybe HooksConfig)
-type ClusterMap   = Map ClusterName ClusterEntry
+type ClusterMap   = Map ClusterName ClusterEnv
 type DiscoveryAction = IO (Either Text Text)
 type DiscoveryMap = Map ClusterName DiscoveryAction
 
@@ -43,14 +42,13 @@ startIPCServer
   -> ClusterMap
   -> DiscoveryMap
   -> FilePath
-  -> Logger
   -> IO ()
-startIPCServer tvar clusterMap discoveryMap socketPath logger =
+startIPCServer tvar clusterMap discoveryMap socketPath =
   bracket (openListenSocket socketPath)
           (\sock -> close sock >> removeLink socketPath `catch` \(_ :: SomeException) -> pure ())
           $ \sock -> do
     listen sock 5
-    acceptLoop sock tvar clusterMap discoveryMap logger
+    acceptLoop sock tvar clusterMap discoveryMap
 
 openListenSocket :: FilePath -> IO Socket
 openListenSocket path = do
@@ -59,20 +57,20 @@ openListenSocket path = do
   bind sock (SockAddrUnix path)
   pure sock
 
-acceptLoop :: Socket -> TVarDaemonState -> ClusterMap -> DiscoveryMap -> Logger -> IO ()
-acceptLoop listenSock tvar clusterMap discoveryMap logger = do
+acceptLoop :: Socket -> TVarDaemonState -> ClusterMap -> DiscoveryMap -> IO ()
+acceptLoop listenSock tvar clusterMap discoveryMap = do
   (clientSock, _) <- accept listenSock
-  _ <- async $ handleClient clientSock tvar clusterMap discoveryMap logger `finally` close clientSock
-  acceptLoop listenSock tvar clusterMap discoveryMap logger
+  _ <- async $ handleClient clientSock tvar clusterMap discoveryMap `finally` close clientSock
+  acceptLoop listenSock tvar clusterMap discoveryMap
 
-handleClient :: Socket -> TVarDaemonState -> ClusterMap -> DiscoveryMap -> Logger -> IO ()
-handleClient sock tvar clusterMap discoveryMap logger = do
+handleClient :: Socket -> TVarDaemonState -> ClusterMap -> DiscoveryMap -> IO ()
+handleClient sock tvar clusterMap discoveryMap = do
   result <- try @SomeException $ do
     msg <- recvLine sock
     case eitherDecode (BLC.pack msg) of
       Left err  -> sendResponse sock (RespError (T.pack err))
       Right req -> do
-        resp <- handleRequest tvar clusterMap discoveryMap logger req
+        resp <- handleRequest tvar clusterMap discoveryMap req
         sendResponse sock resp
   case result of
     Left _ -> pure ()
@@ -97,8 +95,8 @@ sendResponse sock resp = do
   let bytes = BL.toStrict (encode resp <> BLC.singleton '\n')
   NSB.sendAll sock bytes
 
-handleRequest :: TVarDaemonState -> ClusterMap -> DiscoveryMap -> Logger -> Request -> IO Response
-handleRequest tvar clusterMap discoveryMap logger req = case req of
+handleRequest :: TVarDaemonState -> ClusterMap -> DiscoveryMap -> Request -> IO Response
+handleRequest tvar clusterMap discoveryMap req = case req of
   ReqStatus mCluster -> do
     ds <- readDaemonState tvar
     let topos = filterClusters mCluster (dsClusters ds)
@@ -112,15 +110,15 @@ handleRequest tvar clusterMap discoveryMap logger req = case req of
   ReqSwitchover mCluster mToHost dryRun ->
     case lookupCluster mCluster clusterMap of
       Nothing -> pure (RespError "Cluster not found")
-      Just (_, cc, fc, _, pws, mHooks) ->
+      Just env ->
         if dryRun
           then do
-            result <- dryRunSwitchover tvar cc fc mToHost
+            result <- runApp env $ dryRunSwitchover mToHost
             pure $ RespOperation $ case result of
               Left err  -> OperationFailure err
               Right msg -> OperationSuccess msg
           else do
-            result <- runSwitchover tvar cc fc pws mToHost mHooks logger
+            result <- runApp env $ runSwitchover mToHost
             pure $ RespOperation $ case result of
               Left err -> OperationFailure err
               Right () -> OperationSuccess "Switchover completed"
@@ -128,8 +126,8 @@ handleRequest tvar clusterMap discoveryMap logger req = case req of
   ReqAckRecovery mCluster ->
     case lookupCluster mCluster clusterMap of
       Nothing -> pure (RespError "Cluster not found")
-      Just (_, cc, _, _, _, _) -> do
-        atomically $ clearRecoveryBlock tvar (ccName cc)
+      Just env -> do
+        atomically $ clearRecoveryBlock (envDaemonState env) (ccName (envCluster env))
         pure $ RespOperation (OperationSuccess "Recovery block cleared")
 
   ReqErrantGtid mCluster -> do
@@ -141,8 +139,8 @@ handleRequest tvar clusterMap discoveryMap logger req = case req of
   ReqFixErrantGtid mCluster ->
     case lookupCluster mCluster clusterMap of
       Nothing -> pure (RespError "Cluster not found")
-      Just (_, cc, _, _, pws, _) -> do
-        result <- runFixErrantGtid tvar cc (cpPassword pws)
+      Just env -> do
+        result <- runApp env runFixErrantGtid
         pure $ RespOperation $ case result of
           Left err -> OperationFailure err
           Right () -> OperationSuccess "Errant GTIDs fixed on source"
@@ -150,8 +148,8 @@ handleRequest tvar clusterMap discoveryMap logger req = case req of
   ReqDemote mCluster host srcHost ->
     case lookupCluster mCluster clusterMap of
       Nothing -> pure (RespError "Cluster not found")
-      Just (_, cc, _, _, pws, _) -> do
-        result <- runDemote tvar cc pws host srcHost logger
+      Just env -> do
+        result <- runApp env $ runDemote host srcHost
         pure $ RespOperation $ case result of
           Left err -> OperationFailure err
           Right () -> OperationSuccess ("Demote completed: " <> host <> " is now a replica")
@@ -168,8 +166,8 @@ handleRequest tvar clusterMap discoveryMap logger req = case req of
   ReqPauseReplica mCluster host ->
     case lookupCluster mCluster clusterMap of
       Nothing -> pure (RespError "Cluster not found")
-      Just (_, cc, _, _, pws, _) -> do
-        result <- runPauseReplica tvar cc pws host logger
+      Just env -> do
+        result <- runApp env $ runPauseReplica host
         pure $ RespOperation $ case result of
           Left err -> OperationFailure err
           Right () -> OperationSuccess ("Replication paused on " <> host)
@@ -177,8 +175,8 @@ handleRequest tvar clusterMap discoveryMap logger req = case req of
   ReqResumeReplica mCluster host ->
     case lookupCluster mCluster clusterMap of
       Nothing -> pure (RespError "Cluster not found")
-      Just (_, cc, _, _, pws, _) -> do
-        result <- runResumeReplica tvar cc pws host logger
+      Just env -> do
+        result <- runApp env $ runResumeReplica host
         pure $ RespOperation $ case result of
           Left err -> OperationFailure err
           Right () -> OperationSuccess ("Replication resumed on " <> host)
@@ -186,22 +184,22 @@ handleRequest tvar clusterMap discoveryMap logger req = case req of
   ReqPauseFailover mCluster ->
     case lookupCluster mCluster clusterMap of
       Nothing -> pure (RespError "Cluster not found")
-      Just (_, cc, _, _, _, _) -> do
-        atomically $ setClusterPause tvar (ccName cc)
+      Just env -> do
+        atomically $ setClusterPause (envDaemonState env) (ccName (envCluster env))
         pure $ RespOperation (OperationSuccess "Failover paused")
 
   ReqResumeFailover mCluster ->
     case lookupCluster mCluster clusterMap of
       Nothing -> pure (RespError "Cluster not found")
-      Just (_, cc, _, _, _, _) -> do
-        atomically $ clearClusterPause tvar (ccName cc)
+      Just env -> do
+        atomically $ clearClusterPause (envDaemonState env) (ccName (envCluster env))
         pure $ RespOperation (OperationSuccess "Failover resumed")
 
 filterClusters :: Maybe ClusterName -> Map ClusterName ClusterTopology -> [ClusterTopology]
 filterClusters Nothing  m = Map.elems m
 filterClusters (Just n) m = maybe [] pure (Map.lookup n m)
 
-lookupCluster :: Maybe ClusterName -> ClusterMap -> Maybe ClusterEntry
+lookupCluster :: Maybe ClusterName -> ClusterMap -> Maybe ClusterEnv
 lookupCluster Nothing  m = case Map.elems m of { [x] -> Just x; _ -> Nothing }
 lookupCluster (Just n) m = Map.lookup n m
 

--- a/src/PureMyHA/Logger.hs
+++ b/src/PureMyHA/Logger.hs
@@ -5,6 +5,7 @@ module PureMyHA.Logger
   , logInfo
   , logWarn
   , logError
+  , nullLogger
   ) where
 
 import Data.Text (Text)
@@ -39,3 +40,8 @@ logWarn l = logAt l WarningS
 
 logError :: Logger -> Text -> IO ()
 logError l = logAt l ErrorS
+
+nullLogger :: IO Logger
+nullLogger = do
+  le <- initLogEnv "test" "test"
+  pure (Logger le)

--- a/src/PureMyHA/Monitor/Worker.hs
+++ b/src/PureMyHA/Monitor/Worker.hs
@@ -11,15 +11,17 @@ import Control.Concurrent.Async (async, wait, Async)
 import Control.Concurrent.STM (atomically, TVar, newTVarIO, modifyTVar', readTVarIO)
 import Control.Exception (SomeException, catch)
 import Control.Monad (when, forM, forM_, unless)
+import Control.Monad.IO.Class (liftIO)
+import Control.Monad.Reader (ask, asks)
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
-import Data.Text (Text)
 import qualified Data.Text as T
 import Data.Time (getCurrentTime)
-import PureMyHA.Config (ClusterConfig (..), NodeConfig (..), Credentials (..), ClusterPasswords (..), MonitoringConfig (..), HooksConfig (..), FailoverConfig (..), FailureDetectionConfig (..))
+import PureMyHA.Config
+import PureMyHA.Env
 import PureMyHA.Failover.Auto (runAutoFailover)
 import PureMyHA.Hook (runHookFireForget, getCurrentTimestamp, HookEnv (..))
-import PureMyHA.Logger (Logger, logInfo, logWarn)
+import PureMyHA.Logger (logInfo, logWarn)
 import PureMyHA.MySQL.Connection (makeConnectInfo, withNodeConn)
 import PureMyHA.MySQL.Query
 import PureMyHA.Topology.Discovery (discoverTopology)
@@ -30,221 +32,174 @@ import PureMyHA.Monitor.Detector (detectClusterHealth, detectNodeHealth, identif
 type WorkerRegistry = TVar (Map.Map NodeId (Async ()))
 
 -- | Start one async monitor worker per node in a cluster; also returns registry
-startMonitorWorkers
-  :: TVarDaemonState
-  -> ClusterConfig
-  -> TVar MonitoringConfig
-  -> TVar (Maybe HooksConfig)
-  -> FailoverLock
-  -> FailoverConfig
-  -> FailureDetectionConfig
-  -> ClusterPasswords
-  -> Logger
-  -> IO (WorkerRegistry, [Async ()])
-startMonitorWorkers tvar cc mcVar hooksVar lock fc fdc pws logger = do
-  reg <- newTVarIO Map.empty
-  let nodes = map (\nc -> NodeId (ncHost nc) (ncPort nc)) (ccNodes cc)
-  asyncs <- forM nodes $ \nid -> do
-    a <- async (runWorker tvar cc mcVar hooksVar lock fc fdc pws nid logger)
-    atomically $ modifyTVar' reg (Map.insert nid a)
-    pure a
-  pure (reg, asyncs)
+startMonitorWorkers :: App (WorkerRegistry, [Async ()])
+startMonitorWorkers = do
+  env <- ask
+  let nodes = map (\nc -> NodeId (ncHost nc) (ncPort nc)) (ccNodes (envCluster env))
+  liftIO $ do
+    reg <- newTVarIO Map.empty
+    asyncs <- forM nodes $ \nid -> do
+      a <- async (runApp env (runWorker nid))
+      atomically $ modifyTVar' reg (Map.insert nid a)
+      pure a
+    pure (reg, asyncs)
 
-runWorker
-  :: TVarDaemonState
-  -> ClusterConfig
-  -> TVar MonitoringConfig
-  -> TVar (Maybe HooksConfig)
-  -> FailoverLock
-  -> FailoverConfig
-  -> FailureDetectionConfig
-  -> ClusterPasswords
-  -> NodeId
-  -> Logger
-  -> IO ()
-runWorker tvar cc mcVar hooksVar lock fc fdc pws nid logger = loop
+runWorker :: NodeId -> App ()
+runWorker nid = do
+  env <- ask
+  liftIO $ loop env
   where
-    loop = do
-      mc     <- readTVarIO mcVar
-      mHooks <- readTVarIO hooksVar
+    loop env = do
+      mc <- readTVarIO (envMonitoring env)
       let intervalMicros = round (mcInterval mc * 1_000_000) :: Int
-      monitorNode tvar cc mc lock fc fdc pws mHooks nid logger
+      runApp env (monitorNode nid)
         `catch` (\(_ :: SomeException) -> pure ())
       threadDelay intervalMicros
-      loop
+      loop env
 
 -- | Start the topology refresh worker for a cluster
-startTopologyRefreshWorker
-  :: TVarDaemonState
-  -> ClusterConfig
-  -> TVar MonitoringConfig
-  -> TVar (Maybe HooksConfig)
-  -> FailoverLock
-  -> FailoverConfig
-  -> FailureDetectionConfig
-  -> ClusterPasswords
-  -> WorkerRegistry
-  -> Logger
-  -> IO (Async ())
-startTopologyRefreshWorker tvar cc mcVar hooksVar lock fc fdc pws reg logger =
-  async (topologyRefreshLoop tvar cc mcVar hooksVar lock fc fdc pws reg logger)
+startTopologyRefreshWorker :: WorkerRegistry -> App (Async ())
+startTopologyRefreshWorker reg = do
+  env <- ask
+  liftIO $ async (runApp env (topologyRefreshLoop reg))
 
-topologyRefreshLoop
-  :: TVarDaemonState
-  -> ClusterConfig
-  -> TVar MonitoringConfig
-  -> TVar (Maybe HooksConfig)
-  -> FailoverLock
-  -> FailoverConfig
-  -> FailureDetectionConfig
-  -> ClusterPasswords
-  -> WorkerRegistry
-  -> Logger
-  -> IO ()
-topologyRefreshLoop tvar cc mcVar hooksVar lock fc fdc pws reg logger = loop
+topologyRefreshLoop :: WorkerRegistry -> App ()
+topologyRefreshLoop reg = do
+  env <- ask
+  liftIO $ loop env
   where
-    loop = do
-      mc <- readTVarIO mcVar
+    loop env = do
+      mc <- readTVarIO (envMonitoring env)
       let interval = mcDiscoveryInterval mc
       if interval <= 0
         then threadDelay 60_000_000  -- disabled: check every 60s in case config reloads
         else do
           threadDelay (round (interval * 1_000_000) :: Int)
-          runTopologyRefresh tvar cc mcVar hooksVar lock fc fdc pws reg logger
+          runApp env (runTopologyRefresh reg)
             `catch` (\(_ :: SomeException) -> pure ())
-      loop
+      loop env
 
-runTopologyRefresh
-  :: TVarDaemonState
-  -> ClusterConfig
-  -> TVar MonitoringConfig
-  -> TVar (Maybe HooksConfig)
-  -> FailoverLock
-  -> FailoverConfig
-  -> FailureDetectionConfig
-  -> ClusterPasswords
-  -> WorkerRegistry
-  -> Logger
-  -> IO ()
-runTopologyRefresh tvar cc mcVar hooksVar lock fc fdc pws reg logger = do
-  newTopo    <- discoverTopology cc (cpPassword pws) logger
-  atomically $ updateClusterTopology tvar newTopo
-  knownNodes <- Map.keysSet <$> readTVarIO reg
-  let discovered = Map.keysSet (ctNodes newTopo)
-      newNodes   = Set.toList (Set.difference discovered knownNodes)
-  unless (null newNodes) $
-    logInfo logger $ "[" <> ccName cc <> "] Topology refresh: "
-      <> T.pack (show (length newNodes)) <> " new node(s) found"
-  forM_ newNodes $ \nid -> do
-    a <- async (runWorker tvar cc mcVar hooksVar lock fc fdc pws nid logger)
-    atomically $ modifyTVar' reg (Map.insert nid a)
+runTopologyRefresh :: WorkerRegistry -> App ()
+runTopologyRefresh reg = do
+  env <- ask
+  let cc     = envCluster env
+      pws    = envPasswords env
+      logger = envLogger env
+      tvar   = envDaemonState env
+  liftIO $ do
+    newTopo <- discoverTopology cc (cpPassword pws) logger
+    atomically $ updateClusterTopology tvar newTopo
+    knownNodes <- Map.keysSet <$> readTVarIO reg
+    let discovered = Map.keysSet (ctNodes newTopo)
+        newNodes   = Set.toList (Set.difference discovered knownNodes)
+    unless (null newNodes) $
+      logInfo logger $ "[" <> ccName cc <> "] Topology refresh: "
+        <> T.pack (show (length newNodes)) <> " new node(s) found"
+    forM_ newNodes $ \nid -> do
+      a <- async (runApp env (runWorker nid))
+      atomically $ modifyTVar' reg (Map.insert nid a)
 
 -- | Perform a single monitoring cycle for a node
-monitorNode
-  :: TVarDaemonState
-  -> ClusterConfig
-  -> MonitoringConfig
-  -> FailoverLock
-  -> FailoverConfig
-  -> FailureDetectionConfig
-  -> ClusterPasswords
-  -> Maybe HooksConfig
-  -> NodeId
-  -> Logger
-  -> IO ()
-monitorNode tvar cc mc lock fc fdc pws mHooks nid logger = do
-  now <- getCurrentTime
+monitorNode :: NodeId -> App ()
+monitorNode nid = do
+  tvar <- asks envDaemonState
+  cc   <- asks envCluster
+  pws  <- asks envPasswords
+  now  <- liftIO getCurrentTime
   let user = credUser (ccCredentials cc)
       ci   = makeConnectInfo nid user (cpPassword pws)
   -- Read old state before connecting, so we can preserve nsIsSource on error
-  mOldNs <- do
+  mOldNs <- liftIO $ do
     mTopo <- getClusterTopology tvar (ccName cc)
     pure $ mTopo >>= \t -> Map.lookup nid (ctNodes t)
-  result <- withNodeConn ci $ \conn -> do
+  result <- liftIO $ withNodeConn ci $ \conn -> do
     mRs      <- showReplicaStatus conn
     gtidExec <- getGtidExecuted conn
     pure (mRs, gtidExec)
-  ns <- case result of
-    Left err ->
-      pure NodeState
-        { nsNodeId          = nid
-        , nsReplicaStatus   = Nothing
-        , nsGtidExecuted    = ""
-        , nsIsSource        = maybe False nsIsSource mOldNs
-        , nsHealth          = NeedsAttention err
-        , nsLastSeen        = Nothing
-        , nsConnectError    = Just err
-        , nsErrantGtids     = ""
-        , nsPaused          = maybe False nsPaused mOldNs
-        }
-    Right (mRs, gtidExec) ->
-      pure NodeState
-        { nsNodeId          = nid
-        , nsReplicaStatus   = mRs
-        , nsGtidExecuted    = gtidExec
-        , nsIsSource        = mRs == Nothing
-        , nsHealth          = Healthy
-        , nsLastSeen        = Just now
-        , nsConnectError    = Nothing
-        , nsErrantGtids     = ""
-        , nsPaused          = maybe False nsPaused mOldNs
-        }
+  let ns = case result of
+        Left err ->
+          NodeState
+            { nsNodeId          = nid
+            , nsReplicaStatus   = Nothing
+            , nsGtidExecuted    = ""
+            , nsIsSource        = maybe False nsIsSource mOldNs
+            , nsHealth          = NeedsAttention err
+            , nsLastSeen        = Nothing
+            , nsConnectError    = Just err
+            , nsErrantGtids     = ""
+            , nsPaused          = maybe False nsPaused mOldNs
+            }
+        Right (mRs, gtidExec) ->
+          NodeState
+            { nsNodeId          = nid
+            , nsReplicaStatus   = mRs
+            , nsGtidExecuted    = gtidExec
+            , nsIsSource        = mRs == Nothing
+            , nsHealth          = Healthy
+            , nsLastSeen        = Just now
+            , nsConnectError    = Nothing
+            , nsErrantGtids     = ""
+            , nsPaused          = maybe False nsPaused mOldNs
+            }
   -- Update errant GTIDs by querying MySQL
-  ns' <- enrichErrantGtids tvar (ccName cc) ns user (cpPassword pws)
+  ns' <- enrichErrantGtids ns
   let ns'' = ns' { nsHealth = detectNodeHealth ns' }
-  logHealthChange logger (ccName cc) nid mOldNs ns''
-  atomically $ updateNodeState tvar (ccName cc) ns''
+  logHealthChange nid mOldNs ns''
+  liftIO $ atomically $ updateNodeState tvar (ccName cc) ns''
   -- Recompute cluster-level health
-  recomputeClusterHealth tvar cc mc lock fc fdc pws mHooks logger
+  recomputeClusterHealth
 
-logHealthChange :: Logger -> ClusterName -> NodeId -> Maybe NodeState -> NodeState -> IO ()
-logHealthChange logger clusterName nid mOld new = do
-  let host = nodeHost nid
-  if nsPaused new
-    then pure ()
-    else case (fmap nsHealth mOld, nsHealth new) of
-      (Just Healthy, NeedsAttention err) ->
-        logWarn logger $ "[" <> clusterName <> "] Node " <> host <> " unreachable: " <> err
-      (Just (NeedsAttention _), Healthy) ->
-        logInfo logger $ "[" <> clusterName <> "] Node " <> host <> " recovered"
-      (Nothing, NeedsAttention err) ->
-        logWarn logger $ "[" <> clusterName <> "] Node " <> host <> " initial connect failed: " <> err
-      _ -> pure ()
+logHealthChange :: NodeId -> Maybe NodeState -> NodeState -> App ()
+logHealthChange nid mOld new = do
+  clusterName <- getClusterName
+  logger <- asks envLogger
+  liftIO $
+    if nsPaused new
+      then pure ()
+      else case (fmap nsHealth mOld, nsHealth new) of
+        (Just Healthy, NeedsAttention err) ->
+          logWarn logger $ "[" <> clusterName <> "] Node " <> host <> " unreachable: " <> err
+        (Just (NeedsAttention _), Healthy) ->
+          logInfo logger $ "[" <> clusterName <> "] Node " <> host <> " recovered"
+        (Nothing, NeedsAttention err) ->
+          logWarn logger $ "[" <> clusterName <> "] Node " <> host <> " initial connect failed: " <> err
+        _ -> pure ()
+  where
+    host = nodeHost nid
 
-enrichErrantGtids :: TVarDaemonState -> ClusterName -> NodeState -> Text -> Text -> IO NodeState
-enrichErrantGtids tvar clusterName ns user password = do
-  mTopo <- getClusterTopology tvar clusterName
-  case mTopo of
-    Nothing -> pure ns
-    Just topo -> case ctSourceNodeId topo of
+enrichErrantGtids :: NodeState -> App NodeState
+enrichErrantGtids ns = do
+  tvar <- asks envDaemonState
+  cc   <- asks envCluster
+  pws  <- asks envPasswords
+  let user = credUser (ccCredentials cc)
+  liftIO $ do
+    mTopo <- getClusterTopology tvar (ccName cc)
+    case mTopo of
       Nothing -> pure ns
-      Just srcId -> do
-        let srcNodes = Map.lookup srcId (ctNodes topo)
-        case srcNodes of
-          Nothing -> pure ns
-          Just srcNs -> do
-            let replicaGtid = maybe "" rsExecutedGtidSet (nsReplicaStatus ns)
-                sourceGtid  = nsGtidExecuted srcNs
-                ci = makeConnectInfo srcId user password
-            result <- withNodeConn ci $ \conn ->
-              gtidSubtract conn replicaGtid sourceGtid
-            case result of
-              Left _         -> pure ns
-              Right errant   -> pure ns { nsErrantGtids = errant }
+      Just topo -> case ctSourceNodeId topo of
+        Nothing -> pure ns
+        Just srcId -> do
+          let srcNodes = Map.lookup srcId (ctNodes topo)
+          case srcNodes of
+            Nothing -> pure ns
+            Just srcNs -> do
+              let replicaGtid = maybe "" rsExecutedGtidSet (nsReplicaStatus ns)
+                  sourceGtid  = nsGtidExecuted srcNs
+                  ci = makeConnectInfo srcId user (cpPassword pws)
+              result <- withNodeConn ci $ \conn ->
+                gtidSubtract conn replicaGtid sourceGtid
+              case result of
+                Left _         -> pure ns
+                Right errant   -> pure ns { nsErrantGtids = errant }
 
-recomputeClusterHealth
-  :: TVarDaemonState
-  -> ClusterConfig
-  -> MonitoringConfig
-  -> FailoverLock
-  -> FailoverConfig
-  -> FailureDetectionConfig
-  -> ClusterPasswords
-  -> Maybe HooksConfig
-  -> Logger
-  -> IO ()
-recomputeClusterHealth tvar cc mc lock fc fdc pws mHooks logger = do
-  mTopo <- getClusterTopology tvar (ccName cc)
+recomputeClusterHealth :: App ()
+recomputeClusterHealth = do
+  tvar <- asks envDaemonState
+  cc   <- asks envCluster
+  fc   <- asks envFailover
+  env  <- ask
+  mTopo <- liftIO $ getClusterTopology tvar (ccName cc)
   case mTopo of
     Nothing -> pure ()
     Just topo -> do
@@ -258,48 +213,51 @@ recomputeClusterHealth tvar cc mc lock fc fdc pws mHooks logger = do
       let transitioned     = ctHealth topo /= newHealth
           observedHealthy  = ctObservedHealthy topo || newHealth == Healthy
       -- Fire on_failure_detection hook on transition to a dead state
-      when transitioned $
+      liftIO $ when transitioned $
         case newHealth of
           DeadSource -> do
+            mHooks <- readTVarIO (envHooks env)
             ts <- getCurrentTimestamp
-            let env = HookEnv (ccName cc) Nothing Nothing (Just "DeadSource") ts
-            runHookFireForget mHooks hcOnFailureDetection env
+            let hookEnv = HookEnv (ccName cc) Nothing Nothing (Just "DeadSource") ts
+            runHookFireForget mHooks hcOnFailureDetection hookEnv
           DeadSourceAndAllReplicas -> do
+            mHooks <- readTVarIO (envHooks env)
             ts <- getCurrentTimestamp
-            let env = HookEnv (ccName cc) Nothing Nothing (Just "DeadSourceAndAllReplicas") ts
-            runHookFireForget mHooks hcOnFailureDetection env
+            let hookEnv = HookEnv (ccName cc) Nothing Nothing (Just "DeadSourceAndAllReplicas") ts
+            runHookFireForget mHooks hcOnFailureDetection hookEnv
           _ -> pure ()
       -- Log all health transitions for observability
-      when transitioned $
-        logInfo logger $ "[" <> ccName cc <> "] Cluster health: "
+      liftIO $ when transitioned $
+        logInfo (envLogger env) $ "[" <> ccName cc <> "] Cluster health: "
           <> T.pack (show (ctHealth topo)) <> " \x2192 " <> T.pack (show newHealth)
-      atomically $ updateClusterTopology tvar topo'
+      liftIO $ atomically $ updateClusterTopology tvar topo'
       -- Trigger auto-failover when DeadSource (not just on transition, so resume-failover works)
       -- The failover lock prevents concurrent execution; anti-flap block prevents repeated failovers
-      when (newHealth == DeadSource && fcAutoFailover fc && observedHealthy) $ do
-        _ <- async (runAutoFailover tvar lock cc fc fdc pws mHooks logger)
+      liftIO $ when (newHealth == DeadSource && fcAutoFailover fc && observedHealthy) $ do
+        _ <- async (runApp env runAutoFailover)
         pure ()
       -- Emergency re-check on first transition to UnreachableSource
-      when (transitioned && newHealth == UnreachableSource) $ do
-        _ <- async (emergencyReplicaCheck tvar cc mc lock fc fdc pws mHooks logger)
+      liftIO $ when (transitioned && newHealth == UnreachableSource) $ do
+        _ <- async (runApp env emergencyReplicaCheck)
         pure ()
 
 -- | When UnreachableSource is first detected, immediately re-probe IOYes replicas
 -- to confirm whether they can actually reach the source (Orchestrator-style).
-emergencyReplicaCheck
-  :: TVarDaemonState -> ClusterConfig -> MonitoringConfig -> FailoverLock
-  -> FailoverConfig -> FailureDetectionConfig -> ClusterPasswords
-  -> Maybe HooksConfig -> Logger -> IO ()
-emergencyReplicaCheck tvar cc mc lock fc fdc pws mHooks logger = do
-  logInfo logger $ "[" <> ccName cc <> "] UnreachableSource detected: emergency replica re-check"
-  mTopo <- getClusterTopology tvar (ccName cc)
+emergencyReplicaCheck :: App ()
+emergencyReplicaCheck = do
+  tvar <- asks envDaemonState
+  cc   <- asks envCluster
+  env  <- ask
+  appLogInfo $ "[" <> ccName cc <> "] UnreachableSource detected: emergency replica re-check"
+  mTopo <- liftIO $ getClusterTopology tvar (ccName cc)
   case mTopo of
     Nothing   -> pure ()
     Just topo -> do
       let ioYesReplicas = filter isIOYesReplica (Map.elems (ctNodes topo))
-      asyncs <- forM ioYesReplicas $ \ns ->
-        async (monitorNode tvar cc mc lock fc fdc pws mHooks (nsNodeId ns) logger)
-      mapM_ wait asyncs
+      liftIO $ do
+        asyncs <- forM ioYesReplicas $ \ns ->
+          async (runApp env (monitorNode (nsNodeId ns)))
+        mapM_ wait asyncs
 
 isIOYesReplica :: NodeState -> Bool
 isIOYesReplica ns =

--- a/test/Fixtures.hs
+++ b/test/Fixtures.hs
@@ -1,6 +1,7 @@
 module Fixtures
   ( mkNodeState
   , mkReplicaStatus
+  , mkTestEnv
   , fixedTime
   , healthySource
   , healthyReplica
@@ -12,10 +13,15 @@ module Fixtures
   , clusterHealthy
   ) where
 
+import Control.Concurrent.STM (newTVarIO)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Text (Text)
 import Data.Time (UTCTime, fromGregorian, UTCTime (..))
+import PureMyHA.Config
+import PureMyHA.Env (ClusterEnv (..))
+import PureMyHA.Logger (nullLogger)
+import PureMyHA.Topology.State (TVarDaemonState, newFailoverLock)
 import PureMyHA.Types
 
 fixedTime :: UTCTime
@@ -49,6 +55,27 @@ mkNodeState nid isSource mRs health = NodeState
   , nsErrantGtids     = ""
   , nsPaused          = False
   }
+
+-- | Build a test ClusterEnv with dummy values for fields not under test
+mkTestEnv :: TVarDaemonState -> ClusterConfig -> FailoverConfig -> IO ClusterEnv
+mkTestEnv tvar cc fc = do
+  let pws = ClusterPasswords "" "" ""
+      fdc = FailureDetectionConfig 0
+  mcVar    <- newTVarIO (MonitoringConfig 3 5 30 60 300)
+  hooksVar <- newTVarIO Nothing
+  lock     <- newFailoverLock
+  logger   <- nullLogger
+  pure ClusterEnv
+    { envDaemonState = tvar
+    , envCluster     = cc
+    , envFailover    = fc
+    , envDetection   = fdc
+    , envPasswords   = pws
+    , envMonitoring  = mcVar
+    , envHooks       = hooksVar
+    , envLock        = lock
+    , envLogger      = logger
+    }
 
 healthySource :: NodeState
 healthySource = mkNodeState (mkNodeId "db1" 3306) True Nothing Healthy

--- a/test/PureMyHA/SwitchoverSpec.hs
+++ b/test/PureMyHA/SwitchoverSpec.hs
@@ -5,7 +5,8 @@ import qualified Data.Map.Strict as Map
 import qualified Data.Text as T
 import Test.Hspec
 import Fixtures
-import PureMyHA.Config (ClusterConfig (..), NodeConfig (..), Credentials (..), FailoverConfig (..))
+import PureMyHA.Config (ClusterConfig (..), Credentials (..), FailoverConfig (..))
+import PureMyHA.Env (runApp)
 import PureMyHA.Failover.Switchover (switchoverReconnectTargets, dryRunSwitchover)
 import PureMyHA.Topology.Discovery (buildClusterTopology)
 import PureMyHA.Topology.State (newDaemonState, updateClusterTopology)
@@ -48,28 +49,32 @@ spec = do
       tvar <- newDaemonState
       let topo = buildClusterTopology "main" clusterHealthy
       atomically $ updateClusterTopology tvar topo
-      result <- dryRunSwitchover tvar testCC testFC Nothing
+      env <- mkTestEnv tvar testCC testFC
+      result <- runApp env $ dryRunSwitchover Nothing
       result `shouldSatisfy` isRight
 
     it "result contains 'Dry run: would promote'" $ do
       tvar <- newDaemonState
       let topo = buildClusterTopology "main" clusterHealthy
       atomically $ updateClusterTopology tvar topo
-      result <- dryRunSwitchover tvar testCC testFC Nothing
+      env <- mkTestEnv tvar testCC testFC
+      result <- runApp env $ dryRunSwitchover Nothing
       case result of
         Right msg -> msg `shouldSatisfy` T.isPrefixOf "Dry run: would promote"
         Left err  -> expectationFailure (show err)
 
     it "returns Left when cluster is not found" $ do
       tvar <- newDaemonState
-      result <- dryRunSwitchover tvar testCC testFC Nothing
+      env <- mkTestEnv tvar testCC testFC
+      result <- runApp env $ dryRunSwitchover Nothing
       result `shouldBe` Left "Cluster not found"
 
     it "returns Left when specified host does not exist" $ do
       tvar <- newDaemonState
       let topo = buildClusterTopology "main" clusterHealthy
       atomically $ updateClusterTopology tvar topo
-      result <- dryRunSwitchover tvar testCC testFC (Just "nonexistent.host")
+      env <- mkTestEnv tvar testCC testFC
+      result <- runApp env $ dryRunSwitchover (Just "nonexistent.host")
       result `shouldSatisfy` isLeft
 
 testCC :: ClusterConfig
@@ -95,4 +100,3 @@ isRight _         = False
 isLeft :: Either a b -> Bool
 isLeft (Left _) = True
 isLeft _        = False
-


### PR DESCRIPTION
## Summary

- Introduce `ClusterEnv` record bundling 9 shared parameters (`TVarDaemonState`, `ClusterConfig`, `FailoverConfig`, `FailureDetectionConfig`, `ClusterPasswords`, `TVar MonitoringConfig`, `TVar (Maybe HooksConfig)`, `FailoverLock`, `Logger`) that were previously threaded through every call chain
- Define `App = ReaderT ClusterEnv IO` as the standard monad for cluster-scoped operations
- Reduce function arities dramatically: `monitorNode` drops from 10 args to 1, `runAutoFailover` from 8 to 0, `startMonitorWorkers` from 9 to 0, etc.

## Changes

### New file
- `src/PureMyHA/Env.hs` — `ClusterEnv`, `App`, `runApp`, and accessor helpers (`getMonitoringConfig`, `getHooksConfig`, `getClusterName`, `getMySQLUser`, `getMonPassword`, `appLogInfo/Warn/Error`)

### Modified files
| File | Change |
|---|---|
| `src/PureMyHA/Logger.hs` | Add `nullLogger` for test use |
| `src/PureMyHA/Failover/ErrantGtid.hs` | `runFixErrantGtid :: App (Either Text ())` (was 3 explicit args) |
| `src/PureMyHA/Failover/Demote.hs` | `runDemote :: Text -> Text -> App (Either Text ())` (was 6 args) |
| `src/PureMyHA/Failover/PauseReplica.hs` | `runPauseReplica/runResumeReplica :: Text -> App (Either Text ())` (was 5 args each) |
| `src/PureMyHA/Failover/Auto.hs` | `runAutoFailover :: App (Either Text ())` (was 8 args); all internal helpers converted |
| `src/PureMyHA/Failover/Switchover.hs` | `runSwitchover :: Maybe Text -> App`; `dryRunSwitchover :: Maybe Text -> App` |
| `src/PureMyHA/Monitor/Worker.hs` | All workers converted; async workers unwrap via `runApp env` |
| `src/PureMyHA/IPC/Server.hs` | Replace `ClusterEntry` 6-tuple with `ClusterEnv`; operations dispatched via `runApp env $` |
| `app/Daemon/Main.hs` | `initCluster` returns `ClusterEnv`; startup loop calls `runApp env startMonitorWorkers` |
| `test/Fixtures.hs` | Add `mkTestEnv :: TVarDaemonState -> ClusterConfig -> FailoverConfig -> IO ClusterEnv` |
| `test/PureMyHA/SwitchoverSpec.hs` | Update to use `runApp env $ dryRunSwitchover` |

## Key design decisions

- **`IPC.Server` stays in plain IO**: `startIPCServer`/`acceptLoop`/`handleClient` remain in `IO` because they are shared across all clusters. Per-cluster operations are dispatched into `App` via `runApp env $`.
- **Hot-reload preserved**: `envMonitoring` and `envHooks` are `TVar`s, so SIGHUP updates propagate to all running workers without restart.
- **Async workers**: Long-running loops capture `env` with `ask` once and use `runApp env action` to re-enter `App` context, avoiding holding the `ReaderT` across `threadDelay`.
- **`ExceptT` over `App`**: `executeFailover` uses `ExceptT Text App ()` so early-exit error handling composes naturally with the reader environment.

## Test plan

- [x] `cabal build all` — clean build, zero warnings
- [x] `cabal test` — 146/146 unit tests pass
- [x] `bash e2e/run-all.sh` — all 10 E2E tests pass
  - 01-topology-discovery, 02-auto-failover, 03-network-partition, 04-manual-switchover, 05-errant-gtid, 06-anti-flap, 07-hook-execution, 08-pause-resume-replica, 09-demote, 10-pause-resume-failover

🤖 Generated with [Claude Code](https://claude.com/claude-code)