### PR TITLE
refactor: relax type signatures in Env.hs to minimal constraints

### DIFF
--- a/src/PureMyHA/Env.hs
+++ b/src/PureMyHA/Env.hs
@@ -13,8 +13,8 @@ module PureMyHA.Env
   ) where
 
 import Control.Concurrent.STM (TVar, readTVarIO)
-import Control.Monad.Reader (ReaderT, asks, runReaderT)
-import Control.Monad.IO.Class (liftIO)
+import Control.Monad.Reader (MonadReader, ReaderT, asks, runReaderT)
+import Control.Monad.IO.Class (MonadIO, liftIO)
 import Data.Text (Text)
 import PureMyHA.Config
 import PureMyHA.Logger (Logger, logInfo, logWarn, logError)
@@ -39,22 +39,22 @@ runApp :: ClusterEnv -> App a -> IO a
 runApp = flip runReaderT
 
 -- Helpers
-getMonitoringConfig :: App MonitoringConfig
+getMonitoringConfig :: (MonadReader ClusterEnv m, MonadIO m) => m MonitoringConfig
 getMonitoringConfig = asks envMonitoring >>= liftIO . readTVarIO
 
-getHooksConfig :: App (Maybe HooksConfig)
+getHooksConfig :: (MonadReader ClusterEnv m, MonadIO m) => m (Maybe HooksConfig)
 getHooksConfig = asks envHooks >>= liftIO . readTVarIO
 
-getClusterName :: App ClusterName
+getClusterName :: MonadReader ClusterEnv m => m ClusterName
 getClusterName = asks (ccName . envCluster)
 
-getMySQLUser :: App Text
+getMySQLUser :: MonadReader ClusterEnv m => m Text
 getMySQLUser = asks (credUser . ccCredentials . envCluster)
 
-getMonPassword :: App Text
+getMonPassword :: MonadReader ClusterEnv m => m Text
 getMonPassword = asks (cpPassword . envPasswords)
 
-appLogInfo, appLogWarn, appLogError :: Text -> App ()
+appLogInfo, appLogWarn, appLogError :: (MonadReader ClusterEnv m, MonadIO m) => Text -> m ()
 appLogInfo  msg = asks envLogger >>= \l -> liftIO (logInfo l msg)
 appLogWarn  msg = asks envLogger >>= \l -> liftIO (logWarn l msg)
 appLogError msg = asks envLogger >>= \l -> liftIO (logError l msg)


### PR DESCRIPTION
## Summary

- Relaxed type signatures of environment accessor functions from the concrete `App` monad to minimal typeclass constraints (`MonadReader ClusterEnv m`, `MonadIO m`)
- Added `MonadReader` and `MonadIO` imports to support the updated signatures

## Motivation

Using concrete `App` monad in type signatures ties functions unnecessarily to a specific monad stack. By constraining to the minimal required typeclasses, these functions become more reusable and easier to test in isolation.

## Test plan

- [x] Confirm the project builds without errors (`stack build` or `cabal build`)
- [x] Verify existing callers of `getMonitoringConfig`, `getHooksConfig`, `getClusterName`, and related functions continue to compile

🤖 Generated with [Claude Code](https://claude.com/claude-code)