### PR TITLE
feat: add validate-config CLI command for config file validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Inspired by the design philosophy of Orchestrator, PureMyHA provides topology di
 - **Prometheus Metrics Endpoint** — `GET /metrics` exposes cluster health, replication lag, consecutive failures, and node role in Prometheus text exposition format for Grafana and other monitoring stacks
 - **In-Memory Event History** — Maintains a bounded ring buffer of recent events (health changes, failovers, switchovers, config reloads); queryable instantly via `puremyha events` without log parsing
 - **Runtime Log Level Control** — Change log verbosity without restarting the daemon via `puremyha set-log-level debug|info|warn|error` (IPC override takes precedence until the next SIGHUP, which resets to the configured `log_level`)
+- **Config Validation** — `puremyha validate-config` validates the config file offline (no daemon required), reporting YAML parse errors, missing required fields, and semantic constraint violations (port ranges, threshold ordering, etc.)
 
 ## Requirements
 
@@ -311,6 +312,10 @@ puremyha events [--limit=N] [--cluster=<name>]
 # IPC override takes precedence until the next SIGHUP
 puremyha set-log-level debug|info|warn|error
 
+# Validate config file without connecting to the daemon
+# Checks YAML syntax, required fields, and semantic constraints (port ranges, threshold ordering, etc.)
+puremyha validate-config [--config /etc/puremyha/config.yaml]
+
 # JSON output (for scripting / Prometheus exporters)
 puremyha --json status
 puremyha -j topology
@@ -321,6 +326,10 @@ puremyha -j switchover --to db2
 puremyha -j status | jq '.[0].health'
 puremyha -j topology | jq '.[0].nodes[].host'
 puremyha -j events | jq '.[].type'
+
+# validate-config JSON output
+puremyha --json validate-config --config /etc/puremyha/config.yaml
+# → {"valid":true} or {"valid":false,"errors":["cluster 'main': node port 99999 is out of range (1-65535)",...]}
 ```
 
 ## HTTP Health Check Endpoints

--- a/app/CLI/Main.hs
+++ b/app/CLI/Main.hs
@@ -1,11 +1,14 @@
 module Main (main) where
 
+import Data.Aeson (encode, object, (.=))
+import qualified Data.ByteString.Lazy.Char8 as BLC
 import Data.Text (Text)
 import qualified Data.Text as T
 import Options.Applicative
-import System.Exit (exitFailure)
+import System.Exit (exitFailure, exitSuccess)
 import System.IO (hPutStrLn, stderr)
 
+import PureMyHA.Config (loadConfig, validateConfig)
 import PureMyHA.IPC.Client
 import PureMyHA.IPC.Protocol
 import PureMyHA.IPC.Server (defaultSocketPath)
@@ -32,6 +35,7 @@ data Command
   | CmdResumeFailover
   | CmdEvents (Maybe Int)
   | CmdSetLogLevel Text
+  | CmdValidateConfig FilePath
 
 cliOptions :: Parser CLIOptions
 cliOptions = CLIOptions
@@ -78,6 +82,8 @@ cliOptions = CLIOptions
             (info eventsCmd (progDesc "Show recent event history"))
         <> command "set-log-level"
             (info setLogLevelCmd (progDesc "Set daemon log level (debug|info|warn|error)"))
+        <> command "validate-config"
+            (info validateConfigCmd (progDesc "Validate configuration file without connecting to daemon"))
         )
 
 demoteCmd :: Parser Command
@@ -103,6 +109,15 @@ setLogLevelCmd :: Parser Command
 setLogLevelCmd = CmdSetLogLevel
   <$> argument str (metavar "LEVEL" <> help "Log level: debug, info, warn, error")
 
+validateConfigCmd :: Parser Command
+validateConfigCmd = CmdValidateConfig
+  <$> strOption
+        ( long "config"
+        <> short 'c'
+        <> metavar "FILE"
+        <> value "/etc/puremyha/config.yaml"
+        <> help "Path to configuration file" )
+
 switchoverCmd :: Parser Command
 switchoverCmd = CmdSwitchover
   <$> optional (strOption
@@ -121,33 +136,61 @@ main = do
   let socketPath = optSocketPath opts
       mCluster   = optCluster opts
       json       = optJsonOutput opts
-      req = case optCommand opts of
-        CmdStatus           -> ReqStatus mCluster
-        CmdTopology         -> ReqTopology mCluster
-        CmdSwitchover mTo dr  -> ReqSwitchover mCluster mTo dr
-        CmdAckRecovery      -> ReqAckRecovery mCluster
-        CmdErrantGtid       -> ReqErrantGtid mCluster
-        CmdFixErrantGtid    -> ReqFixErrantGtid mCluster
-        CmdDemote host src  -> ReqDemote mCluster host src
-        CmdDiscovery        -> ReqDiscovery mCluster
-        CmdPauseReplica  host -> ReqPauseReplica  mCluster host
-        CmdResumeReplica host -> ReqResumeReplica mCluster host
-        CmdPauseFailover     -> ReqPauseFailover  mCluster
-        CmdResumeFailover    -> ReqResumeFailover mCluster
-        CmdEvents mLimit     -> ReqEventHistory   mCluster mLimit
-        CmdSetLogLevel lvl   -> ReqSetLogLevel lvl
 
-  eResp <- sendRequest socketPath req
-  case eResp of
-    Left err -> do
-      hPutStrLn stderr $ "Error: " <> T.unpack err
-      exitFailure
-    Right resp -> case resp of
-      RespStatus statuses        -> printStatus json statuses
-      RespTopology views         -> printTopology json views
-      RespOperation result       -> printOperationResult json result
-      RespErrantGtids gtids      -> printErrantGtids json gtids
-      RespEventHistory evs       -> printEventHistory json evs
-      RespError msg              -> do
-        hPutStrLn stderr $ "Daemon error: " <> T.unpack msg
-        exitFailure
+  case optCommand opts of
+    CmdValidateConfig configPath -> runValidateConfig configPath json
+    _ -> do
+      let req = case optCommand opts of
+            CmdStatus             -> ReqStatus mCluster
+            CmdTopology           -> ReqTopology mCluster
+            CmdSwitchover mTo dr  -> ReqSwitchover mCluster mTo dr
+            CmdAckRecovery        -> ReqAckRecovery mCluster
+            CmdErrantGtid         -> ReqErrantGtid mCluster
+            CmdFixErrantGtid      -> ReqFixErrantGtid mCluster
+            CmdDemote host src    -> ReqDemote mCluster host src
+            CmdDiscovery          -> ReqDiscovery mCluster
+            CmdPauseReplica  host -> ReqPauseReplica  mCluster host
+            CmdResumeReplica host -> ReqResumeReplica mCluster host
+            CmdPauseFailover      -> ReqPauseFailover  mCluster
+            CmdResumeFailover     -> ReqResumeFailover mCluster
+            CmdEvents mLimit      -> ReqEventHistory   mCluster mLimit
+            CmdSetLogLevel lvl    -> ReqSetLogLevel lvl
+
+      eResp <- sendRequest socketPath req
+      case eResp of
+        Left err -> do
+          hPutStrLn stderr $ "Error: " <> T.unpack err
+          exitFailure
+        Right resp -> case resp of
+          RespStatus statuses        -> printStatus json statuses
+          RespTopology views         -> printTopology json views
+          RespOperation result       -> printOperationResult json result
+          RespErrantGtids gtids      -> printErrantGtids json gtids
+          RespEventHistory evs       -> printEventHistory json evs
+          RespError msg              -> do
+            hPutStrLn stderr $ "Daemon error: " <> T.unpack msg
+            exitFailure
+
+runValidateConfig :: FilePath -> Bool -> IO ()
+runValidateConfig configPath json = do
+  eCfg <- loadConfig configPath
+  case eCfg of
+    Left err -> printResult [err] >> exitFailure
+    Right cfg ->
+      let errs = validateConfig cfg
+      in if null errs
+           then printResult [] >> exitSuccess
+           else printResult errs >> exitFailure
+  where
+    printResult :: [String] -> IO ()
+    printResult [] =
+      if json
+        then putStrLn $ BLC.unpack $ encode $ object ["valid" .= True]
+        else putStrLn "Config is valid."
+    printResult errs =
+      if json
+        then putStrLn $ BLC.unpack $ encode $
+               object ["valid" .= False, "errors" .= errs]
+        else do
+          putStrLn "Config validation failed:"
+          mapM_ (\e -> putStrLn $ "  - " <> e) errs

--- a/e2e/config/invalid-semantic.yaml
+++ b/e2e/config/invalid-semantic.yaml
@@ -1,0 +1,19 @@
+clusters:
+  - name: test-cluster
+    nodes:
+      - host: mysql-source
+        port: 99999
+    credentials:
+      user: puremyha
+      password_file: /etc/puremyha/mysql.pass
+
+global:
+  monitoring:
+    interval: 1s
+    connect_timeout: 2s
+    replication_lag_warning: 5s
+    replication_lag_critical: 10s
+  failure_detection:
+    recovery_block_period: 30s
+  failover:
+    auto_failover: true

--- a/e2e/config/invalid-syntax.yaml
+++ b/e2e/config/invalid-syntax.yaml
@@ -1,0 +1,2 @@
+clusters: [unclosed bracket
+  - name: test

--- a/e2e/tests/16-validate-config.sh
+++ b/e2e/tests/16-validate-config.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Test: validate-config command
+# Verifies that puremyha validate-config correctly validates config files
+# without requiring a daemon connection.
+set -euo pipefail
+source "$(dirname "$0")/../lib/helpers.sh"
+echo "=== Test 16: Config Validation ==="
+
+# 1. Valid config succeeds
+output=$($COMPOSE exec -T puremyhad puremyha validate-config --config /etc/puremyha/puremyha.yaml)
+assert_contains "valid config outputs success message" "Config is valid" "$output"
+
+# 2. Valid config with --json outputs valid=true
+output=$($COMPOSE exec -T puremyhad puremyha --json validate-config --config /etc/puremyha/puremyha.yaml)
+assert_eq "valid config JSON valid=true" "true" "$(echo "$output" | jq -r '.valid')"
+
+# 3. YAML syntax error exits 1
+exit_code=0
+$COMPOSE exec -T puremyhad puremyha validate-config --config /etc/puremyha/invalid-syntax.yaml \
+  || exit_code=$?
+assert_eq "YAML syntax error exits 1" "1" "$exit_code"
+
+# 4. YAML syntax error with --json outputs valid=false
+exit_code=0
+output=$($COMPOSE exec -T puremyhad puremyha --json validate-config \
+  --config /etc/puremyha/invalid-syntax.yaml 2>&1) || exit_code=$?
+assert_eq "YAML syntax error JSON exits 1" "1" "$exit_code"
+assert_eq "YAML syntax error JSON valid=false" "false" "$(echo "$output" | jq -r '.valid')"
+
+# 5. Semantic error exits 1 and mentions the offending field
+exit_code=0
+output=$($COMPOSE exec -T puremyhad puremyha validate-config \
+  --config /etc/puremyha/invalid-semantic.yaml 2>&1) || exit_code=$?
+assert_eq "semantic error exits 1" "1" "$exit_code"
+assert_contains "semantic error mentions port" "port" "$output"
+
+# 6. Semantic error with --json outputs valid=false
+exit_code=0
+output=$($COMPOSE exec -T puremyhad puremyha --json validate-config \
+  --config /etc/puremyha/invalid-semantic.yaml 2>&1) || exit_code=$?
+assert_eq "semantic error JSON exits 1" "1" "$exit_code"
+assert_eq "semantic error JSON valid=false" "false" "$(echo "$output" | jq -r '.valid')"
+
+# 7. Non-existent file exits 1
+exit_code=0
+$COMPOSE exec -T puremyhad puremyha validate-config \
+  --config /etc/puremyha/does-not-exist.yaml || exit_code=$?
+assert_eq "nonexistent file exits 1" "1" "$exit_code"
+
+test_summary

--- a/src/PureMyHA/Config.hs
+++ b/src/PureMyHA/Config.hs
@@ -18,10 +18,12 @@ module PureMyHA.Config
   , defaultHttpConfig
   , loadConfig
   , parseDuration
+  , validateConfig
   ) where
 
 import Control.Applicative ((<|>))
 import Data.Aeson (FromJSON (..), withObject, withText, (.:), (.:?), (.!=))
+import Data.List (group, sort)
 import Data.Text (Text)
 import qualified Data.Text as T
 import Data.Time (NominalDiffTime)
@@ -292,3 +294,68 @@ loadConfig path = do
   pure $ case result of
     Left err  -> Left (show err)
     Right cfg -> Right cfg
+
+-- | Validate a parsed 'Config' for semantic correctness.
+-- Returns a list of error messages; an empty list means the config is valid.
+validateConfig :: Config -> [String]
+validateConfig cfg = clusterErrors ++ httpErrors
+  where
+    clusters = cfgClusters cfg
+
+    clusterErrors
+      | null clusters = ["no clusters defined"]
+      | otherwise     = duplicateClusterErrors ++ concatMap validateCluster clusters
+
+    clusterNames = map ccName clusters
+    duplicateClusterErrors =
+      [ "duplicate cluster name: '" <> T.unpack n <> "'"
+      | n <- duplicates clusterNames ]
+
+    validateCluster :: ClusterConfig -> [String]
+    validateCluster cc = nodeErrors ++ monErrors ++ fdErrors
+      where
+        cname  = T.unpack (ccName cc)
+        prefix = "cluster '" <> cname <> "': "
+        nodes  = ccNodes cc
+
+        nodeErrors
+          | null nodes = [prefix <> "no nodes defined"]
+          | otherwise  = duplicateHostErrors ++ concatMap (validateNode prefix) nodes
+
+        hosts = map ncHost nodes
+        duplicateHostErrors =
+          [ prefix <> "duplicate node host: '" <> T.unpack h <> "'"
+          | h <- duplicates hosts ]
+
+        validateNode :: String -> NodeConfig -> [String]
+        validateNode p nc =
+          [ p <> "node port " <> show (ncPort nc) <> " is out of range (1-65535)"
+          | ncPort nc < 1 || ncPort nc > 65535 ]
+
+        mc = ccMonitoring cc
+        monErrors = concat
+          [ [ prefix <> "monitoring.interval must be > 0"
+            | mcInterval mc <= 0 ]
+          , [ prefix <> "monitoring.connect_timeout must be > 0"
+            | mcConnectTimeout mc <= 0 ]
+          , [ prefix <> "monitoring.replication_lag_warning must be less than replication_lag_critical"
+            | mcReplicationLagWarning mc >= mcReplicationLagCritical mc ]
+          , [ prefix <> "monitoring.connect_retries must be >= 1"
+            | mcConnectRetries mc < 1 ]
+          ]
+
+        fdc = ccFailureDetection cc
+        fdErrors =
+          [ prefix <> "failure_detection.consecutive_failures_for_dead must be >= 1"
+          | fdcConsecutiveFailuresForDead fdc < 1 ]
+
+    httpErrors
+      | not (hcEnabled (cfgHttp cfg)) = []
+      | p < 1 || p > 65535 =
+          ["http.port " <> show p <> " is out of range (1-65535)"]
+      | otherwise = []
+      where p = hcPort (cfgHttp cfg)
+
+-- | Return elements that appear more than once in the list.
+duplicates :: Ord a => [a] -> [a]
+duplicates = map head . filter ((> 1) . length) . group . sort

--- a/test/PureMyHA/ConfigSpec.hs
+++ b/test/PureMyHA/ConfigSpec.hs
@@ -11,6 +11,7 @@ import PureMyHA.Config
   , HooksConfig (..)
   , LoggingConfig (..), LogLevel (..), parseLogLevel
   , parseDuration
+  , validateConfig
   )
 
 spec :: Spec
@@ -310,6 +311,103 @@ spec = do
             ]
       decodeConfig yaml `shouldSatisfy` isLeft
 
+  describe "validateConfig" $ do
+    it "returns no errors for a valid config" $ do
+      let yaml = BC.pack $ unlines
+            [ "clusters:"
+            , "  - name: test"
+            , "    nodes:"
+            , "      - host: db1"
+            , "        port: 3306"
+            , "    credentials:"
+            , "      user: u"
+            , "      password_file: /dev/null"
+            , globalBlock
+            ]
+      case decodeConfig yaml of
+        Left err  -> expectationFailure err
+        Right cfg -> validateConfig cfg `shouldBe` []
+
+    it "reports error for duplicate cluster names" $ do
+      let yaml = BC.pack $ unlines
+            [ "clusters:"
+            , "  - name: test"
+            , "    nodes:"
+            , "      - host: db1"
+            , "    credentials:"
+            , "      user: u"
+            , "      password_file: /dev/null"
+            , "  - name: test"
+            , "    nodes:"
+            , "      - host: db2"
+            , "    credentials:"
+            , "      user: u"
+            , "      password_file: /dev/null"
+            , globalBlock
+            ]
+      case decodeConfig yaml of
+        Left err  -> expectationFailure err
+        Right cfg -> validateConfig cfg `shouldSatisfy` any (isInfixOf "duplicate cluster name")
+
+    it "reports error for port out of range" $ do
+      let yaml = BC.pack $ unlines
+            [ "clusters:"
+            , "  - name: test"
+            , "    nodes:"
+            , "      - host: db1"
+            , "        port: 99999"
+            , "    credentials:"
+            , "      user: u"
+            , "      password_file: /dev/null"
+            , globalBlock
+            ]
+      case decodeConfig yaml of
+        Left err  -> expectationFailure err
+        Right cfg -> validateConfig cfg `shouldSatisfy` any (isInfixOf "port")
+
+    it "reports error when replication_lag_warning >= replication_lag_critical" $ do
+      let yaml = BC.pack $ unlines
+            [ "clusters:"
+            , "  - name: test"
+            , "    nodes:"
+            , "      - host: db1"
+            , "    credentials:"
+            , "      user: u"
+            , "      password_file: /dev/null"
+            , "    monitoring:"
+            , "      interval: 3s"
+            , "      connect_timeout: 2s"
+            , "      replication_lag_warning: 30s"
+            , "      replication_lag_critical: 10s"
+            , "global:"
+            , "  failure_detection:"
+            , "    recovery_block_period: 3600s"
+            , "  failover:"
+            , "    auto_failover: true"
+            ]
+      case decodeConfig yaml of
+        Left err  -> expectationFailure err
+        Right cfg -> validateConfig cfg `shouldSatisfy`
+          any (isInfixOf "replication_lag_warning")
+
+    it "reports error for duplicate node hosts within a cluster" $ do
+      let yaml = BC.pack $ unlines
+            [ "clusters:"
+            , "  - name: test"
+            , "    nodes:"
+            , "      - host: db1"
+            , "        port: 3306"
+            , "      - host: db1"
+            , "        port: 3307"
+            , "    credentials:"
+            , "      user: u"
+            , "      password_file: /dev/null"
+            , globalBlock
+            ]
+      case decodeConfig yaml of
+        Left err  -> expectationFailure err
+        Right cfg -> validateConfig cfg `shouldSatisfy` any (isInfixOf "duplicate node host")
+
 -- | Shared global block (without hooks) used across test cases.
 -- Note: appended lines after this block extend the global section.
 globalBlock :: String
@@ -337,3 +435,12 @@ isLeft _        = False
 isNothing :: Maybe a -> Bool
 isNothing Nothing = True
 isNothing _       = False
+
+isInfixOf :: String -> String -> Bool
+isInfixOf needle haystack = any (needle `isPrefixOf`) (tails haystack)
+  where
+    isPrefixOf [] _          = True
+    isPrefixOf _ []          = False
+    isPrefixOf (x:xs) (y:ys) = x == y && isPrefixOf xs ys
+    tails []         = [[]]
+    tails xs@(_:rest) = xs : tails rest


### PR DESCRIPTION
Closes #46

## Summary

- Add `puremyha validate-config [--config FILE]` command that validates the config file without connecting to the daemon
- Add `validateConfig :: Config -> [String]` to `PureMyHA.Config` for semantic validation (port ranges, threshold ordering, duplicate checks, etc.)
- Add unit tests in `ConfigSpec` and E2E test `e2e/tests/16-validate-config.sh`
- Update `README.md` with feature description and usage examples

## Validation checks

| Check | Field |
|-------|-------|
| At least one cluster defined | `clusters` |
| No duplicate cluster names | `clusters[].name` |
| Each cluster has at least one node | `clusters[].nodes` |
| No duplicate node hosts within a cluster | `clusters[].nodes[].host` |
| Node port in range 1–65535 | `clusters[].nodes[].port` |
| `interval > 0`, `connect_timeout > 0` | `monitoring` |
| `replication_lag_warning < replication_lag_critical` | `monitoring` |
| `connect_retries >= 1` | `monitoring` |
| `consecutive_failures_for_dead >= 1` | `failure_detection` |
| HTTP port in range 1–65535 (when HTTP enabled) | `http.port` |

## Test plan

- [x] `cabal build all` — no warnings
- [x] `cabal test` — 196 examples, 0 failures (5 new `validateConfig` tests)
- [ ] `cd e2e && ./run-all.sh 16` — E2E test for `validate-config` (7 scenarios: valid config, JSON output, YAML syntax error, semantic error, nonexistent file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)