### PR TITLE
feat: support runtime log level changes via IPC and config reload

### DIFF
--- a/app/Daemon/Main.hs
+++ b/app/Daemon/Main.hs
@@ -22,7 +22,7 @@ import PureMyHA.Env (ClusterEnv (..), runApp)
 import PureMyHA.Event (EventBuffer, newEventBuffer, recordEvent)
 import PureMyHA.HTTP.Server (startHTTPServer)
 import PureMyHA.IPC.Server (startIPCServer, defaultSocketPath, DiscoveryAction)
-import PureMyHA.Logger (Logger, initLogger, closeLogger, reopenLogger, logInfo, logWarn)
+import PureMyHA.Logger (Logger, initLogger, closeLogger, reopenLogger, setLogLevel, logInfo, logWarn)
 import PureMyHA.Monitor.Worker (startMonitorWorkers, startTopologyRefreshWorker, WorkerRegistry, runWorker)
 import PureMyHA.Topology.Discovery (discoverTopology, buildInitialTopology)
 import PureMyHA.Topology.State
@@ -52,10 +52,8 @@ main = do
   opts <- execParser (info (daemonOptions <**> helper)
     (fullDesc <> progDesc "PureMyHA daemon" <> header "puremyhad"))
   cfg       <- loadAndValidateConfig (optConfigPath opts)
-  let logCfg  = cfgLogging cfg
-      initLvl = lcLogLevel logCfg
-  levelVar  <- newTVarIO initLvl
-  loggerVar <- newTVarIO =<< initLogger (lcLogFile logCfg) initLvl
+  let logCfg = cfgLogging cfg
+  loggerVar <- newTVarIO =<< initLogger (lcLogFile logCfg) (lcLogLevel logCfg)
   eventBuf  <- newEventBuffer (lcMaxEvents logCfg)
 
   tvar        <- newDaemonState
@@ -65,10 +63,10 @@ main = do
   clusterEnvs      <- mapM (initCluster tvar loggerVar eventBuf) clusterPasswords
 
   httpAsyncVar <- newTVarIO Nothing
-  installHUPHandler (optConfigPath opts) clusterEnvs loggerVar httpAsyncVar tvar eventBuf levelVar
-  installUSR1Handler (lcLogFile (cfgLogging cfg)) loggerVar levelVar
+  installHUPHandler (optConfigPath opts) clusterEnvs loggerVar httpAsyncVar tvar eventBuf
+  installUSR1Handler (lcLogFile (cfgLogging cfg)) loggerVar
 
-  allWorkers <- startAllWorkers clusterEnvs (optSocketPath opts) tvar eventBuf loggerVar (lcLogFile (cfgLogging cfg)) levelVar
+  allWorkers <- startAllWorkers clusterEnvs (optSocketPath opts) tvar eventBuf loggerVar
   when (hcEnabled (cfgHttp cfg)) $ do
     a <- async (startHTTPServer (cfgHttp cfg) tvar)
     atomically $ writeTVar httpAsyncVar (Just a)
@@ -92,8 +90,8 @@ installShutdownHandlers = do
   _ <- installHandler sigINT  h Nothing
   pure shutdownVar
 
-installHUPHandler :: FilePath -> [ClusterEnv] -> TVar Logger -> TVar (Maybe (Async ())) -> TVarDaemonState -> EventBuffer -> TVar LogLevel -> IO ()
-installHUPHandler configPath clusterEnvs loggerVar httpAsyncVar tvar eventBuf levelVar = do
+installHUPHandler :: FilePath -> [ClusterEnv] -> TVar Logger -> TVar (Maybe (Async ())) -> TVarDaemonState -> EventBuffer -> IO ()
+installHUPHandler configPath clusterEnvs loggerVar httpAsyncVar tvar eventBuf = do
   _ <- installHandler sigHUP (Catch $ do
     logger <- readTVarIO loggerVar
     eCfg' <- loadConfig configPath
@@ -114,30 +112,25 @@ installHUPHandler configPath clusterEnvs loggerVar httpAsyncVar tvar eventBuf le
             a <- async (startHTTPServer (cfgHttp cfg') tvar)
             atomically $ writeTVar httpAsyncVar (Just a)
           else atomically $ writeTVar httpAsyncVar Nothing
-        let newLevel = lcLogLevel (cfgLogging cfg')
-        new <- reopenLogger (lcLogFile (cfgLogging cfg')) newLevel logger
-        atomically $ do
-          writeTVar loggerVar new
-          writeTVar levelVar newLevel
-        logInfo new "SIGHUP: config reloaded"
+        setLogLevel logger (lcLogLevel (cfgLogging cfg'))
+        logInfo logger "SIGHUP: config reloaded"
         now <- getCurrentTime
         forM_ clusterEnvs $ \env ->
           recordEvent eventBuf (Event now (ccName (envCluster env)) EvConfigReloaded Nothing "Config reloaded via SIGHUP")
         ) Nothing
   pure ()
 
-installUSR1Handler :: FilePath -> TVar Logger -> TVar LogLevel -> IO ()
-installUSR1Handler logFile loggerVar levelVar = do
+installUSR1Handler :: FilePath -> TVar Logger -> IO ()
+installUSR1Handler logFile loggerVar = do
   _ <- installHandler sigUSR1 (Catch $ do
     old <- readTVarIO loggerVar
-    lvl <- readTVarIO levelVar
-    new <- reopenLogger logFile lvl old
+    new <- reopenLogger logFile old
     atomically $ writeTVar loggerVar new
     logInfo new "SIGUSR1: log file reopened") Nothing
   pure ()
 
-startAllWorkers :: [ClusterEnv] -> FilePath -> TVarDaemonState -> EventBuffer -> TVar Logger -> FilePath -> TVar LogLevel -> IO [Async ()]
-startAllWorkers clusterEnvs socketPath tvar eventBuf loggerVar logFile levelVar = do
+startAllWorkers :: [ClusterEnv] -> FilePath -> TVarDaemonState -> EventBuffer -> TVar Logger -> IO [Async ()]
+startAllWorkers clusterEnvs socketPath tvar eventBuf loggerVar = do
   let clusterMap = Map.fromList
         [ (ccName (envCluster env), env)
         | env <- clusterEnvs
@@ -157,7 +150,7 @@ startAllWorkers clusterEnvs socketPath tvar eventBuf loggerVar logFile levelVar 
         | (env, reg) <- zip clusterEnvs registries
         ]
 
-  ipcAsync <- async $ startIPCServer tvar clusterMap discoveryMap eventBuf socketPath loggerVar logFile levelVar
+  ipcAsync <- async $ startIPCServer tvar clusterMap discoveryMap eventBuf socketPath loggerVar
 
   pure $ ipcAsync : monitorWorkers <> refreshWorkers
 

--- a/src/PureMyHA/IPC/Server.hs
+++ b/src/PureMyHA/IPC/Server.hs
@@ -7,7 +7,7 @@ module PureMyHA.IPC.Server
   ) where
 
 import Control.Concurrent.Async (async)
-import Control.Concurrent.STM (TVar, atomically, readTVarIO, writeTVar)
+import Control.Concurrent.STM (TVar, atomically, readTVarIO)
 import Control.Exception (bracket, try, catch, SomeException, finally)
 import Data.Aeson (encode, eitherDecode)
 import qualified Data.ByteString as BS
@@ -23,7 +23,7 @@ import qualified Network.Socket.ByteString as NSB
 import PureMyHA.Config
 import PureMyHA.Env (ClusterEnv (..), runApp)
 import PureMyHA.Event (EventBuffer, getRecentEvents)
-import PureMyHA.Logger (Logger, reopenLogger)
+import PureMyHA.Logger (Logger, setLogLevel)
 import PureMyHA.Failover.Demote (runDemote)
 import PureMyHA.Failover.PauseReplica (runPauseReplica, runResumeReplica)
 import PureMyHA.Failover.ErrantGtid (runFixErrantGtid)
@@ -46,17 +46,15 @@ startIPCServer
   -> ClusterMap
   -> DiscoveryMap
   -> EventBuffer
-  -> FilePath       -- ^ socket path
-  -> TVar Logger    -- ^ for set-log-level
-  -> FilePath       -- ^ log file path
-  -> TVar LogLevel  -- ^ current log level
+  -> FilePath    -- ^ socket path
+  -> TVar Logger -- ^ for set-log-level
   -> IO ()
-startIPCServer tvar clusterMap discoveryMap eventBuf socketPath loggerVar logFile levelVar =
+startIPCServer tvar clusterMap discoveryMap eventBuf socketPath loggerVar =
   bracket (openListenSocket socketPath)
           (\sock -> close sock >> removeLink socketPath `catch` \(_ :: SomeException) -> pure ())
           $ \sock -> do
     listen sock 5
-    acceptLoop sock tvar clusterMap discoveryMap eventBuf loggerVar logFile levelVar
+    acceptLoop sock tvar clusterMap discoveryMap eventBuf loggerVar
 
 openListenSocket :: FilePath -> IO Socket
 openListenSocket path = do
@@ -65,20 +63,20 @@ openListenSocket path = do
   bind sock (SockAddrUnix path)
   pure sock
 
-acceptLoop :: Socket -> TVarDaemonState -> ClusterMap -> DiscoveryMap -> EventBuffer -> TVar Logger -> FilePath -> TVar LogLevel -> IO ()
-acceptLoop listenSock tvar clusterMap discoveryMap eventBuf loggerVar logFile levelVar = do
+acceptLoop :: Socket -> TVarDaemonState -> ClusterMap -> DiscoveryMap -> EventBuffer -> TVar Logger -> IO ()
+acceptLoop listenSock tvar clusterMap discoveryMap eventBuf loggerVar = do
   (clientSock, _) <- accept listenSock
-  _ <- async $ handleClient clientSock tvar clusterMap discoveryMap eventBuf loggerVar logFile levelVar `finally` close clientSock
-  acceptLoop listenSock tvar clusterMap discoveryMap eventBuf loggerVar logFile levelVar
+  _ <- async $ handleClient clientSock tvar clusterMap discoveryMap eventBuf loggerVar `finally` close clientSock
+  acceptLoop listenSock tvar clusterMap discoveryMap eventBuf loggerVar
 
-handleClient :: Socket -> TVarDaemonState -> ClusterMap -> DiscoveryMap -> EventBuffer -> TVar Logger -> FilePath -> TVar LogLevel -> IO ()
-handleClient sock tvar clusterMap discoveryMap eventBuf loggerVar logFile levelVar = do
+handleClient :: Socket -> TVarDaemonState -> ClusterMap -> DiscoveryMap -> EventBuffer -> TVar Logger -> IO ()
+handleClient sock tvar clusterMap discoveryMap eventBuf loggerVar = do
   result <- try @SomeException $ do
     msg <- recvLine sock
     case eitherDecode (BLC.pack msg) of
       Left err  -> sendResponse sock (RespError (T.pack err))
       Right req -> do
-        resp <- handleRequest tvar clusterMap discoveryMap eventBuf loggerVar logFile levelVar req
+        resp <- handleRequest tvar clusterMap discoveryMap eventBuf loggerVar req
         sendResponse sock resp
   case result of
     Left _ -> pure ()
@@ -103,8 +101,8 @@ sendResponse sock resp = do
   let bytes = BL.toStrict (encode resp <> BLC.singleton '\n')
   NSB.sendAll sock bytes
 
-handleRequest :: TVarDaemonState -> ClusterMap -> DiscoveryMap -> EventBuffer -> TVar Logger -> FilePath -> TVar LogLevel -> Request -> IO Response
-handleRequest tvar clusterMap discoveryMap eventBuf loggerVar logFile levelVar req = case req of
+handleRequest :: TVarDaemonState -> ClusterMap -> DiscoveryMap -> EventBuffer -> TVar Logger -> Request -> IO Response
+handleRequest tvar clusterMap discoveryMap eventBuf loggerVar req = case req of
   ReqStatus mCluster -> do
     ds <- readDaemonState tvar
     let topos = filterClusters mCluster (dsClusters ds)
@@ -211,11 +209,8 @@ handleRequest tvar clusterMap discoveryMap eventBuf loggerVar logFile levelVar r
     case parseLogLevel lvlText of
       Nothing  -> pure $ RespError ("Invalid log level: " <> lvlText <> " (expected: debug, info, warn, error)")
       Just lvl -> do
-        old <- readTVarIO loggerVar
-        new <- reopenLogger logFile lvl old
-        atomically $ do
-          writeTVar loggerVar new
-          writeTVar levelVar lvl
+        logger <- readTVarIO loggerVar
+        setLogLevel logger lvl
         pure $ RespOperation (OperationSuccess ("Log level set to " <> lvlText))
 
 filterClusters :: Maybe ClusterName -> Map ClusterName ClusterTopology -> [ClusterTopology]

--- a/src/PureMyHA/Logger.hs
+++ b/src/PureMyHA/Logger.hs
@@ -3,6 +3,7 @@ module PureMyHA.Logger
   , initLogger
   , closeLogger
   , reopenLogger
+  , setLogLevel
   , logDebug
   , logInfo
   , logWarn
@@ -10,12 +11,13 @@ module PureMyHA.Logger
   , nullLogger
   ) where
 
+import Control.Concurrent.STM (TVar, atomically, newTVarIO, readTVarIO, writeTVar)
 import Data.Text (Text)
 import Katip
 import PureMyHA.Config (LogLevel (..))
 import System.IO (BufferMode (..), IOMode (..), hSetBuffering, openFile)
 
-newtype Logger = Logger LogEnv
+data Logger = Logger LogEnv (TVar Severity)
 
 logLevelToSeverity :: LogLevel -> Severity
 logLevelToSeverity LogLevelDebug = DebugS
@@ -27,24 +29,41 @@ initLogger :: FilePath -> LogLevel -> IO Logger
 initLogger logFile level = do
   h <- openFile logFile AppendMode
   hSetBuffering h LineBuffering
-  scribe <- mkHandleScribe ColorIfTerminal h (permitItem (logLevelToSeverity level)) V2
+  scribe <- mkHandleScribe ColorIfTerminal h (permitItem DebugS) V2
   le <- initLogEnv "puremyha" "production"
   le' <- registerScribe "file" scribe defaultScribeSettings le
-  pure (Logger le')
+  sevVar <- newTVarIO (logLevelToSeverity level)
+  pure (Logger le' sevVar)
 
 closeLogger :: Logger -> IO ()
-closeLogger (Logger le) = do
+closeLogger (Logger le _) = do
   _ <- closeScribes le
   pure ()
 
-reopenLogger :: FilePath -> LogLevel -> Logger -> IO Logger
-reopenLogger logFile level old = do
+-- | Reopen the log file (e.g. after log rotation via SIGUSR1).
+-- Reuses the existing severity TVar so any runtime log level override is preserved.
+reopenLogger :: FilePath -> Logger -> IO Logger
+reopenLogger logFile old@(Logger _ sevVar) = do
   closeLogger old
-  initLogger logFile level
+  h <- openFile logFile AppendMode
+  hSetBuffering h LineBuffering
+  scribe <- mkHandleScribe ColorIfTerminal h (permitItem DebugS) V2
+  le <- initLogEnv "puremyha" "production"
+  le' <- registerScribe "file" scribe defaultScribeSettings le
+  pure (Logger le' sevVar)
+
+-- | Atomically update the minimum log level. Takes effect immediately on the
+-- next log call without reopening or closing the log file.
+setLogLevel :: Logger -> LogLevel -> IO ()
+setLogLevel (Logger _ sevVar) level =
+  atomically $ writeTVar sevVar (logLevelToSeverity level)
 
 logAt :: Logger -> Severity -> Text -> IO ()
-logAt (Logger le) sev msg =
-  runKatipT le $ logMsg "puremyha" sev (logStr msg)
+logAt (Logger le sevVar) sev msg = do
+  minSev <- readTVarIO sevVar
+  if sev >= minSev
+    then runKatipT le $ logMsg "puremyha" sev (logStr msg)
+    else pure ()
 
 logDebug :: Logger -> Text -> IO ()
 logDebug l = logAt l DebugS
@@ -61,4 +80,5 @@ logError l = logAt l ErrorS
 nullLogger :: IO Logger
 nullLogger = do
   le <- initLogEnv "test" "test"
-  pure (Logger le)
+  sevVar <- newTVarIO InfoS
+  pure (Logger le sevVar)


### PR DESCRIPTION
## Summary

- Add `logging.log_level` config field (`debug|info|warn|error`, default `info`) parsed into a new `LogLevel` type; converted to katip `Severity` inside `Logger`
- `puremyha set-log-level <level>` changes log verbosity at runtime without a daemon restart via a new `setLogLevel` function (atomic `TVar` write — no file I/O)
- SIGHUP reloads `log_level` from config atomically; the IPC override takes precedence until the next SIGHUP
- `reopenLogger` (SIGUSR1 log rotation) reuses the existing `TVar Severity` so any runtime level override survives rotation
- 9 new unit tests for `parseLogLevel` and `LoggingConfig` parsing

## Design note

An earlier implementation changed the log level by reopening the log file (`closeScribes` + `openFile`) inside the SIGHUP handler. This caused E2E test `15-event-history.sh` step [4] to fail because an exception or timing issue in `reopenLogger` could prevent the subsequent `recordEvent` call from running.

The fix stores `TVar Severity` inside `Logger` and filters in `logAt`, making log level changes a pure atomic write with no risk of interrupting signal handler execution.

## Test plan
- [x] `cabal build all` — no warnings
- [x] `cabal test` — 200 examples, 0 failures
- [x] E2E `15-event-history.sh` — 14 passed, 0 failed (including step [4] ConfigReloaded after SIGHUP)
- [ ] `puremyha set-log-level debug` returns success; daemon emits debug-level logs
- [ ] `puremyha set-log-level info` restores normal verbosity
- [ ] `puremyha set-log-level invalid` returns an error response
- [ ] `kill -HUP <pid>` resets log level to the value in `config.yaml`

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)