### PR TITLE
feat: support runtime log level changes via IPC and config reload

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Inspired by the design philosophy of Orchestrator, PureMyHA provides topology di
 - **HTTP Health Check Endpoint** — Optional read-only HTTP listener for load balancer probes and Kubernetes liveness/readiness checks (`GET /health`, `/cluster/:name/status`, `/cluster/:name/topology`)
 - **Prometheus Metrics Endpoint** — `GET /metrics` exposes cluster health, replication lag, consecutive failures, and node role in Prometheus text exposition format for Grafana and other monitoring stacks
 - **In-Memory Event History** — Maintains a bounded ring buffer of recent events (health changes, failovers, switchovers, config reloads); queryable instantly via `puremyha events` without log parsing
+- **Runtime Log Level Control** — Change log verbosity without restarting the daemon via `puremyha set-log-level debug|info|warn|error` (IPC override takes precedence until the next SIGHUP, which resets to the configured `log_level`)
 
 ## Requirements
 
@@ -220,9 +221,10 @@ http:                                  # Optional HTTP server (disabled by defau
 logging:
   log_file: /var/log/puremyha.log  # Optional; defaults to /var/log/puremyha.log
   max_events: 1000                  # Optional; in-memory event buffer size (default: 1000)
+  log_level: info                   # Optional; debug | info | warn | error (default: info)
 ```
 
-`monitoring`, `failure_detection`, `failover`, and `hooks` can be set per-cluster or defined as defaults in the `global` section. Per-cluster settings take precedence over `global` on a section-by-section basis. `monitoring`, `failure_detection`, and `failover` are required in at least one of the two. The `logging` section is optional and global (defaults to `/var/log/puremyha.log` and `max_events: 1000` when omitted).
+`monitoring`, `failure_detection`, `failover`, and `hooks` can be set per-cluster or defined as defaults in the `global` section. Per-cluster settings take precedence over `global` on a section-by-section basis. `monitoring`, `failure_detection`, and `failover` are required in at least one of the two. The `logging` section is optional and global (defaults to `/var/log/puremyha.log`, `max_events: 1000`, and `log_level: info` when omitted).
 
 See `config/config.yaml.example` for a full annotated example.
 
@@ -239,10 +241,11 @@ puremyhad --config /etc/puremyha/config.yaml
 | Signal | Effect |
 |--------|--------|
 | `SIGTERM` / `SIGINT` | Graceful shutdown — stops all workers and removes the socket file |
-| `SIGHUP` | Hot-reload `monitoring`, `hooks`, and `http` config without restart |
+| `SIGHUP` | Hot-reload `monitoring`, `hooks`, `http`, and `log_level` config without restart |
+| `SIGUSR1` | Reopen the log file (for log rotation tools such as logrotate) |
 
 ```bash
-# Reload config (e.g. after editing intervals or hooks)
+# Reload config (e.g. after editing intervals, hooks, or log_level)
 systemctl reload puremyhad        # via systemd (preferred)
 kill -HUP $(pidof puremyhad)      # direct signal (non-systemd)
 
@@ -303,6 +306,10 @@ puremyha resume-failover [--cluster=<name>]
 # Show recent event history (health changes, failovers, switchovers, config reloads)
 # Events are newest-first; buffer is cleared on daemon restart
 puremyha events [--limit=N] [--cluster=<name>]
+
+# Change daemon log level at runtime (no restart required)
+# IPC override takes precedence until the next SIGHUP
+puremyha set-log-level debug|info|warn|error
 
 # JSON output (for scripting / Prometheus exporters)
 puremyha --json status
@@ -373,6 +380,27 @@ backend mysql_source
 ## Logging
 
 PureMyHA writes structured, timestamped logs via [katip](https://hackage.haskell.org/package/katip). The log file path is configured with `logging.log_file` (default: `/var/log/puremyha.log`).
+
+### Log level
+
+The minimum log level is set via `logging.log_level` in the config (default: `info`). Valid values: `debug`, `info`, `warn`, `error`.
+
+```yaml
+logging:
+  log_level: info   # debug | info | warn | error
+```
+
+The level can also be changed at runtime without restarting the daemon:
+
+```bash
+# Increase verbosity for incident investigation
+puremyha set-log-level debug
+
+# Restore to normal
+puremyha set-log-level info
+```
+
+The IPC override takes precedence until the next SIGHUP, which resets the level to whatever is in the config file.
 
 ### Logged events
 

--- a/app/CLI/Main.hs
+++ b/app/CLI/Main.hs
@@ -31,6 +31,7 @@ data Command
   | CmdPauseFailover
   | CmdResumeFailover
   | CmdEvents (Maybe Int)
+  | CmdSetLogLevel Text
 
 cliOptions :: Parser CLIOptions
 cliOptions = CLIOptions
@@ -75,6 +76,8 @@ cliOptions = CLIOptions
             (info (pure CmdResumeFailover) (progDesc "Resume automatic failover"))
         <> command "events"
             (info eventsCmd (progDesc "Show recent event history"))
+        <> command "set-log-level"
+            (info setLogLevelCmd (progDesc "Set daemon log level (debug|info|warn|error)"))
         )
 
 demoteCmd :: Parser Command
@@ -95,6 +98,10 @@ eventsCmd = CmdEvents
         <> short 'n'
         <> metavar "N"
         <> help "Maximum number of events to show" ))
+
+setLogLevelCmd :: Parser Command
+setLogLevelCmd = CmdSetLogLevel
+  <$> argument str (metavar "LEVEL" <> help "Log level: debug, info, warn, error")
 
 switchoverCmd :: Parser Command
 switchoverCmd = CmdSwitchover
@@ -128,6 +135,7 @@ main = do
         CmdPauseFailover     -> ReqPauseFailover  mCluster
         CmdResumeFailover    -> ReqResumeFailover mCluster
         CmdEvents mLimit     -> ReqEventHistory   mCluster mLimit
+        CmdSetLogLevel lvl   -> ReqSetLogLevel lvl
 
   eResp <- sendRequest socketPath req
   case eResp of

--- a/app/Daemon/Main.hs
+++ b/app/Daemon/Main.hs
@@ -52,8 +52,11 @@ main = do
   opts <- execParser (info (daemonOptions <**> helper)
     (fullDesc <> progDesc "PureMyHA daemon" <> header "puremyhad"))
   cfg       <- loadAndValidateConfig (optConfigPath opts)
-  loggerVar <- newTVarIO =<< initLogger (lcLogFile (cfgLogging cfg))
-  eventBuf  <- newEventBuffer (lcMaxEvents (cfgLogging cfg))
+  let logCfg  = cfgLogging cfg
+      initLvl = lcLogLevel logCfg
+  levelVar  <- newTVarIO initLvl
+  loggerVar <- newTVarIO =<< initLogger (lcLogFile logCfg) initLvl
+  eventBuf  <- newEventBuffer (lcMaxEvents logCfg)
 
   tvar        <- newDaemonState
   shutdownVar <- installShutdownHandlers
@@ -62,10 +65,10 @@ main = do
   clusterEnvs      <- mapM (initCluster tvar loggerVar eventBuf) clusterPasswords
 
   httpAsyncVar <- newTVarIO Nothing
-  installHUPHandler (optConfigPath opts) clusterEnvs loggerVar httpAsyncVar tvar eventBuf
-  installUSR1Handler (lcLogFile (cfgLogging cfg)) loggerVar
+  installHUPHandler (optConfigPath opts) clusterEnvs loggerVar httpAsyncVar tvar eventBuf levelVar
+  installUSR1Handler (lcLogFile (cfgLogging cfg)) loggerVar levelVar
 
-  allWorkers <- startAllWorkers clusterEnvs (optSocketPath opts) tvar eventBuf
+  allWorkers <- startAllWorkers clusterEnvs (optSocketPath opts) tvar eventBuf loggerVar (lcLogFile (cfgLogging cfg)) levelVar
   when (hcEnabled (cfgHttp cfg)) $ do
     a <- async (startHTTPServer (cfgHttp cfg) tvar)
     atomically $ writeTVar httpAsyncVar (Just a)
@@ -89,8 +92,8 @@ installShutdownHandlers = do
   _ <- installHandler sigINT  h Nothing
   pure shutdownVar
 
-installHUPHandler :: FilePath -> [ClusterEnv] -> TVar Logger -> TVar (Maybe (Async ())) -> TVarDaemonState -> EventBuffer -> IO ()
-installHUPHandler configPath clusterEnvs loggerVar httpAsyncVar tvar eventBuf = do
+installHUPHandler :: FilePath -> [ClusterEnv] -> TVar Logger -> TVar (Maybe (Async ())) -> TVarDaemonState -> EventBuffer -> TVar LogLevel -> IO ()
+installHUPHandler configPath clusterEnvs loggerVar httpAsyncVar tvar eventBuf levelVar = do
   _ <- installHandler sigHUP (Catch $ do
     logger <- readTVarIO loggerVar
     eCfg' <- loadConfig configPath
@@ -111,24 +114,30 @@ installHUPHandler configPath clusterEnvs loggerVar httpAsyncVar tvar eventBuf = 
             a <- async (startHTTPServer (cfgHttp cfg') tvar)
             atomically $ writeTVar httpAsyncVar (Just a)
           else atomically $ writeTVar httpAsyncVar Nothing
-        logInfo logger "SIGHUP: config reloaded"
+        let newLevel = lcLogLevel (cfgLogging cfg')
+        new <- reopenLogger (lcLogFile (cfgLogging cfg')) newLevel logger
+        atomically $ do
+          writeTVar loggerVar new
+          writeTVar levelVar newLevel
+        logInfo new "SIGHUP: config reloaded"
         now <- getCurrentTime
         forM_ clusterEnvs $ \env ->
           recordEvent eventBuf (Event now (ccName (envCluster env)) EvConfigReloaded Nothing "Config reloaded via SIGHUP")
         ) Nothing
   pure ()
 
-installUSR1Handler :: FilePath -> TVar Logger -> IO ()
-installUSR1Handler logFile loggerVar = do
+installUSR1Handler :: FilePath -> TVar Logger -> TVar LogLevel -> IO ()
+installUSR1Handler logFile loggerVar levelVar = do
   _ <- installHandler sigUSR1 (Catch $ do
     old <- readTVarIO loggerVar
-    new <- reopenLogger logFile old
+    lvl <- readTVarIO levelVar
+    new <- reopenLogger logFile lvl old
     atomically $ writeTVar loggerVar new
     logInfo new "SIGUSR1: log file reopened") Nothing
   pure ()
 
-startAllWorkers :: [ClusterEnv] -> FilePath -> TVarDaemonState -> EventBuffer -> IO [Async ()]
-startAllWorkers clusterEnvs socketPath tvar eventBuf = do
+startAllWorkers :: [ClusterEnv] -> FilePath -> TVarDaemonState -> EventBuffer -> TVar Logger -> FilePath -> TVar LogLevel -> IO [Async ()]
+startAllWorkers clusterEnvs socketPath tvar eventBuf loggerVar logFile levelVar = do
   let clusterMap = Map.fromList
         [ (ccName (envCluster env), env)
         | env <- clusterEnvs
@@ -148,7 +157,7 @@ startAllWorkers clusterEnvs socketPath tvar eventBuf = do
         | (env, reg) <- zip clusterEnvs registries
         ]
 
-  ipcAsync <- async $ startIPCServer tvar clusterMap discoveryMap eventBuf socketPath
+  ipcAsync <- async $ startIPCServer tvar clusterMap discoveryMap eventBuf socketPath loggerVar logFile levelVar
 
   pure $ ipcAsync : monitorWorkers <> refreshWorkers
 

--- a/src/PureMyHA/Config.hs
+++ b/src/PureMyHA/Config.hs
@@ -12,6 +12,8 @@ module PureMyHA.Config
   , HttpConfig (..)
   , CandidatePriority (..)
   , GlobalConfig (..)
+  , LogLevel (..)
+  , parseLogLevel
   , defaultLoggingConfig
   , defaultHttpConfig
   , loadConfig
@@ -42,13 +44,24 @@ data HttpConfig = HttpConfig
 defaultHttpConfig :: HttpConfig
 defaultHttpConfig = HttpConfig False "127.0.0.1" 8080
 
+data LogLevel = LogLevelDebug | LogLevelInfo | LogLevelWarn | LogLevelError
+  deriving (Show, Eq)
+
+parseLogLevel :: Text -> Maybe LogLevel
+parseLogLevel "debug" = Just LogLevelDebug
+parseLogLevel "info"  = Just LogLevelInfo
+parseLogLevel "warn"  = Just LogLevelWarn
+parseLogLevel "error" = Just LogLevelError
+parseLogLevel _       = Nothing
+
 data LoggingConfig = LoggingConfig
   { lcLogFile   :: FilePath
   , lcMaxEvents :: Int      -- ^ In-memory event history buffer size (default 1000)
-  } deriving (Show, Generic)
+  , lcLogLevel  :: LogLevel -- ^ Minimum log level (default: info)
+  } deriving (Show)
 
 defaultLoggingConfig :: LoggingConfig
-defaultLoggingConfig = LoggingConfig "/var/log/puremyha.log" 1000
+defaultLoggingConfig = LoggingConfig "/var/log/puremyha.log" 1000 LogLevelInfo
 
 -- | Global defaults applied to all clusters unless overridden per-cluster.
 data GlobalConfig = GlobalConfig
@@ -185,10 +198,15 @@ instance FromJSON Config where
     pure $ Config clusters logging http
 
 instance FromJSON LoggingConfig where
-  parseJSON = withObject "LoggingConfig" $ \o ->
-    LoggingConfig
-      <$> o .:? "log_file"   .!= "/var/log/puremyha.log"
-      <*> o .:? "max_events" .!= 1000
+  parseJSON = withObject "LoggingConfig" $ \o -> do
+    logFile   <- o .:? "log_file"   .!= "/var/log/puremyha.log"
+    maxEvents <- o .:? "max_events" .!= 1000
+    lvlText   <- o .:? "log_level"  .!= ("info" :: Text)
+    logLevel  <- case parseLogLevel lvlText of
+      Just l  -> pure l
+      Nothing -> fail $ "Invalid log_level: " <> T.unpack lvlText
+                      <> " (expected: debug, info, warn, error)"
+    pure $ LoggingConfig logFile maxEvents logLevel
 
 instance FromJSON GlobalConfig where
   parseJSON = withObject "GlobalConfig" $ \o ->

--- a/src/PureMyHA/IPC/Protocol.hs
+++ b/src/PureMyHA/IPC/Protocol.hs
@@ -185,6 +185,7 @@ data Request
   | ReqPauseFailover  { reqCluster :: Maybe ClusterName }
   | ReqResumeFailover { reqCluster :: Maybe ClusterName }
   | ReqEventHistory   { reqCluster :: Maybe ClusterName, reqLimit :: Maybe Int }
+  | ReqSetLogLevel    { reqLogLevel :: Text }
   deriving (Show, Eq, Generic)
 
 instance ToJSON Request where
@@ -201,6 +202,7 @@ instance ToJSON Request where
   toJSON (ReqPauseFailover  mc)  = object ["type" .= ("pause-failover"   :: Text), "cluster" .= mc]
   toJSON (ReqResumeFailover mc)  = object ["type" .= ("resume-failover"  :: Text), "cluster" .= mc]
   toJSON (ReqEventHistory mc ml) = object ["type" .= ("event-history"   :: Text), "cluster" .= mc, "limit" .= ml]
+  toJSON (ReqSetLogLevel lvl)    = object ["type" .= ("set-log-level"   :: Text), "level" .= lvl]
 
 instance FromJSON Request where
   parseJSON = withObject "Request" $ \o -> do
@@ -219,6 +221,7 @@ instance FromJSON Request where
       "pause-failover"  -> ReqPauseFailover  <$> o .:? "cluster"
       "resume-failover" -> ReqResumeFailover <$> o .:? "cluster"
       "event-history"   -> ReqEventHistory   <$> o .:? "cluster" <*> o .:? "limit"
+      "set-log-level"   -> ReqSetLogLevel    <$> o .:  "level"
       _                 -> fail $ "Unknown request type: " <> show t
 
 -- | IPC Response types

--- a/src/PureMyHA/IPC/Server.hs
+++ b/src/PureMyHA/IPC/Server.hs
@@ -7,7 +7,7 @@ module PureMyHA.IPC.Server
   ) where
 
 import Control.Concurrent.Async (async)
-import Control.Concurrent.STM (atomically)
+import Control.Concurrent.STM (TVar, atomically, readTVarIO, writeTVar)
 import Control.Exception (bracket, try, catch, SomeException, finally)
 import Data.Aeson (encode, eitherDecode)
 import qualified Data.ByteString as BS
@@ -23,6 +23,7 @@ import qualified Network.Socket.ByteString as NSB
 import PureMyHA.Config
 import PureMyHA.Env (ClusterEnv (..), runApp)
 import PureMyHA.Event (EventBuffer, getRecentEvents)
+import PureMyHA.Logger (Logger, reopenLogger)
 import PureMyHA.Failover.Demote (runDemote)
 import PureMyHA.Failover.PauseReplica (runPauseReplica, runResumeReplica)
 import PureMyHA.Failover.ErrantGtid (runFixErrantGtid)
@@ -45,14 +46,17 @@ startIPCServer
   -> ClusterMap
   -> DiscoveryMap
   -> EventBuffer
-  -> FilePath
+  -> FilePath       -- ^ socket path
+  -> TVar Logger    -- ^ for set-log-level
+  -> FilePath       -- ^ log file path
+  -> TVar LogLevel  -- ^ current log level
   -> IO ()
-startIPCServer tvar clusterMap discoveryMap eventBuf socketPath =
+startIPCServer tvar clusterMap discoveryMap eventBuf socketPath loggerVar logFile levelVar =
   bracket (openListenSocket socketPath)
           (\sock -> close sock >> removeLink socketPath `catch` \(_ :: SomeException) -> pure ())
           $ \sock -> do
     listen sock 5
-    acceptLoop sock tvar clusterMap discoveryMap eventBuf
+    acceptLoop sock tvar clusterMap discoveryMap eventBuf loggerVar logFile levelVar
 
 openListenSocket :: FilePath -> IO Socket
 openListenSocket path = do
@@ -61,20 +65,20 @@ openListenSocket path = do
   bind sock (SockAddrUnix path)
   pure sock
 
-acceptLoop :: Socket -> TVarDaemonState -> ClusterMap -> DiscoveryMap -> EventBuffer -> IO ()
-acceptLoop listenSock tvar clusterMap discoveryMap eventBuf = do
+acceptLoop :: Socket -> TVarDaemonState -> ClusterMap -> DiscoveryMap -> EventBuffer -> TVar Logger -> FilePath -> TVar LogLevel -> IO ()
+acceptLoop listenSock tvar clusterMap discoveryMap eventBuf loggerVar logFile levelVar = do
   (clientSock, _) <- accept listenSock
-  _ <- async $ handleClient clientSock tvar clusterMap discoveryMap eventBuf `finally` close clientSock
-  acceptLoop listenSock tvar clusterMap discoveryMap eventBuf
+  _ <- async $ handleClient clientSock tvar clusterMap discoveryMap eventBuf loggerVar logFile levelVar `finally` close clientSock
+  acceptLoop listenSock tvar clusterMap discoveryMap eventBuf loggerVar logFile levelVar
 
-handleClient :: Socket -> TVarDaemonState -> ClusterMap -> DiscoveryMap -> EventBuffer -> IO ()
-handleClient sock tvar clusterMap discoveryMap eventBuf = do
+handleClient :: Socket -> TVarDaemonState -> ClusterMap -> DiscoveryMap -> EventBuffer -> TVar Logger -> FilePath -> TVar LogLevel -> IO ()
+handleClient sock tvar clusterMap discoveryMap eventBuf loggerVar logFile levelVar = do
   result <- try @SomeException $ do
     msg <- recvLine sock
     case eitherDecode (BLC.pack msg) of
       Left err  -> sendResponse sock (RespError (T.pack err))
       Right req -> do
-        resp <- handleRequest tvar clusterMap discoveryMap eventBuf req
+        resp <- handleRequest tvar clusterMap discoveryMap eventBuf loggerVar logFile levelVar req
         sendResponse sock resp
   case result of
     Left _ -> pure ()
@@ -99,8 +103,8 @@ sendResponse sock resp = do
   let bytes = BL.toStrict (encode resp <> BLC.singleton '\n')
   NSB.sendAll sock bytes
 
-handleRequest :: TVarDaemonState -> ClusterMap -> DiscoveryMap -> EventBuffer -> Request -> IO Response
-handleRequest tvar clusterMap discoveryMap eventBuf req = case req of
+handleRequest :: TVarDaemonState -> ClusterMap -> DiscoveryMap -> EventBuffer -> TVar Logger -> FilePath -> TVar LogLevel -> Request -> IO Response
+handleRequest tvar clusterMap discoveryMap eventBuf loggerVar logFile levelVar req = case req of
   ReqStatus mCluster -> do
     ds <- readDaemonState tvar
     let topos = filterClusters mCluster (dsClusters ds)
@@ -202,6 +206,17 @@ handleRequest tvar clusterMap discoveryMap eventBuf req = case req of
   ReqEventHistory mCluster mLimit -> do
     evs <- getRecentEvents eventBuf mCluster mLimit
     pure (RespEventHistory evs)
+
+  ReqSetLogLevel lvlText ->
+    case parseLogLevel lvlText of
+      Nothing  -> pure $ RespError ("Invalid log level: " <> lvlText <> " (expected: debug, info, warn, error)")
+      Just lvl -> do
+        old <- readTVarIO loggerVar
+        new <- reopenLogger logFile lvl old
+        atomically $ do
+          writeTVar loggerVar new
+          writeTVar levelVar lvl
+        pure $ RespOperation (OperationSuccess ("Log level set to " <> lvlText))
 
 filterClusters :: Maybe ClusterName -> Map ClusterName ClusterTopology -> [ClusterTopology]
 filterClusters Nothing  m = Map.elems m

--- a/src/PureMyHA/Logger.hs
+++ b/src/PureMyHA/Logger.hs
@@ -12,15 +12,22 @@ module PureMyHA.Logger
 
 import Data.Text (Text)
 import Katip
+import PureMyHA.Config (LogLevel (..))
 import System.IO (BufferMode (..), IOMode (..), hSetBuffering, openFile)
 
 newtype Logger = Logger LogEnv
 
-initLogger :: FilePath -> IO Logger
-initLogger logFile = do
+logLevelToSeverity :: LogLevel -> Severity
+logLevelToSeverity LogLevelDebug = DebugS
+logLevelToSeverity LogLevelInfo  = InfoS
+logLevelToSeverity LogLevelWarn  = WarningS
+logLevelToSeverity LogLevelError = ErrorS
+
+initLogger :: FilePath -> LogLevel -> IO Logger
+initLogger logFile level = do
   h <- openFile logFile AppendMode
   hSetBuffering h LineBuffering
-  scribe <- mkHandleScribe ColorIfTerminal h (permitItem InfoS) V2
+  scribe <- mkHandleScribe ColorIfTerminal h (permitItem (logLevelToSeverity level)) V2
   le <- initLogEnv "puremyha" "production"
   le' <- registerScribe "file" scribe defaultScribeSettings le
   pure (Logger le')
@@ -30,10 +37,10 @@ closeLogger (Logger le) = do
   _ <- closeScribes le
   pure ()
 
-reopenLogger :: FilePath -> Logger -> IO Logger
-reopenLogger logFile old = do
+reopenLogger :: FilePath -> LogLevel -> Logger -> IO Logger
+reopenLogger logFile level old = do
   closeLogger old
-  initLogger logFile
+  initLogger logFile level
 
 logAt :: Logger -> Severity -> Text -> IO ()
 logAt (Logger le) sev msg =

--- a/test/PureMyHA/ConfigSpec.hs
+++ b/test/PureMyHA/ConfigSpec.hs
@@ -6,9 +6,57 @@ import qualified Data.ByteString.Lazy.Char8 as BLC
 import qualified Data.Yaml as Yaml
 import Test.Hspec
 import PureMyHA.Config
+  ( Config (..), ClusterConfig (..), MonitoringConfig (..)
+  , FailureDetectionConfig (..), FailoverConfig (..)
+  , HooksConfig (..)
+  , LoggingConfig (..), LogLevel (..), parseLogLevel
+  , parseDuration
+  )
 
 spec :: Spec
 spec = do
+  describe "parseLogLevel" $ do
+    it "parses 'debug'" $
+      parseLogLevel "debug" `shouldBe` Just LogLevelDebug
+    it "parses 'info'" $
+      parseLogLevel "info"  `shouldBe` Just LogLevelInfo
+    it "parses 'warn'" $
+      parseLogLevel "warn"  `shouldBe` Just LogLevelWarn
+    it "parses 'error'" $
+      parseLogLevel "error" `shouldBe` Just LogLevelError
+    it "returns Nothing for invalid level" $
+      parseLogLevel "trace" `shouldSatisfy` isNothing
+    it "is case-sensitive" $
+      parseLogLevel "Info"  `shouldSatisfy` isNothing
+
+  describe "LoggingConfig log_level" $ do
+    it "defaults to LogLevelInfo when field is absent" $ do
+      let yaml = BC.pack $ unlines
+            [ "clusters: []"
+            , "logging:"
+            , "  log_file: /tmp/test.log"
+            ]
+      case Yaml.decodeEither' yaml :: Either Yaml.ParseException LoggingConfig of
+        Right lc -> lcLogLevel lc `shouldBe` LogLevelInfo
+        Left err -> expectationFailure (Yaml.prettyPrintParseException err)
+
+    it "parses explicit log_level: debug" $ do
+      let yaml = BC.pack $ unlines
+            [ "log_file: /tmp/test.log"
+            , "log_level: debug"
+            ]
+      case Yaml.decodeEither' yaml :: Either Yaml.ParseException LoggingConfig of
+        Right lc -> lcLogLevel lc `shouldBe` LogLevelDebug
+        Left err -> expectationFailure (Yaml.prettyPrintParseException err)
+
+    it "rejects invalid log_level" $ do
+      let yaml = BC.pack $ unlines
+            [ "log_file: /tmp/test.log"
+            , "log_level: verbose"
+            ]
+      (Yaml.decodeEither' yaml :: Either Yaml.ParseException LoggingConfig)
+        `shouldSatisfy` isLeft
+
   describe "parseDuration" $ do
     it "parses integer seconds" $
       parseDuration "3s" `shouldBe` Right 3


### PR DESCRIPTION
## Summary
- Add `logging.log_level` config field (`debug|info|warn|error`, default `info`) and parse it into katip `Severity` via a new `LogLevel` type
- `puremyha set-log-level <level>` changes log verbosity at runtime without a daemon restart; the IPC override takes precedence until the next SIGHUP
- SIGHUP now reloads `log_level` from config in addition to monitoring/hooks/http
- 9 new unit tests for `parseLogLevel` and `LoggingConfig` parsing

## Test plan
- [x] `cabal test` passes (200 examples, 0 failures)
- [ ] `cabal build all` produces no warnings
- [ ] `puremyha set-log-level debug` returns success and daemon emits debug-level logs
- [ ] `puremyha set-log-level info` restores normal verbosity
- [ ] `puremyha set-log-level invalid` returns an error response
- [ ] `kill -HUP <pid>` resets log level to the value in `config.yaml`

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)