### PR TITLE
refactor: introduce DbCredentials to encapsulate MySQL user/password pair

### DIFF
--- a/app/Daemon/Main.hs
+++ b/app/Daemon/Main.hs
@@ -202,7 +202,10 @@ loadClusterPasswords cc = do
   monPw <- loadPassword (ccCredentials cc)
   let replCreds = fromMaybe (ccCredentials cc) (ccReplicationCredentials cc)
   replPw <- loadPassword replCreds
-  pure $ ClusterPasswords monPw (credUser replCreds) replPw
+  pure $ ClusterPasswords
+    { cpMonCredentials  = DbCredentials (credUser (ccCredentials cc)) monPw
+    , cpReplCredentials = DbCredentials (credUser replCreds) replPw
+    }
 
 loadPassword :: Credentials -> IO Text
 loadPassword creds = do

--- a/src/PureMyHA/Config.hs
+++ b/src/PureMyHA/Config.hs
@@ -3,6 +3,7 @@ module PureMyHA.Config
   , ClusterConfig (..)
   , NodeConfig (..)
   , Credentials (..)
+  , DbCredentials (..)
   , ClusterPasswords (..)
   , MonitoringConfig (..)
   , FailureDetectionConfig (..)
@@ -99,10 +100,14 @@ data RawClusterConfig = RawClusterConfig
   , rccHooks                  :: Maybe HooksConfig
   } deriving (Show, Generic)
 
+data DbCredentials = DbCredentials
+  { dbUser     :: Text
+  , dbPassword :: Text
+  } deriving (Show)
+
 data ClusterPasswords = ClusterPasswords
-  { cpPassword     :: Text   -- ^ monitoring/management password
-  , cpReplUser     :: Text   -- ^ replication user
-  , cpReplPassword :: Text   -- ^ replication password
+  { cpMonCredentials  :: DbCredentials  -- ^ monitoring/management credentials
+  , cpReplCredentials :: DbCredentials  -- ^ replication credentials
   } deriving (Show)
 
 data NodeConfig = NodeConfig

--- a/src/PureMyHA/Env.hs
+++ b/src/PureMyHA/Env.hs
@@ -5,8 +5,8 @@ module PureMyHA.Env
   , getMonitoringConfig
   , getHooksConfig
   , getClusterName
-  , getMySQLUser
-  , getMonPassword
+  , getMonCredentials
+  , getReplCredentials
   , appLogInfo
   , appLogWarn
   , appLogError
@@ -52,11 +52,11 @@ getHooksConfig = asks envHooks >>= liftIO . readTVarIO
 getClusterName :: MonadReader ClusterEnv m => m ClusterName
 getClusterName = asks (ccName . envCluster)
 
-getMySQLUser :: MonadReader ClusterEnv m => m Text
-getMySQLUser = asks (credUser . ccCredentials . envCluster)
+getMonCredentials :: MonadReader ClusterEnv m => m DbCredentials
+getMonCredentials = asks (cpMonCredentials . envPasswords)
 
-getMonPassword :: MonadReader ClusterEnv m => m Text
-getMonPassword = asks (cpPassword . envPasswords)
+getReplCredentials :: MonadReader ClusterEnv m => m DbCredentials
+getReplCredentials = asks (cpReplCredentials . envPasswords)
 
 appLogInfo, appLogWarn, appLogError :: (MonadReader ClusterEnv m, MonadIO m) => Text -> m ()
 appLogInfo  = withLogger logInfo

--- a/src/PureMyHA/Failover/Auto.hs
+++ b/src/PureMyHA/Failover/Auto.hs
@@ -156,11 +156,10 @@ commitFailoverState candidateId topo now = do
 
 promoteCandidate :: NodeId -> Int -> App (Either Text ())
 promoteCandidate nid waitTimeout = do
-  user <- getMySQLUser
-  password <- getMonPassword
+  creds <- getMonCredentials
   clusterName <- getClusterName
   logger <- asks envLogger >>= liftIO . readTVarIO
-  let ci = makeConnectInfo nid user password
+  let ci = makeConnectInfo nid creds
   liftIO $ do
     result <- withNodeConn ci $ \conn -> do
       caughtUp <- waitForRelayLogApply conn waitTimeout
@@ -176,14 +175,13 @@ promoteCandidate nid waitTimeout = do
 
 reconnectReplica :: NodeId -> NodeState -> App ()
 reconnectReplica newSourceId ns = do
-  user <- getMySQLUser
-  password <- getMonPassword
-  pws <- asks envPasswords
-  let ci = makeConnectInfo (nsNodeId ns) user password
+  monCreds  <- getMonCredentials
+  replCreds <- getReplCredentials
+  let ci = makeConnectInfo (nsNodeId ns) monCreds
   liftIO $ do
     _ <- withNodeConn ci $ \conn -> do
       stopReplica conn
-      changeReplicationSourceTo conn (nodeHost newSourceId) (nodePort newSourceId) (cpReplUser pws) (cpReplPassword pws)
+      changeReplicationSourceTo conn (nodeHost newSourceId) (nodePort newSourceId) replCreds
       setReadOnly conn
       startReplica conn
     pure ()

--- a/src/PureMyHA/Failover/Demote.hs
+++ b/src/PureMyHA/Failover/Demote.hs
@@ -4,8 +4,8 @@ import Control.Concurrent.STM (atomically)
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Reader (asks)
 import Data.Text (Text)
-import PureMyHA.Config (ClusterConfig (..), ClusterPasswords (..))
-import PureMyHA.Env (App, ClusterEnv (..), getMySQLUser, getMonPassword, appLogInfo, appLogError)
+import PureMyHA.Config (ClusterConfig (..))
+import PureMyHA.Env (App, ClusterEnv (..), getMonCredentials, getReplCredentials, appLogInfo, appLogError)
 import PureMyHA.MySQL.Connection (makeConnectInfo, withNodeConn)
 import PureMyHA.MySQL.Query
   ( stopReplica, setReadOnly, changeReplicationSourceTo, startReplica )
@@ -18,11 +18,10 @@ runDemote
   -> Text       -- ^ new source host
   -> App (Either Text ())
 runDemote demoteHost srcHost = do
-  tvar <- asks envDaemonState
-  cc   <- asks envCluster
-  pws  <- asks envPasswords
-  user <- getMySQLUser
-  password <- getMonPassword
+  tvar      <- asks envDaemonState
+  cc        <- asks envCluster
+  monCreds  <- getMonCredentials
+  replCreds <- getReplCredentials
   mTopo <- liftIO $ getClusterTopology tvar (ccName cc)
   case mTopo of
     Nothing -> pure (Left "Cluster not found")
@@ -33,13 +32,13 @@ runDemote demoteHost srcHost = do
         (Just demoteNs, Just srcNs) -> do
           let demoteId = nsNodeId demoteNs
               srcId    = nsNodeId srcNs
-              ci       = makeConnectInfo demoteId user password
+              ci       = makeConnectInfo demoteId monCreds
           appLogInfo $ "[" <> ccName cc <> "] Demoting " <> demoteHost
                     <> " to replica under " <> srcHost
           result <- liftIO $ withNodeConn ci $ \conn -> do
             stopReplica conn
             setReadOnly conn
-            changeReplicationSourceTo conn (nodeHost srcId) (nodePort srcId) (cpReplUser pws) (cpReplPassword pws)
+            changeReplicationSourceTo conn (nodeHost srcId) (nodePort srcId) replCreds
             startReplica conn
           case result of
             Left err -> do

--- a/src/PureMyHA/Failover/ErrantGtid.hs
+++ b/src/PureMyHA/Failover/ErrantGtid.hs
@@ -11,7 +11,7 @@ import qualified Data.Map.Strict as Map
 import Data.Text (Text)
 import qualified Data.Text as T
 import PureMyHA.Config (ClusterConfig (..))
-import PureMyHA.Env (App, ClusterEnv (..), getMySQLUser, getMonPassword)
+import PureMyHA.Env (App, ClusterEnv (..), getMonCredentials)
 import PureMyHA.MySQL.Connection (makeConnectInfo, withNodeConn)
 import PureMyHA.MySQL.GTID (GtidEntry (..), GtidInterval (..), parseGtidIntervals)
 import PureMyHA.MySQL.Query (injectEmptyTransaction)
@@ -33,10 +33,9 @@ collectErrantGtids = nub . concatMap (concatMap expandGtidEntry)
 -- | Fix errant GTIDs by injecting empty transactions on the source
 runFixErrantGtid :: App (Either Text ())
 runFixErrantGtid = do
-  tvar <- asks (envDaemonState)
-  cc   <- asks (envCluster)
-  user <- getMySQLUser
-  password <- getMonPassword
+  tvar  <- asks (envDaemonState)
+  cc    <- asks (envCluster)
+  creds <- getMonCredentials
   liftIO $ do
     mTopo <- getClusterTopology tvar (ccName cc)
     case mTopo of
@@ -55,7 +54,7 @@ runFixErrantGtid = do
                   Left err -> pure (Left ("GTID parse error: " <> T.pack err))
                   Right entryLists -> do
                     let gtids = collectErrantGtids entryLists
-                    let srcCi = makeConnectInfo srcId user password
+                    let srcCi = makeConnectInfo srcId creds
                     result <- withNodeConn srcCi $ \conn ->
                       mapM_ (injectEmptyTransaction conn) gtids
                     case result of

--- a/src/PureMyHA/Failover/PauseReplica.hs
+++ b/src/PureMyHA/Failover/PauseReplica.hs
@@ -6,7 +6,7 @@ import Control.Monad.Reader (asks)
 import Data.Text (Text)
 import Database.MySQL.Base (MySQLConn)
 import PureMyHA.Config (ClusterConfig (..))
-import PureMyHA.Env (App, ClusterEnv (..), getMySQLUser, getMonPassword, appLogInfo, appLogError)
+import PureMyHA.Env (App, ClusterEnv (..), getMonCredentials, appLogInfo, appLogError)
 import PureMyHA.MySQL.Connection (makeConnectInfo, withNodeConn)
 import PureMyHA.MySQL.Query (stopReplica, startReplica)
 import PureMyHA.Topology.State (getClusterTopology, updateNodeState)
@@ -34,10 +34,9 @@ withTargetNode
   -> (NodeState -> NodeState)        -- ^ state update on success
   -> App (Either Text ())
 withTargetNode actionName targetHost mysqlAction stateUpdate = do
-  tvar <- asks envDaemonState
-  cc   <- asks envCluster
-  user <- getMySQLUser
-  password <- getMonPassword
+  tvar  <- asks envDaemonState
+  cc    <- asks envCluster
+  creds <- getMonCredentials
   mTopo <- liftIO $ getClusterTopology tvar (ccName cc)
   case mTopo of
     Nothing -> pure (Left "Cluster not found")
@@ -45,7 +44,7 @@ withTargetNode actionName targetHost mysqlAction stateUpdate = do
       case findNodeByHost targetHost (ctNodes topo) of
         Nothing -> pure (Left $ "Node not found: " <> targetHost)
         Just targetNs -> do
-          let ci = makeConnectInfo (nsNodeId targetNs) user password
+          let ci = makeConnectInfo (nsNodeId targetNs) creds
           appLogInfo $ "[" <> ccName cc <> "] " <> actionName <> " replication on " <> targetHost
           result <- liftIO $ withNodeConn ci $ \conn -> mysqlAction conn
           case result of

--- a/src/PureMyHA/Failover/Switchover.hs
+++ b/src/PureMyHA/Failover/Switchover.hs
@@ -77,14 +77,13 @@ doSwitchover
   -> ClusterTopology
   -> App (Either Text ())
 doSwitchover candidateId oldSourceId oldSourceHost topo = do
-  cc   <- asks envCluster
-  user <- getMySQLUser
-  password <- getMonPassword
+  cc    <- asks envCluster
+  creds <- getMonCredentials
   -- Step 1: Set old source to read_only (abort on failure to prevent split-brain)
   readOnlyResult <- liftIO $ case oldSourceId of
     Nothing -> pure (Right ())
     Just srcId -> do
-      let srcCi = makeConnectInfo srcId user password
+      let srcCi = makeConnectInfo srcId creds
       withNodeConn srcCi setReadOnly
   case readOnlyResult of
     Left err -> do
@@ -95,14 +94,14 @@ doSwitchover candidateId oldSourceId oldSourceHost topo = do
       mOldGtid <- liftIO $ case oldSourceId of
         Nothing -> pure Nothing
         Just srcId -> do
-          let srcCi = makeConnectInfo srcId user password
+          let srcCi = makeConnectInfo srcId creds
           result <- withNodeConn srcCi getGtidExecuted
           pure $ case result of
             Right gtid -> Just gtid
             Left _     -> Nothing
 
       -- Step 3: Wait for candidate to catch up
-      let candidateCi = makeConnectInfo candidateId user password
+      let candidateCi = makeConnectInfo candidateId creds
       caught <- liftIO $ waitForCatchup candidateCi mOldGtid maxWaitSeconds
 
       if not caught
@@ -168,14 +167,13 @@ waitForCatchup ci (Just targetGtid) secondsLeft
 
 reconnectToNew :: NodeId -> NodeState -> App ()
 reconnectToNew newSourceId ns = do
-  user <- getMySQLUser
-  password <- getMonPassword
-  pws <- asks envPasswords
-  let ci = makeConnectInfo (nsNodeId ns) user password
+  monCreds  <- getMonCredentials
+  replCreds <- getReplCredentials
+  let ci = makeConnectInfo (nsNodeId ns) monCreds
   liftIO $ do
     _ <- withNodeConn ci $ \conn -> do
       _ <- try @SomeException (stopReplica conn)
-      changeReplicationSourceTo conn (nodeHost newSourceId) (nodePort newSourceId) (cpReplUser pws) (cpReplPassword pws)
+      changeReplicationSourceTo conn (nodeHost newSourceId) (nodePort newSourceId) replCreds
       setReadOnly conn
       startReplica conn
     pure ()

--- a/src/PureMyHA/Monitor/Worker.hs
+++ b/src/PureMyHA/Monitor/Worker.hs
@@ -116,12 +116,11 @@ monitorNode nid = do
   env  <- ask
   tvar <- asks envDaemonState
   cc   <- asks envCluster
-  pws  <- asks envPasswords
   fdc  <- asks envDetection
   now  <- liftIO getCurrentTime
-  mc <- liftIO $ readTVarIO (envMonitoring env)
-  let user      = credUser (ccCredentials cc)
-      ci        = makeConnectInfo nid user (cpPassword pws)
+  mc   <- liftIO $ readTVarIO (envMonitoring env)
+  creds <- getMonCredentials
+  let ci        = makeConnectInfo nid creds
       threshold = fdcConsecutiveFailuresForDead fdc
       retries   = mcConnectRetries mc
       backoff   = mcConnectRetryBackoff mc
@@ -202,10 +201,9 @@ logHealthChange nid mOld new = do
 
 enrichErrantGtids :: NodeState -> App NodeState
 enrichErrantGtids ns = do
-  tvar <- asks envDaemonState
-  cc   <- asks envCluster
-  pws  <- asks envPasswords
-  let user = credUser (ccCredentials cc)
+  tvar  <- asks envDaemonState
+  cc    <- asks envCluster
+  creds <- getMonCredentials
   liftIO $ do
     mTopo <- getClusterTopology tvar (ccName cc)
     case mTopo of
@@ -223,7 +221,7 @@ enrichErrantGtids ns = do
                   sourceGtid = case nsProbeResult srcNs of
                     ProbeSuccess{prGtidExecuted = g} -> g
                     ProbeFailure{} -> ""
-                  ci = makeConnectInfo srcId user (cpPassword pws)
+                  ci = makeConnectInfo srcId creds
               result <- withNodeConn ci $ \conn ->
                 gtidSubtract conn replicaGtid sourceGtid
               case result of

--- a/src/PureMyHA/MySQL/Connection.hs
+++ b/src/PureMyHA/MySQL/Connection.hs
@@ -12,16 +12,17 @@ import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
 import Data.Time (NominalDiffTime)
 import Database.MySQL.Base (ConnectInfo (..), defaultConnectInfo, close, MySQLConn)
+import PureMyHA.Config (DbCredentials (..))
 import PureMyHA.MySQL.Auth (connectWithAuth)
 import PureMyHA.Types (NodeId (..))
 
 -- | Build ConnectInfo from NodeId and credentials
-makeConnectInfo :: NodeId -> Text -> Text -> ConnectInfo
-makeConnectInfo NodeId{..} user password = defaultConnectInfo
+makeConnectInfo :: NodeId -> DbCredentials -> ConnectInfo
+makeConnectInfo NodeId{..} DbCredentials{..} = defaultConnectInfo
   { ciHost     = T.unpack nodeHost
   , ciPort     = fromIntegral nodePort
-  , ciUser     = TE.encodeUtf8 user
-  , ciPassword = TE.encodeUtf8 password
+  , ciUser     = TE.encodeUtf8 dbUser
+  , ciPassword = TE.encodeUtf8 dbPassword
   , ciDatabase = ""
   }
 

--- a/src/PureMyHA/MySQL/Query.hs
+++ b/src/PureMyHA/MySQL/Query.hs
@@ -27,6 +27,7 @@ import Database.MySQL.Base
   , Query (..), ColumnDef (..)
   )
 import qualified System.IO.Streams as S
+import PureMyHA.Config (DbCredentials (..))
 import PureMyHA.Types
 
 -- | Convert a lazy ByteString SQL to a Query
@@ -121,12 +122,12 @@ getGtidExecuted conn = do
     _         -> pure ""
 
 -- | CHANGE REPLICATION SOURCE TO ... SOURCE_AUTO_POSITION=1
-changeReplicationSourceTo :: MySQLConn -> Text -> Int -> Text -> Text -> IO ()
-changeReplicationSourceTo conn host port replUser replPassword = do
+changeReplicationSourceTo :: MySQLConn -> Text -> Int -> DbCredentials -> IO ()
+changeReplicationSourceTo conn host port DbCredentials{..} = do
   let sql = "CHANGE REPLICATION SOURCE TO SOURCE_HOST='" <> host
             <> "', SOURCE_PORT=" <> T.pack (show port)
-            <> ", SOURCE_USER='" <> replUser <> "'"
-            <> ", SOURCE_PASSWORD='" <> replPassword <> "'"
+            <> ", SOURCE_USER='" <> dbUser <> "'"
+            <> ", SOURCE_PASSWORD='" <> dbPassword <> "'"
             <> ", SOURCE_AUTO_POSITION=1"
             <> ", GET_SOURCE_PUBLIC_KEY=1"
   _ <- execute_ conn (toQuery (BL.fromStrict (TE.encodeUtf8 sql)))

--- a/src/PureMyHA/Topology/Discovery.hs
+++ b/src/PureMyHA/Topology/Discovery.hs
@@ -17,8 +17,8 @@ import qualified Data.Set as Set
 import Data.Text (Text)
 import qualified Data.Text as T
 import Data.Time (UTCTime, getCurrentTime)
-import PureMyHA.Config (ClusterConfig (..), NodeConfig (..))
-import PureMyHA.Env (App, envCluster, envLogger, getMySQLUser, getMonPassword)
+import PureMyHA.Config (ClusterConfig (..), DbCredentials, NodeConfig (..))
+import PureMyHA.Env (App, ClusterEnv (..), envLogger, getMonCredentials)
 import PureMyHA.Logger (Logger, logInfo)
 import PureMyHA.MySQL.Connection (makeConnectInfo, withNodeConn)
 import PureMyHA.MySQL.Query
@@ -28,12 +28,11 @@ import PureMyHA.Monitor.Detector (identifySource, detectClusterHealth)
 -- | Discover all nodes reachable from the seed nodes
 discoverTopology :: App ClusterTopology
 discoverTopology = do
-  cc       <- asks envCluster
-  user     <- getMySQLUser
-  password <- getMonPassword
-  logger   <- asks envLogger >>= liftIO . readTVarIO
+  cc     <- asks envCluster
+  creds  <- getMonCredentials
+  logger <- asks envLogger >>= liftIO . readTVarIO
   let seedNodes = map (\nc -> NodeId (ncHost nc) (ncPort nc)) (ccNodes cc)
-  nodeStates <- liftIO $ discoverAll user password (Set.fromList seedNodes) Set.empty Map.empty logger
+  nodeStates <- liftIO $ discoverAll creds (Set.fromList seedNodes) Set.empty Map.empty logger
   pure (buildClusterTopology (ccName cc) nodeStates)
 
 -- | Build a ClusterTopology from discovered node states (pure)
@@ -60,14 +59,13 @@ buildClusterTopology name nodeStates =
 
 -- | Recursively discover nodes
 discoverAll
-  :: Text              -- ^ user
-  -> Text              -- ^ password
+  :: DbCredentials     -- ^ credentials
   -> Set NodeId        -- ^ queue
   -> Set NodeId        -- ^ visited
   -> Map NodeId NodeState
   -> Logger
   -> IO (Map NodeId NodeState)
-discoverAll user password queue visited acc logger
+discoverAll creds queue visited acc logger
   | Set.null queue = do
       logInfo logger $ "[discovery] Queue empty, discovery complete (" <> T.pack (show (Map.size acc)) <> " node(s))"
       pure acc
@@ -75,22 +73,22 @@ discoverAll user password queue visited acc logger
       logInfo logger $ "[discovery] Queue: " <> T.pack (show (map (\n -> nodeHost n <> ":" <> T.pack (show (nodePort n))) (Set.toList queue)))
       let (nid, rest) = Set.deleteFindMin queue
       if Set.member nid visited
-        then discoverAll user password rest visited acc logger
+        then discoverAll creds rest visited acc logger
         else do
-          (ns, replicaIds) <- probeNode user password nid logger
+          (ns, replicaIds) <- probeNode creds nid logger
           let visited'  = Set.insert nid visited
               acc'      = Map.insert nid ns acc
               fromRs    = nextDiscoveryTargets ns visited' rest
               newQueue  = foldr (\rid q -> if Set.notMember rid visited' then Set.insert rid q else q) fromRs replicaIds
-          discoverAll user password newQueue visited' acc' logger
+          discoverAll creds newQueue visited' acc' logger
 
 -- | Probe a single node and return its NodeState plus any replicas discovered
 -- via SHOW PROCESSLIST (only populated when the node is a source).
-probeNode :: Text -> Text -> NodeId -> Logger -> IO (NodeState, [NodeId])
-probeNode user password nid logger = do
+probeNode :: DbCredentials -> NodeId -> Logger -> IO (NodeState, [NodeId])
+probeNode creds nid logger = do
   logInfo logger $ "[discovery] Probing " <> nodeHost nid <> ":" <> T.pack (show (nodePort nid))
   now <- getCurrentTime
-  let ci = makeConnectInfo nid user password
+  let ci = makeConnectInfo nid creds
   result <- withNodeConn ci $ \conn -> do
     mReplicaStatus <- showReplicaStatus conn
     gtidExec       <- getGtidExecuted conn

--- a/test/Fixtures.hs
+++ b/test/Fixtures.hs
@@ -58,7 +58,7 @@ mkNodeState nid role mRs health = NodeState
 -- | Build a test ClusterEnv with dummy values for fields not under test
 mkTestEnv :: TVarDaemonState -> ClusterConfig -> FailoverConfig -> IO ClusterEnv
 mkTestEnv tvar cc fc = do
-  let pws = ClusterPasswords "" "" ""
+  let pws = ClusterPasswords (DbCredentials "" "") (DbCredentials "" "")
       fdc = FailureDetectionConfig 0 3
   mcVar    <- newTVarIO (MonitoringConfig 3 5 30 60 300 1 1)
   hooksVar <- newTVarIO Nothing


### PR DESCRIPTION
## Summary

- Introduce `DbCredentials { dbUser, dbPassword }` in `Config.hs` as a dedicated type for a MySQL user/password pair
- Restructure `ClusterPasswords` to hold two `DbCredentials` fields (`cpMonCredentials`, `cpReplCredentials`) instead of three flat `Text` fields
- Replace `getMySQLUser`/`getMonPassword` helpers in `Env.hs` with `getMonCredentials`/`getReplCredentials`
- Update `makeConnectInfo` and `changeReplicationSourceTo` to accept `DbCredentials` instead of separate `Text` arguments
- Update all callers across `Discovery`, `Monitor/Worker`, and all `Failover` modules

Closes #59

## Test plan

- [x] `cabal build` — compiles with no errors
- [x] `cabal test` — all 205 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)