### PR TITLE
refactor: introduce newtype ClusterName for type safety (#52)

### DIFF
--- a/app/CLI/Main.hs
+++ b/app/CLI/Main.hs
@@ -12,6 +12,7 @@ import PureMyHA.Config (loadConfig, validateConfig)
 import PureMyHA.IPC.Client
 import PureMyHA.IPC.Protocol
 import PureMyHA.IPC.Server (defaultSocketPath)
+import PureMyHA.Types (ClusterName (..))
 
 data CLIOptions = CLIOptions
   { optSocketPath  :: FilePath
@@ -123,7 +124,7 @@ main = do
     (fullDesc <> progDesc "PureMyHA CLI" <> header "puremyha"))
 
   let socketPath = optSocketPath opts
-      mCluster   = optCluster opts
+      mCluster   = fmap ClusterName (optCluster opts)
       json       = optJsonOutput opts
 
   case optCommand opts of

--- a/app/Daemon/Main.hs
+++ b/app/Daemon/Main.hs
@@ -24,7 +24,7 @@ import PureMyHA.Logger (Logger, initLogger, closeLogger, reopenLogger, setLogLev
 import PureMyHA.Monitor.Worker (startMonitorWorkers, startTopologyRefreshWorker, WorkerRegistry, runWorker)
 import PureMyHA.Topology.Discovery (discoverTopology, buildInitialTopology)
 import PureMyHA.Topology.State
-import PureMyHA.Types (ClusterTopology(..))
+import PureMyHA.Types (ClusterTopology(..), unClusterName)
 
 data DaemonOptions = DaemonOptions
   { optConfigPath :: FilePath
@@ -98,7 +98,7 @@ installHUPHandler configPath clusterEnvs loggerVar httpAsyncVar tvar = do
         forM_ clusterEnvs $ \env -> do
           let name = ccName (envCluster env)
           case find (\cc -> ccName cc == name) (cfgClusters cfg') of
-            Nothing -> logWarn logger $ "SIGHUP: cluster " <> name <> " not found in new config"
+            Nothing -> logWarn logger $ "SIGHUP: cluster " <> unClusterName name <> " not found in new config"
             Just cc -> atomically $ do
               writeTVar (envMonitoring env) (ccMonitoring cc)
               writeTVar (envHooks env)      (ccHooks cc)
@@ -184,7 +184,7 @@ initCluster tvar loggerVar (cc, pws) = do
         }
   topo <- runApp env discoverTopology
   logger <- readTVarIO loggerVar
-  logInfo logger $ "[" <> ccName cc <> "] Initial discovery found "
+  logInfo logger $ "[" <> unClusterName (ccName cc) <> "] Initial discovery found "
     <> T.pack (show (Map.size (ctNodes topo))) <> " node(s)"
   atomically $ updateClusterTopology tvar topo
   pure env

--- a/src/PureMyHA/Config.hs
+++ b/src/PureMyHA/Config.hs
@@ -32,6 +32,7 @@ import Data.Time (NominalDiffTime)
 import Data.Yaml (decodeFileEither)
 import GHC.Generics (Generic)
 import Text.Read (readMaybe)
+import PureMyHA.Types (ClusterName (..), unClusterName)
 
 data Config = Config
   { cfgClusters :: [ClusterConfig]
@@ -77,7 +78,7 @@ data GlobalConfig = GlobalConfig
   } deriving (Show, Generic)
 
 data ClusterConfig = ClusterConfig
-  { ccName                   :: Text
+  { ccName                   :: ClusterName
   , ccNodes                  :: [NodeConfig]
   , ccCredentials            :: Credentials
   , ccReplicationCredentials :: Maybe Credentials
@@ -179,7 +180,7 @@ resolveCluster mglobal raw = do
   fdc <- require "failure_detection" rccFailureDetection (gcFailureDetection =<< mglobal)
   fc  <- require "failover"          rccFailover         (gcFailover         =<< mglobal)
   pure ClusterConfig
-    { ccName                   = rccName raw
+    { ccName                   = ClusterName (rccName raw)
     , ccNodes                  = rccNodes raw
     , ccCredentials            = rccCredentials raw
     , ccReplicationCredentials = rccReplicationCredentials raw
@@ -314,13 +315,13 @@ validateConfig cfg = clusterErrors ++ httpErrors
 
     clusterNames = map ccName clusters
     duplicateClusterErrors =
-      [ "duplicate cluster name: '" <> T.unpack n <> "'"
+      [ "duplicate cluster name: '" <> T.unpack (unClusterName n) <> "'"
       | n <- duplicates clusterNames ]
 
     validateCluster :: ClusterConfig -> [String]
     validateCluster cc = nodeErrors ++ monErrors ++ fdErrors
       where
-        cname  = T.unpack (ccName cc)
+        cname  = T.unpack (unClusterName (ccName cc))
         prefix = "cluster '" <> cname <> "': "
         nodes  = ccNodes cc
 

--- a/src/PureMyHA/Failover/Auto.hs
+++ b/src/PureMyHA/Failover/Auto.hs
@@ -64,23 +64,23 @@ doFailover = do
   mTopo <- liftIO $ getClusterTopology tvar (ccName cc)
   case mTopo of
     Nothing -> do
-      appLogError $ "[" <> ccName cc <> "] Auto-failover failed: Cluster not found"
+      appLogError $ "[" <> unClusterName (ccName cc) <> "] Auto-failover failed: Cluster not found"
       pure (Left "Cluster not found")
     Just topo -> do
       now <- liftIO getCurrentTime
       case checkAutoFailoverPreconditions now topo (fcMinReplicasForFailover fc) of
         Left err -> do
-          appLogError $ "[" <> ccName cc <> "] Auto-failover failed: " <> err
+          appLogError $ "[" <> unClusterName (ccName cc) <> "] Auto-failover failed: " <> err
           pure (Left err)
         Right () -> do
-          appLogInfo $ "[" <> ccName cc <> "] Auto-failover started"
+          appLogInfo $ "[" <> unClusterName (ccName cc) <> "] Auto-failover started"
           executeFailover topo
 
 executeFailover :: ClusterTopology -> App (Either Text ())
 executeFailover topo = runExceptT $ do
   cc <- lift $ asks envCluster
   fc <- lift $ asks envFailover
-  let prefix = "[" <> ccName cc <> "] "
+  let prefix = "[" <> unClusterName (ccName cc) <> "] "
   candidateId <- ExceptT $ do
     case selectCandidate (ctNodes topo) (fcCandidatePriority fc) Nothing of
       Left err -> do
@@ -110,7 +110,7 @@ runPreFailoverHook candidateId oldSourceHost = do
   preResult <- liftIO $ runHookOrAbort mHooks hcPreFailover preEnv
   case preResult of
     Left err -> do
-      appLogError $ "[" <> ccName cc <> "] Pre-failover hook aborted failover: " <> err
+      appLogError $ "[" <> unClusterName (ccName cc) <> "] Pre-failover hook aborted failover: " <> err
       pure (Left $ "Pre-failover hook failed: " <> err)
     Right () -> pure (Right ())
 
@@ -120,7 +120,7 @@ promoteWithOnFailureHook candidateId waitTimeout oldSourceHost = do
   promoteResult <- promoteCandidate candidateId waitTimeout
   case promoteResult of
     Left err -> do
-      appLogError $ "[" <> clusterName <> "] Auto-failover failed: Promote failed: " <> err
+      appLogError $ "[" <> unClusterName clusterName <> "] Auto-failover failed: Promote failed: " <> err
       ts <- liftIO getCurrentTimestamp
       mHooks <- getHooksConfig
       let failEnv = HookEnv clusterName (Just (nodeHost candidateId)) oldSourceHost (Just "PromoteFailed") ts
@@ -160,8 +160,8 @@ promoteCandidate nid waitTimeout = do
     result <- withNodeConn ci $ \conn -> do
       caughtUp <- waitForRelayLogApply conn waitTimeout
       if caughtUp
-        then logInfo logger $ "[" <> clusterName <> "] Relay log apply completed on " <> nodeHost nid
-        else logError logger $ "[" <> clusterName <> "] WARNING: Relay log apply timed out on " <> nodeHost nid <> ", proceeding with promotion"
+        then logInfo logger $ "[" <> unClusterName clusterName <> "] Relay log apply completed on " <> nodeHost nid
+        else logError logger $ "[" <> unClusterName clusterName <> "] WARNING: Relay log apply timed out on " <> nodeHost nid <> ", proceeding with promotion"
       stopReplica conn
       resetReplicaAll conn
       setReadWrite conn

--- a/src/PureMyHA/Failover/Demote.hs
+++ b/src/PureMyHA/Failover/Demote.hs
@@ -33,7 +33,7 @@ runDemote demoteHost srcHost = do
           let demoteId = nsNodeId demoteNs
               srcId    = nsNodeId srcNs
               ci       = makeConnectInfo demoteId monCreds
-          appLogInfo $ "[" <> ccName cc <> "] Demoting " <> demoteHost
+          appLogInfo $ "[" <> unClusterName (ccName cc) <> "] Demoting " <> demoteHost
                     <> " to replica under " <> srcHost
           result <- liftIO $ withNodeConn ci $ \conn -> do
             stopReplica conn
@@ -42,11 +42,11 @@ runDemote demoteHost srcHost = do
             startReplica conn
           case result of
             Left err -> do
-              appLogError $ "[" <> ccName cc <> "] Demote failed: " <> err
+              appLogError $ "[" <> unClusterName (ccName cc) <> "] Demote failed: " <> err
               pure (Left err)
             Right () -> do
               liftIO $ atomically $ updateNodeState tvar (ccName cc)
                 (demoteNs { nsRole = Replica })
-              appLogInfo $ "[" <> ccName cc <> "] Demote completed: "
+              appLogInfo $ "[" <> unClusterName (ccName cc) <> "] Demote completed: "
                         <> demoteHost <> " is now a replica"
               pure (Right ())

--- a/src/PureMyHA/Failover/PauseReplica.hs
+++ b/src/PureMyHA/Failover/PauseReplica.hs
@@ -45,15 +45,15 @@ withTargetNode actionName targetHost mysqlAction stateUpdate = do
         Nothing -> pure (Left $ "Node not found: " <> targetHost)
         Just targetNs -> do
           let ci = makeConnectInfo (nsNodeId targetNs) creds
-          appLogInfo $ "[" <> ccName cc <> "] " <> actionName <> " replication on " <> targetHost
+          appLogInfo $ "[" <> unClusterName (ccName cc) <> "] " <> actionName <> " replication on " <> targetHost
           result <- liftIO $ withNodeConn ci $ \conn -> mysqlAction conn
           case result of
             Left err -> do
-              appLogError $ "[" <> ccName cc <> "] " <> actionName <> " failed: " <> err
+              appLogError $ "[" <> unClusterName (ccName cc) <> "] " <> actionName <> " failed: " <> err
               pure (Left err)
             Right () -> do
               liftIO $ atomically $ updateNodeState tvar (ccName cc) (stateUpdate targetNs)
-              appLogInfo $ "[" <> ccName cc <> "] Replication " <> actionResult <> " on " <> targetHost
+              appLogInfo $ "[" <> unClusterName (ccName cc) <> "] Replication " <> actionResult <> " on " <> targetHost
               pure (Right ())
   where
     actionResult = case actionName of

--- a/src/PureMyHA/Failover/Switchover.hs
+++ b/src/PureMyHA/Failover/Switchover.hs
@@ -45,18 +45,18 @@ runSwitchover mToHost = do
   mTopo <- liftIO $ getClusterTopology tvar (ccName cc)
   case mTopo of
     Nothing -> do
-      appLogError $ "[" <> ccName cc <> "] Switchover failed: Cluster not found"
+      appLogError $ "[" <> unClusterName (ccName cc) <> "] Switchover failed: Cluster not found"
       pure (Left "Cluster not found")
     Just topo ->
       case selectCandidate (ctNodes topo) (fcCandidatePriority fc) mToHost of
         Left err -> do
-          appLogError $ "[" <> ccName cc <> "] Switchover failed: " <> err
+          appLogError $ "[" <> unClusterName (ccName cc) <> "] Switchover failed: " <> err
           pure (Left err)
         Right candidateId -> do
           let oldSourceId   = ctSourceNodeId topo
               oldSourceHost = fmap nodeHost oldSourceId
 
-          appLogInfo $ "[" <> ccName cc <> "] Switchover started"
+          appLogInfo $ "[" <> unClusterName (ccName cc) <> "] Switchover started"
 
           -- Pre-switchover hook (blocking: non-zero exit aborts)
           mHooks <- getHooksConfig
@@ -65,7 +65,7 @@ runSwitchover mToHost = do
           preResult <- liftIO $ runHookOrAbort mHooks hcPreSwitchover preEnv
           case preResult of
             Left err -> do
-              appLogError $ "[" <> ccName cc <> "] Pre-switchover hook aborted: " <> err
+              appLogError $ "[" <> unClusterName (ccName cc) <> "] Pre-switchover hook aborted: " <> err
               pure (Left $ "Pre-switchover hook failed: " <> err)
             Right () ->
               doSwitchover candidateId oldSourceId oldSourceHost topo
@@ -87,7 +87,7 @@ doSwitchover candidateId oldSourceId oldSourceHost topo = do
       withNodeConn srcCi setReadOnly
   case readOnlyResult of
     Left err -> do
-      appLogError $ "[" <> ccName cc <> "] Switchover aborted: cannot set old source read_only: " <> err
+      appLogError $ "[" <> unClusterName (ccName cc) <> "] Switchover aborted: cannot set old source read_only: " <> err
       pure (Left $ "Cannot set old source read_only: " <> err)
     Right () -> do
       -- Step 2: Get old source GTID set
@@ -106,7 +106,7 @@ doSwitchover candidateId oldSourceId oldSourceHost topo = do
 
       if not caught
         then do
-          appLogError $ "[" <> ccName cc <> "] Switchover failed: Candidate did not catch up within timeout"
+          appLogError $ "[" <> unClusterName (ccName cc) <> "] Switchover failed: Candidate did not catch up within timeout"
           pure (Left "Candidate did not catch up within timeout")
         else do
           -- Step 4: Promote candidate
@@ -116,7 +116,7 @@ doSwitchover candidateId oldSourceId oldSourceHost topo = do
             setReadWrite conn
           case promoteResult of
             Left err -> do
-              appLogError $ "[" <> ccName cc <> "] Switchover failed: Promote failed: " <> err
+              appLogError $ "[" <> unClusterName (ccName cc) <> "] Switchover failed: Promote failed: " <> err
               pure (Left $ "Promote failed: " <> err)
             Right () -> do
               -- Step 5: Update topology roles atomically
@@ -141,7 +141,7 @@ doSwitchover candidateId oldSourceId oldSourceHost topo = do
               let postEnv = HookEnv (ccName cc) (Just (nodeHost candidateId)) oldSourceHost Nothing ts
               liftIO $ runHookFireForget mHooks hcPostSwitchover postEnv
 
-              appLogInfo $ "[" <> ccName cc <> "] Switchover completed: new source is " <> nodeHost candidateId
+              appLogInfo $ "[" <> unClusterName (ccName cc) <> "] Switchover completed: new source is " <> nodeHost candidateId
               pure (Right ())
 
 waitForCatchup :: ConnectInfo -> Maybe Text -> Int -> IO Bool

--- a/src/PureMyHA/HTTP/Server.hs
+++ b/src/PureMyHA/HTTP/Server.hs
@@ -55,14 +55,14 @@ handleHealth tvar = do
 handleStatus :: TVarDaemonState -> Text -> IO Response
 handleStatus tvar name = do
   ds <- readDaemonState tvar
-  case Map.lookup name (dsClusters ds) of
+  case Map.lookup (ClusterName name) (dsClusters ds) of
     Nothing -> pure $ responseLBS status404 [jsonCT] (encode (object ["error" .= ("cluster not found" :: Text)]))
     Just ct -> pure $ responseLBS status200 [jsonCT] (encode (toClusterStatus ct))
 
 handleTopology :: TVarDaemonState -> Text -> IO Response
 handleTopology tvar name = do
   ds <- readDaemonState tvar
-  case Map.lookup name (dsClusters ds) of
+  case Map.lookup (ClusterName name) (dsClusters ds) of
     Nothing -> pure $ responseLBS status404 [jsonCT] (encode (object ["error" .= ("cluster not found" :: Text)]))
     Just ct -> pure $ responseLBS status200 [jsonCT] (encode (toClusterTopologyView ct))
 
@@ -117,12 +117,12 @@ metricBlock name typ help samples =
   , "# TYPE " <> name <> " " <> typ
   ] ++ [ name <> "{" <> labels <> "} " <> val | (labels, val) <- samples ]
 
-clusterLabels :: Text -> Text
-clusterLabels name = "cluster=" <> quoted name
+clusterLabels :: ClusterName -> Text
+clusterLabels name = "cluster=" <> quoted (unClusterName name)
 
-nodeLabels :: Text -> NodeState -> Text
+nodeLabels :: ClusterName -> NodeState -> Text
 nodeLabels clusterName ns =
-  "cluster=" <> quoted clusterName
+  "cluster=" <> quoted (unClusterName clusterName)
   <> ",host=" <> quoted (nodeHost (nsNodeId ns))
   <> ",port=" <> quoted (T.pack (show (nodePort (nsNodeId ns))))
 

--- a/src/PureMyHA/Hook.hs
+++ b/src/PureMyHA/Hook.hs
@@ -14,9 +14,10 @@ import Data.Time (getCurrentTime, formatTime, defaultTimeLocale)
 import System.Exit (ExitCode (..))
 import System.Process (createProcess, proc, waitForProcess, env)
 import PureMyHA.Config (HooksConfig (..))
+import PureMyHA.Types (ClusterName, unClusterName)
 
 data HookEnv = HookEnv
-  { hookClusterName :: Text
+  { hookClusterName :: ClusterName
   , hookNewSource   :: Maybe Text
   , hookOldSource   :: Maybe Text
   , hookFailureType :: Maybe Text   -- e.g. "DeadSource", "PromoteFailed"
@@ -32,14 +33,14 @@ getCurrentTimestamp =
 runHook :: FilePath -> HookEnv -> IO (Either Text ())
 runHook scriptPath hookEnv = do
   let envVars =
-        [ ("PUREMYHA_CLUSTER", T.unpack (hookClusterName hookEnv))
+        [ ("PUREMYHA_CLUSTER", T.unpack (unClusterName (hookClusterName hookEnv)))
         ] ++
         maybe [] (\h -> [("PUREMYHA_NEW_SOURCE", T.unpack h)]) (hookNewSource hookEnv) ++
         maybe [] (\h -> [("PUREMYHA_OLD_SOURCE", T.unpack h)]) (hookOldSource hookEnv) ++
         maybe [] (\ft -> [("PUREMYHA_FAILURE_TYPE", T.unpack ft)]) (hookFailureType hookEnv) ++
         [("PUREMYHA_TIMESTAMP", T.unpack (hookTimestamp hookEnv))]
   result <- try @SomeException $ do
-    (_, _, _, ph) <- createProcess (proc scriptPath [T.unpack (hookClusterName hookEnv)])
+    (_, _, _, ph) <- createProcess (proc scriptPath [T.unpack (unClusterName (hookClusterName hookEnv))])
       { env = Just envVars }
     exitCode <- waitForProcess ph
     pure exitCode

--- a/src/PureMyHA/IPC/Client.hs
+++ b/src/PureMyHA/IPC/Client.hs
@@ -72,7 +72,7 @@ printClusterStatus cs = do
       nodes       = show (csNodeCount cs)
       paused      = if csPaused cs then "yes" else "no"
       blocked     = maybe "-" showTime (csRecoveryBlockedUntil cs)
-  putStrLn $ padR 20 (T.unpack (csClusterName cs))
+  putStrLn $ padR 20 (T.unpack (unClusterName (csClusterName cs)))
            <> padR 25 health
            <> padR 20 source
            <> padR 6  nodes
@@ -86,7 +86,7 @@ printTopology False views = mapM_ printClusterTopology views
 
 printClusterTopology :: ClusterTopologyView -> IO ()
 printClusterTopology ctv = do
-  TIO.putStrLn $ "Cluster: " <> ctvClusterName ctv
+  TIO.putStrLn $ "Cluster: " <> unClusterName (ctvClusterName ctv)
   let nodes = ctvNodes ctv
       source = filter nsvIsSource nodes
       replicas = filter (not . nsvIsSource) nodes

--- a/src/PureMyHA/Monitor/Worker.hs
+++ b/src/PureMyHA/Monitor/Worker.hs
@@ -96,7 +96,7 @@ runTopologyRefresh reg = do
   let discovered = Map.keysSet (ctNodes mergedTopo)
       newNodes   = Set.toList (Set.difference discovered knownNodes)
   unless (null newNodes) $
-    appLogInfo $ "[" <> ccName cc <> "] Topology refresh: "
+    appLogInfo $ "[" <> unClusterName (ccName cc) <> "] Topology refresh: "
       <> T.pack (show (length newNodes)) <> " new node(s) found"
   liftIO $ forM_ newNodes $ \nid -> do
     a <- async (runApp env (runWorker nid))
@@ -126,7 +126,7 @@ monitorNode nid = do
       backoff   = mcConnectRetryBackoff mc
       cap       = mcConnectTimeout mc
       logRetry msg = readTVarIO (envLogger env) >>= \l ->
-        logDebug l ("[" <> ccName cc <> "] Node " <> nodeHost nid <> ": " <> msg)
+        logDebug l ("[" <> unClusterName (ccName cc) <> "] Node " <> nodeHost nid <> ": " <> msg)
   -- Read old state before connecting for prevFailures count
   mOldNs <- liftIO $ do
     mTopo <- getClusterTopology tvar (ccName cc)
@@ -167,7 +167,7 @@ monitorNode nid = do
   liftIO $ when (newFailures > 0 && newFailures < threshold) $ do
     logger <- readTVarIO (envLogger env)
     case result of
-      Left err -> logInfo logger $ "[" <> ccName cc <> "] Node " <> nodeHost nid
+      Left err -> logInfo logger $ "[" <> unClusterName (ccName cc) <> "] Node " <> nodeHost nid
                     <> " probe failed (" <> T.pack (show newFailures) <> "/"
                     <> T.pack (show threshold) <> "): " <> err
       Right _  -> pure ()
@@ -187,11 +187,11 @@ logHealthChange nid mOld new = do
     then pure ()
     else case (fmap nsHealth mOld, nsHealth new) of
       (Just Healthy, NeedsAttention err) ->
-        liftIO $ logWarn logger $ "[" <> clusterName <> "] Node " <> host <> " unreachable: " <> err
+        liftIO $ logWarn logger $ "[" <> unClusterName clusterName <> "] Node " <> host <> " unreachable: " <> err
       (Just (NeedsAttention _), Healthy) ->
-        liftIO $ logInfo logger $ "[" <> clusterName <> "] Node " <> host <> " recovered"
+        liftIO $ logInfo logger $ "[" <> unClusterName clusterName <> "] Node " <> host <> " recovered"
       (Nothing, NeedsAttention err) ->
-        liftIO $ logWarn logger $ "[" <> clusterName <> "] Node " <> host <> " initial connect failed: " <> err
+        liftIO $ logWarn logger $ "[" <> unClusterName clusterName <> "] Node " <> host <> " initial connect failed: " <> err
       _ -> pure ()
   where
     host = nodeHost nid
@@ -256,7 +256,7 @@ recomputeClusterHealth = do
       -- Log all health transitions for observability
       when transitioned $ liftIO $ do
         logger <- readTVarIO (envLogger env)
-        logInfo logger $ "[" <> ccName cc <> "] Cluster health: "
+        logInfo logger $ "[" <> unClusterName (ccName cc) <> "] Cluster health: "
           <> T.pack (show (ctHealth topo)) <> " \x2192 " <> T.pack (show newHealth)
       liftIO $ atomically $ updateClusterHealthFields tvar (ccName cc) newHealth newSrcId observedHealthy
       -- Trigger auto-failover when DeadSource (not just on transition, so resume-failover works)
@@ -276,7 +276,7 @@ emergencyReplicaCheck = do
   tvar <- asks envDaemonState
   cc   <- asks envCluster
   env  <- ask
-  appLogInfo $ "[" <> ccName cc <> "] UnreachableSource detected: emergency replica re-check"
+  appLogInfo $ "[" <> unClusterName (ccName cc) <> "] UnreachableSource detected: emergency replica re-check"
   mTopo <- liftIO $ getClusterTopology tvar (ccName cc)
   case mTopo of
     Nothing   -> pure ()

--- a/src/PureMyHA/Types.hs
+++ b/src/PureMyHA/Types.hs
@@ -1,6 +1,7 @@
 module PureMyHA.Types
   ( NodeId (..)
-  , ClusterName
+  , ClusterName (..)
+  , unClusterName
   , IORunning (..)
   , SQLThreadState (..)
   , ReplicaStatus (..)
@@ -20,13 +21,26 @@ module PureMyHA.Types
   , ErrantGtidInfo (..)
   ) where
 
+import Data.Aeson (FromJSON (..), ToJSON (..))
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
+import Data.String (IsString (..))
 import Data.Text (Text)
+import qualified Data.Text as T
 import Data.Time (UTCTime)
 import GHC.Generics (Generic)
 
-type ClusterName = Text
+newtype ClusterName = ClusterName { unClusterName :: Text }
+  deriving (Eq, Ord, Show, Generic)
+
+instance IsString ClusterName where
+  fromString = ClusterName . T.pack
+
+instance FromJSON ClusterName where
+  parseJSON v = ClusterName <$> parseJSON v
+
+instance ToJSON ClusterName where
+  toJSON (ClusterName t) = toJSON t
 
 data NodeId = NodeId
   { nodeHost :: Text


### PR DESCRIPTION
## Summary

- Replaces `type ClusterName = Text` with `newtype ClusterName = ClusterName { unClusterName :: Text }` in `Types.hs`
- Adds `IsString` instance so string literals in tests coerce transparently (no test changes required)
- Adds transparent `FromJSON` / `ToJSON` instances, preserving the existing JSON wire format
- Updates all 12 affected files to unwrap `ClusterName` via `unClusterName` at log-message concatenation sites, and to wrap incoming `Text` values at boundaries (CLI argument, HTTP URL path segment)

## Motivation

The previous type alias provided no compile-time protection — a `ClusterName` and an arbitrary `Text` were indistinguishable to the type checker. The newtype makes incorrect mixing a compile error. Follows the newtype pattern introduced in #50 for `DbCredentials`.

## Test plan

- [x] `cabal build all` — clean build, no errors
- [x] `cabal test` — 205/205 tests pass
- [x] `grep -r "type ClusterName" src/` — returns only the new `newtype` definition

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)