### PR TITLE
docs: Add self-HA options and improve Daemon HA section readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Inspired by the design philosophy of Orchestrator, PureMyHA provides topology di
 
 - **MySQL**: 8.4+ with GTID enabled (`gtid_mode=ON`, `enforce_gtid_consistency=ON`) and `caching_sha2_password` authentication (default in MySQL 8.4). `mysql_native_password` is not supported.
 - **OS**: Linux
-- **HA for PureMyHA itself**: Pacemaker + QDevice (recommended) or VIP-watching cron / systemd.timer (simple)
+- **HA for PureMyHA itself** *(optional)*: Pacemaker + QDevice (recommended) or VIP-watching cron / systemd.timer (simple)
 
 ### MySQL Users
 
@@ -105,47 +105,9 @@ graph LR
 
 Delegates leader election entirely to Pacemaker + QDevice. Daemon state is held in memory only and rebuilt from MySQL on restart.
 
-#### VIP-watching cron / systemd.timer (simple)
-
-A simpler alternative that requires only a shared VIP (e.g. managed by keepalived).
-Each node periodically checks whether the VIP is assigned to a local interface, and starts or stops `puremyhad` accordingly.
-
-**cron:**
-
-```cron
-* * * * * ip addr show | grep -q <VIP> && systemctl start puremyhad || systemctl stop puremyhad
-```
-
-**systemd.timer** (modern alternative to cron):
-
-```ini
-# /etc/systemd/system/puremyhad-vip-watch.timer
-[Unit]
-Description=PureMyHA VIP watch timer
-
-[Timer]
-OnBootSec=30s
-OnUnitActiveSec=1min
-
-[Install]
-WantedBy=timers.target
-```
-
-```ini
-# /etc/systemd/system/puremyhad-vip-watch.service
-[Unit]
-Description=PureMyHA VIP watch
-
-[Service]
-Type=oneshot
-ExecStart=/bin/sh -c 'ip addr show | grep -q <VIP> && systemctl start puremyhad || systemctl stop puremyhad'
-```
-
-This avoids the complexity of Corosync/Pacemaker/QDevice — suitable when a VIP is already managed by another mechanism such as keepalived. Daemon state is held in memory only and rebuilt from MySQL on restart.
-
 Sample configuration files and a Docker Compose demo are in [`pacemaker-sample/`](pacemaker-sample/).
 
-#### Quick start (Docker Compose demo)
+##### Quick start (Docker Compose demo)
 
 ```bash
 cd pacemaker-sample/demo
@@ -171,7 +133,7 @@ make clean
 
 > **Note:** STONITH is disabled in the demo. See the production setup below.
 
-#### Production setup
+##### Production setup
 
 **Target topology**
 
@@ -281,7 +243,7 @@ pcs constraint order puremyhad then puremyha-vip
 
 See [`pacemaker-sample/setup.sh`](pacemaker-sample/setup.sh) for a fully annotated reference script.
 
-#### Verification
+##### Verification
 
 ```bash
 # Overall cluster health
@@ -301,6 +263,44 @@ ls -la /run/puremyhad.sock    # run on the active node — should exist
 # Config reload (sends SIGHUP via ExecReload in the systemd unit)
 pcs resource reload puremyhad
 ```
+
+#### VIP-watching cron / systemd.timer (simple)
+
+A simpler alternative that requires only a shared VIP (e.g. managed by keepalived).
+Each node periodically checks whether the VIP is assigned to a local interface, and starts or stops `puremyhad` accordingly.
+
+**cron:**
+
+```cron
+* * * * * ip addr show | grep -q <VIP> && systemctl start puremyhad || systemctl stop puremyhad
+```
+
+**systemd.timer** (modern alternative to cron):
+
+```ini
+# /etc/systemd/system/puremyhad-vip-watch.timer
+[Unit]
+Description=PureMyHA VIP watch timer
+
+[Timer]
+OnBootSec=30s
+OnUnitActiveSec=1min
+
+[Install]
+WantedBy=timers.target
+```
+
+```ini
+# /etc/systemd/system/puremyhad-vip-watch.service
+[Unit]
+Description=PureMyHA VIP watch
+
+[Service]
+Type=oneshot
+ExecStart=/bin/sh -c 'ip addr show | grep -q <VIP> && systemctl start puremyhad || systemctl stop puremyhad'
+```
+
+This avoids the complexity of Corosync/Pacemaker/QDevice — suitable when a VIP is already managed by another mechanism such as keepalived. Daemon state is held in memory only and rebuilt from MySQL on restart.
 
 ## Installation
 


### PR DESCRIPTION
## Summary

- Rename `Daemon HA with Pacemaker` section to `Daemon HA` to reflect that multiple approaches are available
- Add VIP-watching cron / systemd.timer as a simpler alternative to Pacemaker for PureMyHA self-HA
- Reorganize the Daemon HA section so Pacemaker-specific content (Quick start, Production setup, Verification) is clearly grouped under the Pacemaker heading, and the VIP-watching section follows as a separate peer
- Mark "HA for PureMyHA itself" as optional in Requirements

## Test plan

- [x] Render README.md (GitHub preview or `grip`) and verify the Daemon HA section structure is clear
- [x] Confirm Pacemaker subsections (Quick start, Production setup, Verification) appear nested under the Pacemaker heading
- [x] Confirm VIP-watching section appears as a separate `####` section after all Pacemaker content
- [x] Confirm Requirements lists self-HA as `*(optional)*`

🤖 Generated with [Claude Code](https://claude.com/claude-code)