### PR TITLE
fix: retain dynamically-discovered replicas during periodic topology refresh

### DIFF
--- a/e2e/config/puremyha-source-only.yaml
+++ b/e2e/config/puremyha-source-only.yaml
@@ -1,0 +1,26 @@
+clusters:
+  - name: e2e
+    nodes:
+      - host: mysql-source
+        port: 3306
+    credentials:
+      user: puremyha
+      password_file: /etc/puremyha/mysql.pass
+    replication_credentials:
+      user: repl
+      password_file: /etc/puremyha/repl.pass
+
+monitoring:
+  interval: 1s
+  connect_timeout: 2s
+  replication_lag_warning: 5s
+  replication_lag_critical: 10s
+  discovery_interval: 5s
+
+failure_detection:
+  recovery_block_period: 30s
+
+failover:
+  auto_failover: false
+  min_replicas_for_failover: 1
+  wait_for_relay_log_apply_timeout: 10s

--- a/e2e/docker-compose.source-only.yml
+++ b/e2e/docker-compose.source-only.yml
@@ -1,0 +1,3 @@
+services:
+  puremyhad:
+    command: ["puremyhad", "--config", "/etc/puremyha/puremyha-source-only.yaml", "--socket", "/run/puremyhad.sock"]

--- a/e2e/tests/11-replica-retention-on-source-dead.sh
+++ b/e2e/tests/11-replica-retention-on-source-dead.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Test: Replica Retention When Source Dead
+# Verifies that dynamically-discovered replicas are not lost from ctNodes when
+# periodic topology refresh runs while the source is unreachable.
+set -euo pipefail
+source "$(dirname "$0")/../lib/helpers.sh"
+echo "=== Test 11: Replica Retention on Source Dead ==="
+
+COMPOSE_OVERRIDE="${E2E_DIR}/docker-compose.source-only.yml"
+
+# 1. Restart puremyhad with source-only config (only mysql-source in nodes list)
+echo "  Restarting puremyhad with source-only config..."
+docker compose -f "${E2E_DIR}/docker-compose.yml" -f "$COMPOSE_OVERRIDE" \
+  up -d --no-deps --force-recreate puremyhad
+
+# 2. Wait for daemon to discover all 3 nodes via SHOW REPLICAS on the source
+echo "  Waiting for 3-node topology to be discovered..."
+for i in $(seq 1 60); do
+  count=$(get_node_count)
+  if [ "$count" = "3" ]; then
+    echo "  All 3 nodes discovered (${i}s)"
+    break
+  fi
+  sleep 1
+done
+count=$(get_node_count)
+assert_eq "3 nodes discovered via auto-discovery" "3" "$count"
+
+wait_for_health "Healthy" 30
+
+# 3. Stop the source
+echo "  Stopping mysql-source..."
+$COMPOSE stop mysql-source
+
+# 4. Wait for DeadSource detection
+wait_for_health "DeadSource" 30
+
+# 5. Wait long enough for periodic discover (5s interval) to run multiple times
+echo "  Waiting 20s for periodic topology refresh to run..."
+sleep 20
+
+# 6. Verify replicas are still tracked
+count_after=$(get_node_count)
+assert_eq "Replicas retained after source death + topology refresh" "3" "$count_after"
+
+# 7. Restore original config
+echo "  Restoring original puremyhad config..."
+$COMPOSE up -d --no-deps --force-recreate puremyhad
+reset_cluster
+
+test_summary

--- a/src/PureMyHA/Monitor/Worker.hs
+++ b/src/PureMyHA/Monitor/Worker.hs
@@ -88,9 +88,14 @@ runTopologyRefresh reg = do
       tvar   = envDaemonState env
   liftIO $ do
     newTopo <- discoverTopology cc (cpPassword pws) logger
-    atomically $ updateClusterTopology tvar newTopo
+    mOldTopo <- getClusterTopology tvar (ccName cc)
+    let mergedTopo = case mOldTopo of
+          Nothing      -> newTopo
+          Just oldTopo ->
+            newTopo { ctNodes = Map.union (ctNodes newTopo) (ctNodes oldTopo) }
+    atomically $ updateClusterTopology tvar mergedTopo
     knownNodes <- Map.keysSet <$> readTVarIO reg
-    let discovered = Map.keysSet (ctNodes newTopo)
+    let discovered = Map.keysSet (ctNodes mergedTopo)
         newNodes   = Set.toList (Set.difference discovered knownNodes)
     unless (null newNodes) $
       logInfo logger $ "[" <> ccName cc <> "] Topology refresh: "

--- a/test/PureMyHA/TopologySpec.hs
+++ b/test/PureMyHA/TopologySpec.hs
@@ -4,6 +4,7 @@ import Test.Hspec
 import Fixtures
 import PureMyHA.Monitor.Detector (identifySource)
 import PureMyHA.Types
+import qualified Data.Map.Strict as Map
 
 spec :: Spec
 spec = do
@@ -30,3 +31,29 @@ spec = do
           rep = healthyReplica
       -- db2's replica status points to db1, so db1 should still be identified
       identifySource [src, rep] `shouldNotBe` Nothing
+
+  describe "topology merge (runTopologyRefresh merge logic)" $ do
+    it "retains nodes from oldTopo not present in newTopo" $ do
+      -- newTopo has only the dead source (config node), oldTopo had replica too
+      let extraReplica = mkNodeState (NodeId "db3" 3306) False
+                           (Just (mkReplicaStatus "db1" 3306 IOYes "uuid1:1-100")) Healthy
+          newNodes = Map.fromList [(NodeId "db1" 3306, (unreachableNode (NodeId "db1" 3306)) { nsIsSource = True })]
+          oldNodes = Map.union clusterWithDeadSource (Map.singleton (NodeId "db3" 3306) extraReplica)
+          merged   = Map.union newNodes oldNodes
+      Map.member (NodeId "db3" 3306) merged `shouldBe` True
+
+    it "uses new state for nodes present in both topos" $ do
+      -- newTopo has updated state for db1; oldTopo has stale state
+      let newSource = (unreachableNode (NodeId "db1" 3306)) { nsIsSource = True }
+          newNodes  = Map.singleton (NodeId "db1" 3306) newSource
+          oldNodes  = clusterHealthy
+          merged    = Map.union newNodes oldNodes
+      nsHealth (merged Map.! NodeId "db1" 3306) `shouldBe` NeedsAttention "Connection refused"
+
+    it "with no oldTopo, uses newTopo as-is" $ do
+      -- simulates first discover (Nothing case)
+      let newNodes = ctNodes <$> Just (ClusterTopology "e2e" clusterHealthy Nothing Healthy False Nothing Nothing False)
+          merged   = case newNodes of
+                       Nothing      -> clusterWithDeadSource
+                       Just nodes   -> nodes
+      Map.size merged `shouldBe` 2


### PR DESCRIPTION
## Summary

- **Bug**: Dynamically-discovered replicas (not listed in the config file) were silently dropped from `ctNodes` whenever the periodic topology refresh ran while the source was unreachable. This happened because `discoverTopology` can only find config-listed seed nodes when `SHOW REPLICAS` is unavailable, and the old code replaced the entire node map with the result.
- **Fix**: In `runTopologyRefresh`, read the existing topology before applying the new one and merge using `Map.union (ctNodes newTopo) (ctNodes oldTopo)`. Left-biased union ensures freshly-discovered nodes take precedence while nodes absent from the latest discovery are retained. Monitor workers for those nodes continue running uninterrupted.
- **Scope**: Manual discover via `makeDiscoveryAction` (IPC command) is intentionally left as a full replacement, allowing operators to explicitly remove nodes.

## Changes

| File | Change |
|------|--------|
| `src/PureMyHA/Monitor/Worker.hs` | Merge old topology into new before applying in `runTopologyRefresh` |
| `test/PureMyHA/TopologySpec.hs` | 3 new unit tests verifying merge semantics (retain missing nodes, prefer new state, first-discover passthrough) |
| `e2e/config/puremyha-source-only.yaml` | E2E config listing only the source node (replicas are auto-discovered) |
| `e2e/docker-compose.source-only.yml` | Compose override pointing daemon at the source-only config |
| `e2e/tests/11-replica-retention-on-source-dead.sh` | E2E test reproducing the bug end-to-end |

## Test plan

- [x] `cabal build all` — clean build
- [x] `cabal test` — 149 examples, 0 failures (3 new topology merge tests included)
- [x] E2E test 11 — daemon starts with source-only config, auto-discovers 3 nodes, source is stopped, periodic refresh (5 s interval) runs 4+ times, node count remains 3
- [x] All 11 E2E tests pass (`Tests run: 11, Failed: 0`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)