### PR TITLE
feat: require N consecutive monitoring failures before declaring a node dead

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Inspired by the design philosophy of Orchestrator, PureMyHA provides topology di
 - **Automatic Failover** — Detects dead sources and promotes the best replica (GTID-aware, errant-GTID-safe, waits for relay log apply)
 - **Manual Switchover** — Planned maintenance with zero-data-loss semantics
 - **Errant GTID Detection & Repair** — Identifies and fixes errant GTIDs via empty transactions
+- **Consecutive Failure Threshold** — Requires N consecutive probe failures before marking a node dead, preventing failover on transient TCP timeouts or momentary MySQL unresponsiveness (configurable `consecutive_failures_for_dead`, default 3)
 - **Anti-Flap Protection** — Blocks repeated automatic failovers via configurable `recovery_block_period`
 - **Hook Support** — Pre/post hooks for failover and switchover events
 - **MySQL 8.4 Native** — Uses only modern syntax (`SHOW REPLICA STATUS`, `CHANGE REPLICATION SOURCE TO`, etc.)
@@ -186,6 +187,7 @@ global:
     discovery_interval: 300s   # Optional; 0s = disabled. Default: 300s
   failure_detection:
     recovery_block_period: 3600s   # Block auto-failover for this long after a failover
+    consecutive_failures_for_dead: 3  # Require N consecutive probe failures before marking a node dead (default: 3)
   failover:
     auto_failover: true
     min_replicas_for_failover: 1
@@ -302,7 +304,8 @@ PureMyHA writes structured, timestamped logs via [katip](https://hackage.haskell
 | Event | Level |
 |-------|-------|
 | Daemon started | Info |
-| Node unreachable / connect failed | Warn |
+| Node probe failed (below consecutive threshold) | Info |
+| Node unreachable / connect failed (threshold reached) | Warn |
 | Node recovered | Info |
 | Auto-failover started / completed / failed | Info / Error |
 | Switchover started / completed / failed | Info / Error |

--- a/config/config.yaml.example
+++ b/config/config.yaml.example
@@ -24,6 +24,7 @@ global:
     discovery_interval: 300s   # optional; 0s = disabled. Default: 300s
   failure_detection:
     recovery_block_period: 3600s   # block auto-failover for this long after a failover
+    consecutive_failures_for_dead: 3  # require N consecutive probe failures before marking a node dead (default: 3)
   failover:
     auto_failover: true
     min_replicas_for_failover: 1

--- a/puremyha.cabal
+++ b/puremyha.cabal
@@ -107,6 +107,7 @@ test-suite puremyha-test
     PureMyHA.SwitchoverSpec
     PureMyHA.DiscoverySpec
     PureMyHA.ErrantGtidSpec
+    PureMyHA.WorkerSpec
   build-depends:
     puremyha,
     hspec            >= 2.9,

--- a/src/PureMyHA/Config.hs
+++ b/src/PureMyHA/Config.hs
@@ -93,7 +93,8 @@ data MonitoringConfig = MonitoringConfig
   } deriving (Show, Generic)
 
 data FailureDetectionConfig = FailureDetectionConfig
-  { fdcRecoveryBlockPeriod :: NominalDiffTime
+  { fdcRecoveryBlockPeriod         :: NominalDiffTime
+  , fdcConsecutiveFailuresForDead  :: Int   -- ^ Consecutive failures required to mark a node dead (default 3)
   } deriving (Show, Generic)
 
 data FailoverConfig = FailoverConfig
@@ -215,7 +216,8 @@ instance FromJSON MonitoringConfig where
 instance FromJSON FailureDetectionConfig where
   parseJSON = withObject "FailureDetectionConfig" $ \o ->
     FailureDetectionConfig
-      <$> (unDuration <$> o .: "recovery_block_period")
+      <$> (unDuration <$> o .:  "recovery_block_period")
+      <*> o .:? "consecutive_failures_for_dead" .!= 3
 
 instance FromJSON FailoverConfig where
   parseJSON = withObject "FailoverConfig" $ \o ->

--- a/src/PureMyHA/Monitor/Worker.hs
+++ b/src/PureMyHA/Monitor/Worker.hs
@@ -4,6 +4,7 @@ module PureMyHA.Monitor.Worker
   , WorkerRegistry
   , monitorNode
   , runWorker
+  , suppressBelowThreshold
   ) where
 
 import Control.Concurrent (threadDelay)
@@ -101,53 +102,78 @@ runTopologyRefresh reg = do
     a <- async (runApp env (runWorker nid))
     atomically $ modifyTVar' reg (Map.insert nid a)
 
+-- | Suppress NeedsAttention health state when consecutive failure count is below
+-- the configured threshold. Falls back to previous health (or Healthy if no prior state).
+suppressBelowThreshold :: Int -> Int -> Maybe NodeState -> NodeState -> NodeState
+suppressBelowThreshold threshold failCount mOldNs ns
+  | failCount > 0 && failCount < threshold =
+      ns { nsHealth = maybe Healthy nsHealth mOldNs }
+  | otherwise = ns
+
 -- | Perform a single monitoring cycle for a node
 monitorNode :: NodeId -> App ()
 monitorNode nid = do
+  env  <- ask
   tvar <- asks envDaemonState
   cc   <- asks envCluster
   pws  <- asks envPasswords
+  fdc  <- asks envDetection
   now  <- liftIO getCurrentTime
-  let user = credUser (ccCredentials cc)
-      ci   = makeConnectInfo nid user (cpPassword pws)
+  let user      = credUser (ccCredentials cc)
+      ci        = makeConnectInfo nid user (cpPassword pws)
+      threshold = fdcConsecutiveFailuresForDead fdc
   -- Read old state before connecting, so we can preserve nsIsSource on error
   mOldNs <- liftIO $ do
     mTopo <- getClusterTopology tvar (ccName cc)
     pure $ mTopo >>= \t -> Map.lookup nid (ctNodes t)
+  let prevFailures = maybe 0 nsConsecutiveFailures mOldNs
   result <- liftIO $ withNodeConn ci $ \conn -> do
     mRs      <- showReplicaStatus conn
     gtidExec <- getGtidExecuted conn
     pure (mRs, gtidExec)
+  let newFailures = case result of { Left _ -> prevFailures + 1; Right _ -> 0 }
   let ns = case result of
         Left err ->
           NodeState
-            { nsNodeId          = nid
-            , nsReplicaStatus   = Nothing
-            , nsGtidExecuted    = ""
-            , nsIsSource        = maybe False nsIsSource mOldNs
-            , nsHealth          = NeedsAttention err
-            , nsLastSeen        = Nothing
-            , nsConnectError    = Just err
-            , nsErrantGtids     = ""
-            , nsPaused          = maybe False nsPaused mOldNs
+            { nsNodeId               = nid
+            , nsReplicaStatus        = Nothing
+            , nsGtidExecuted         = ""
+            , nsIsSource             = maybe False nsIsSource mOldNs
+            , nsHealth               = NeedsAttention err
+            , nsLastSeen             = Nothing
+            , nsConnectError         = Just err
+            , nsErrantGtids          = ""
+            , nsPaused               = maybe False nsPaused mOldNs
+            , nsConsecutiveFailures  = newFailures
             }
         Right (mRs, gtidExec) ->
           NodeState
-            { nsNodeId          = nid
-            , nsReplicaStatus   = mRs
-            , nsGtidExecuted    = gtidExec
-            , nsIsSource        = mRs == Nothing
-            , nsHealth          = Healthy
-            , nsLastSeen        = Just now
-            , nsConnectError    = Nothing
-            , nsErrantGtids     = ""
-            , nsPaused          = maybe False nsPaused mOldNs
+            { nsNodeId               = nid
+            , nsReplicaStatus        = mRs
+            , nsGtidExecuted         = gtidExec
+            , nsIsSource             = mRs == Nothing
+            , nsHealth               = Healthy
+            , nsLastSeen             = Just now
+            , nsConnectError         = Nothing
+            , nsErrantGtids          = ""
+            , nsPaused               = maybe False nsPaused mOldNs
+            , nsConsecutiveFailures  = 0
             }
   -- Update errant GTIDs by querying MySQL
   ns' <- enrichErrantGtids ns
-  let ns'' = ns' { nsHealth = detectNodeHealth ns' }
-  logHealthChange nid mOldNs ns''
-  liftIO $ atomically $ updateNodeState tvar (ccName cc) ns''
+  let ns''  = ns' { nsHealth = detectNodeHealth ns' }
+  -- Apply consecutive failure threshold: suppress NeedsAttention until N consecutive failures
+  let ns''' = suppressBelowThreshold threshold newFailures mOldNs ns''
+  -- Log below-threshold failures for observability
+  liftIO $ when (newFailures > 0 && newFailures < threshold) $ do
+    logger <- readTVarIO (envLogger env)
+    case result of
+      Left err -> logInfo logger $ "[" <> ccName cc <> "] Node " <> nodeHost nid
+                    <> " probe failed (" <> T.pack (show newFailures) <> "/"
+                    <> T.pack (show threshold) <> "): " <> err
+      Right _  -> pure ()
+  logHealthChange nid mOldNs ns'''
+  liftIO $ atomically $ updateNodeState tvar (ccName cc) ns'''
   -- Recompute cluster-level health
   recomputeClusterHealth
 

--- a/src/PureMyHA/Topology/Discovery.hs
+++ b/src/PureMyHA/Topology/Discovery.hs
@@ -129,26 +129,28 @@ buildNodeStateFromProbe
   -> Either Text (Maybe ReplicaStatus, Text)
   -> NodeState
 buildNodeStateFromProbe nid _ (Left err) = NodeState
-  { nsNodeId        = nid
-  , nsReplicaStatus = Nothing
-  , nsGtidExecuted  = ""
-  , nsIsSource      = False
-  , nsHealth        = NeedsAttention err
-  , nsLastSeen      = Nothing
-  , nsConnectError  = Just err
-  , nsErrantGtids   = ""
-  , nsPaused        = False
+  { nsNodeId               = nid
+  , nsReplicaStatus        = Nothing
+  , nsGtidExecuted         = ""
+  , nsIsSource             = False
+  , nsHealth               = NeedsAttention err
+  , nsLastSeen             = Nothing
+  , nsConnectError         = Just err
+  , nsErrantGtids          = ""
+  , nsPaused               = False
+  , nsConsecutiveFailures  = 0
   }
 buildNodeStateFromProbe nid now (Right (mRs, gtidExec)) = NodeState
-  { nsNodeId        = nid
-  , nsReplicaStatus = mRs
-  , nsGtidExecuted  = gtidExec
-  , nsIsSource      = mRs == Nothing  -- no replica status = potential source
-  , nsHealth        = Healthy
-  , nsLastSeen      = Just now
-  , nsConnectError  = Nothing
-  , nsErrantGtids   = ""
-  , nsPaused        = False
+  { nsNodeId               = nid
+  , nsReplicaStatus        = mRs
+  , nsGtidExecuted         = gtidExec
+  , nsIsSource             = mRs == Nothing  -- no replica status = potential source
+  , nsHealth               = Healthy
+  , nsLastSeen             = Just now
+  , nsConnectError         = Nothing
+  , nsErrantGtids          = ""
+  , nsPaused               = False
+  , nsConsecutiveFailures  = 0
   }
 
 -- | Calculate next nodes to probe from a discovered node's replica status (pure)

--- a/src/PureMyHA/Types.hs
+++ b/src/PureMyHA/Types.hs
@@ -51,15 +51,16 @@ data NodeHealth
   deriving (Eq, Show, Generic)
 
 data NodeState = NodeState
-  { nsNodeId        :: NodeId
-  , nsReplicaStatus :: Maybe ReplicaStatus
-  , nsGtidExecuted  :: Text
-  , nsIsSource      :: Bool
-  , nsHealth        :: NodeHealth
-  , nsLastSeen      :: Maybe UTCTime
-  , nsConnectError  :: Maybe Text
-  , nsErrantGtids   :: Text
-  , nsPaused        :: Bool
+  { nsNodeId               :: NodeId
+  , nsReplicaStatus        :: Maybe ReplicaStatus
+  , nsGtidExecuted         :: Text
+  , nsIsSource             :: Bool
+  , nsHealth               :: NodeHealth
+  , nsLastSeen             :: Maybe UTCTime
+  , nsConnectError         :: Maybe Text
+  , nsErrantGtids          :: Text
+  , nsPaused               :: Bool
+  , nsConsecutiveFailures  :: Int    -- ^ Number of consecutive probe failures; resets to 0 on success
   } deriving (Eq, Show, Generic)
 
 data ClusterTopology = ClusterTopology

--- a/test/Fixtures.hs
+++ b/test/Fixtures.hs
@@ -45,22 +45,23 @@ mkReplicaStatus srcHost srcPort ioRunning execGtid = ReplicaStatus
 
 mkNodeState :: NodeId -> Bool -> Maybe ReplicaStatus -> NodeHealth -> NodeState
 mkNodeState nid isSource mRs health = NodeState
-  { nsNodeId          = nid
-  , nsReplicaStatus   = mRs
-  , nsGtidExecuted    = ""
-  , nsIsSource        = isSource
-  , nsHealth          = health
-  , nsLastSeen        = Just fixedTime
-  , nsConnectError    = Nothing
-  , nsErrantGtids     = ""
-  , nsPaused          = False
+  { nsNodeId               = nid
+  , nsReplicaStatus        = mRs
+  , nsGtidExecuted         = ""
+  , nsIsSource             = isSource
+  , nsHealth               = health
+  , nsLastSeen             = Just fixedTime
+  , nsConnectError         = Nothing
+  , nsErrantGtids          = ""
+  , nsPaused               = False
+  , nsConsecutiveFailures  = 0
   }
 
 -- | Build a test ClusterEnv with dummy values for fields not under test
 mkTestEnv :: TVarDaemonState -> ClusterConfig -> FailoverConfig -> IO ClusterEnv
 mkTestEnv tvar cc fc = do
   let pws = ClusterPasswords "" "" ""
-      fdc = FailureDetectionConfig 0
+      fdc = FailureDetectionConfig 0 3
   mcVar    <- newTVarIO (MonitoringConfig 3 5 30 60 300)
   hooksVar <- newTVarIO Nothing
   lock     <- newFailoverLock
@@ -99,15 +100,16 @@ replicaWithIOError = mkNodeState (mkNodeId "db4" 3306) False
 
 unreachableNode :: NodeId -> NodeState
 unreachableNode nid = NodeState
-  { nsNodeId          = nid
-  , nsReplicaStatus   = Nothing
-  , nsGtidExecuted    = ""
-  , nsIsSource        = False
-  , nsHealth          = NeedsAttention "Connection refused"
-  , nsLastSeen        = Nothing
-  , nsConnectError    = Just "Connection refused"
-  , nsErrantGtids     = ""
-  , nsPaused          = False
+  { nsNodeId               = nid
+  , nsReplicaStatus        = Nothing
+  , nsGtidExecuted         = ""
+  , nsIsSource             = False
+  , nsHealth               = NeedsAttention "Connection refused"
+  , nsLastSeen             = Nothing
+  , nsConnectError         = Just "Connection refused"
+  , nsErrantGtids          = ""
+  , nsPaused               = False
+  , nsConsecutiveFailures  = 0
   }
 
 unreachableReplica :: NodeState
@@ -118,15 +120,16 @@ clusterWithDeadSource :: Map NodeId NodeState
 clusterWithDeadSource = Map.fromList
   [ (mkNodeId "db1" 3306, (unreachableNode (mkNodeId "db1" 3306)) { nsIsSource = True })
   , (mkNodeId "db2" 3306, NodeState
-      { nsNodeId    = mkNodeId "db2" 3306
-      , nsReplicaStatus = Just (mkReplicaStatus "db1" 3306 IONo "uuid1:1-100")
-      , nsGtidExecuted    = ""
-      , nsIsSource  = False
-      , nsHealth    = Healthy
-      , nsLastSeen  = Just fixedTime
-      , nsConnectError = Nothing
-      , nsErrantGtids = ""
-      , nsPaused = False
+      { nsNodeId               = mkNodeId "db2" 3306
+      , nsReplicaStatus        = Just (mkReplicaStatus "db1" 3306 IONo "uuid1:1-100")
+      , nsGtidExecuted         = ""
+      , nsIsSource             = False
+      , nsHealth               = Healthy
+      , nsLastSeen             = Just fixedTime
+      , nsConnectError         = Nothing
+      , nsErrantGtids          = ""
+      , nsPaused               = False
+      , nsConsecutiveFailures  = 0
       })
   ]
 

--- a/test/PureMyHA/ConfigSpec.hs
+++ b/test/PureMyHA/ConfigSpec.hs
@@ -103,6 +103,39 @@ spec = do
         Right cfg ->
           fdcRecoveryBlockPeriod (ccFailureDetection (head (cfgClusters cfg))) `shouldBe` 60
 
+    it "consecutive_failures_for_dead defaults to 3 when absent" $ do
+      let yaml = BC.pack $ unlines
+            [ "clusters:"
+            , "  - name: test"
+            , "    nodes: []"
+            , "    credentials:"
+            , "      user: u"
+            , "      password_file: /dev/null"
+            , globalBlock
+            ]
+      case decodeConfig yaml of
+        Left err -> expectationFailure err
+        Right cfg ->
+          fdcConsecutiveFailuresForDead (ccFailureDetection (head (cfgClusters cfg))) `shouldBe` 3
+
+    it "parses explicit consecutive_failures_for_dead" $ do
+      let yaml = BC.pack $ unlines
+            [ "clusters:"
+            , "  - name: test"
+            , "    nodes: []"
+            , "    credentials:"
+            , "      user: u"
+            , "      password_file: /dev/null"
+            , "    failure_detection:"
+            , "      recovery_block_period: 3600s"
+            , "      consecutive_failures_for_dead: 5"
+            , globalBlock
+            ]
+      case decodeConfig yaml of
+        Left err -> expectationFailure err
+        Right cfg ->
+          fdcConsecutiveFailuresForDead (ccFailureDetection (head (cfgClusters cfg))) `shouldBe` 5
+
     it "cluster-level failover overrides global" $ do
       let yaml = BC.pack $ unlines
             [ "clusters:"

--- a/test/PureMyHA/DetectorSpec.hs
+++ b/test/PureMyHA/DetectorSpec.hs
@@ -36,15 +36,16 @@ spec = do
       let cluster = Map.fromList
             [ (NodeId "db1" 3306, (unreachableNode (NodeId "db1" 3306)) { nsIsSource = True })
             , (NodeId "db2" 3306, NodeState
-                { nsNodeId        = NodeId "db2" 3306
-                , nsReplicaStatus = Just (mkReplicaStatus "db1" 3306 IOConnecting "")
-                , nsGtidExecuted  = ""
-                , nsIsSource      = False
-                , nsHealth        = Healthy
-                , nsLastSeen      = Just fixedTime
-                , nsConnectError  = Nothing
-                , nsErrantGtids   = ""
-                , nsPaused        = False
+                { nsNodeId               = NodeId "db2" 3306
+                , nsReplicaStatus        = Just (mkReplicaStatus "db1" 3306 IOConnecting "")
+                , nsGtidExecuted         = ""
+                , nsIsSource             = False
+                , nsHealth               = Healthy
+                , nsLastSeen             = Just fixedTime
+                , nsConnectError         = Nothing
+                , nsErrantGtids          = ""
+                , nsPaused               = False
+                , nsConsecutiveFailures  = 0
                 })
             ]
       detectClusterHealth cluster `shouldBe` DeadSource
@@ -53,15 +54,16 @@ spec = do
       let cluster = Map.fromList
             [ (NodeId "db1" 3306, (unreachableNode (NodeId "db1" 3306)) { nsIsSource = True })
             , (NodeId "db2" 3306, NodeState
-                { nsNodeId        = NodeId "db2" 3306
-                , nsReplicaStatus = Just (mkReplicaStatus "db1" 3306 IOYes "")
-                , nsGtidExecuted  = ""
-                , nsIsSource      = False
-                , nsHealth        = Healthy
-                , nsLastSeen      = Just fixedTime
-                , nsConnectError  = Nothing
-                , nsErrantGtids   = ""
-                , nsPaused        = False
+                { nsNodeId               = NodeId "db2" 3306
+                , nsReplicaStatus        = Just (mkReplicaStatus "db1" 3306 IOYes "")
+                , nsGtidExecuted         = ""
+                , nsIsSource             = False
+                , nsHealth               = Healthy
+                , nsLastSeen             = Just fixedTime
+                , nsConnectError         = Nothing
+                , nsErrantGtids          = ""
+                , nsPaused               = False
+                , nsConsecutiveFailures  = 0
                 })
             ]
       detectClusterHealth cluster `shouldBe` UnreachableSource

--- a/test/PureMyHA/DiscoverySpec.hs
+++ b/test/PureMyHA/DiscoverySpec.hs
@@ -30,7 +30,7 @@ testCC = ClusterConfig
   , ccCredentials            = Credentials "root" "/run/pw"
   , ccReplicationCredentials = Nothing
   , ccMonitoring             = MonitoringConfig 3 5 30 60 300
-  , ccFailureDetection       = FailureDetectionConfig 3600
+  , ccFailureDetection       = FailureDetectionConfig 3600 3
   , ccFailover               = FailoverConfig True 1 [] 60
   , ccHooks                  = Nothing
   }

--- a/test/PureMyHA/SwitchoverSpec.hs
+++ b/test/PureMyHA/SwitchoverSpec.hs
@@ -84,7 +84,7 @@ testCC = ClusterConfig
   , ccCredentials            = Credentials "user" "/dev/null"
   , ccReplicationCredentials = Nothing
   , ccMonitoring             = MonitoringConfig 3 5 30 60 300
-  , ccFailureDetection       = FailureDetectionConfig 3600
+  , ccFailureDetection       = FailureDetectionConfig 3600 3
   , ccFailover               = FailoverConfig True 1 [] 60
   , ccHooks                  = Nothing
   }

--- a/test/PureMyHA/WorkerSpec.hs
+++ b/test/PureMyHA/WorkerSpec.hs
@@ -1,0 +1,45 @@
+module PureMyHA.WorkerSpec (spec) where
+
+import Test.Hspec
+import Fixtures
+import PureMyHA.Monitor.Worker (suppressBelowThreshold)
+import PureMyHA.Types
+
+spec :: Spec
+spec = describe "suppressBelowThreshold" $ do
+  let threshold = 3
+      errNs     = healthySource
+                    { nsHealth              = NeedsAttention "refused"
+                    , nsConnectError        = Just "refused"
+                    , nsConsecutiveFailures = 1
+                    }
+
+  it "keeps previous health when failCount is below threshold" $
+    suppressBelowThreshold threshold 1 (Just healthySource) errNs
+      `shouldBe` errNs { nsHealth = Healthy }
+
+  it "applies NeedsAttention when failCount equals threshold" $
+    suppressBelowThreshold threshold 3 (Just healthySource) errNs
+      `shouldBe` errNs { nsHealth = NeedsAttention "refused" }
+
+  it "applies NeedsAttention when failCount exceeds threshold" $
+    suppressBelowThreshold threshold 5 (Just healthySource) errNs
+      `shouldBe` errNs { nsHealth = NeedsAttention "refused" }
+
+  it "uses Healthy as fallback when no previous state (first probe)" $
+    suppressBelowThreshold threshold 1 Nothing errNs
+      `shouldBe` errNs { nsHealth = Healthy }
+
+  it "does not suppress when failCount is 0 (success case)" $
+    suppressBelowThreshold threshold 0 (Just healthySource) healthySource
+      `shouldBe` healthySource
+
+  it "resets to Healthy on success after previous NeedsAttention" $ do
+    let prev = healthySource { nsHealth = NeedsAttention "err", nsConsecutiveFailures = 2 }
+        curr = healthySource { nsConsecutiveFailures = 0 }
+    suppressBelowThreshold threshold 0 (Just prev) curr `shouldBe` curr
+
+  it "preserves NeedsAttention from previous state when below threshold" $ do
+    let prev = healthySource { nsHealth = NeedsAttention "prior err", nsConsecutiveFailures = 2 }
+    suppressBelowThreshold threshold 2 (Just prev) errNs
+      `shouldBe` errNs { nsHealth = NeedsAttention "prior err" }


### PR DESCRIPTION
## Summary

Closes #35

A single failed monitoring cycle could previously set a node to `NeedsAttention`, and one more cycle where replicas confirmed IO stopped would trigger `DeadSource` and auto-failover. With `interval: 1s`, a transient TCP timeout or momentary MySQL unresponsiveness during buffer pool warm-up could cause failover within ~2 seconds.

This PR adds a configurable consecutive-failure threshold — matching the behaviour of Orchestrator and MHA — so that a node is only declared dead after **N consecutive probe failures** (default: 3).

- **`Types.hs`** — add `nsConsecutiveFailures :: Int` to `NodeState`; resets to `0` on any successful probe
- **`Config.hs`** — add `fdcConsecutiveFailuresForDead :: Int` (default `3`) to `FailureDetectionConfig`; parsed from `consecutive_failures_for_dead` in YAML
- **`Monitor/Worker.hs`** — implement threshold logic in `monitorNode`; extract pure helper `suppressBelowThreshold` (exported for testing); log suppressed failures at Info level as `"Node X probe failed (N/threshold): ..."`
- **`Topology/Discovery.hs`** — initialise `nsConsecutiveFailures = 0` in `buildNodeStateFromProbe`
- **Tests** — new `WorkerSpec.hs` (7 unit tests for `suppressBelowThreshold`); 2 new `ConfigSpec` cases for default value and explicit parsing
- **Docs** — `config/config.yaml.example` and `README.md` updated with the new field

## Test plan

- [x] `cabal build all` — no warnings
- [x] `cabal test` — 168 examples, 0 failures (including 7 new `WorkerSpec` tests and 2 new `ConfigSpec` tests)
- [x] E2E tests — 12 test suites, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)