### PR TITLE
refactor: extract shared recvLine into IPC.Socket module

### DIFF
--- a/puremyha.cabal
+++ b/puremyha.cabal
@@ -55,6 +55,7 @@ library
     PureMyHA.Failover.ErrantGtid
     PureMyHA.Failover.Switchover
     PureMyHA.IPC.Protocol
+    PureMyHA.IPC.Socket
     PureMyHA.IPC.Server
     PureMyHA.IPC.Client
     PureMyHA.HTTP.Server

--- a/src/PureMyHA/IPC/Client.hs
+++ b/src/PureMyHA/IPC/Client.hs
@@ -8,8 +8,6 @@ module PureMyHA.IPC.Client
 
 import Control.Exception (bracket, try, SomeException)
 import Data.Aeson (encode, eitherDecode)
-import qualified Data.ByteString as BS
-import qualified Data.ByteString.Char8 as BSC
 import qualified Data.ByteString.Lazy as BL
 import qualified Data.ByteString.Lazy.Char8 as BLC
 import Data.Text (Text)
@@ -19,6 +17,7 @@ import Data.Time (UTCTime, formatTime, defaultTimeLocale)
 import Network.Socket
 import qualified Network.Socket.ByteString as NSB
 import PureMyHA.IPC.Protocol
+import qualified PureMyHA.IPC.Socket as IPCSocket
 import PureMyHA.Types
 
 -- | Send a request to the daemon and return the response
@@ -40,22 +39,12 @@ connectSocket path = do
   pure sock
 
 recvResponse :: Socket -> IO (Either Text Response)
-recvResponse sock = go []
-  where
-    go acc = do
-      chunk <- NSB.recv sock 4096
-      if BS.null chunk
-        then pure (Left "Connection closed before response")
-        else do
-          let acc' = chunk : acc
-              full = BS.concat (reverse acc')
-          if BSC.elem '\n' full
-            then
-              let line = BSC.takeWhile (/= '\n') full
-              in pure $ case eitherDecode (BL.fromStrict line) of
-                Left err   -> Left (T.pack err)
-                Right resp -> Right resp
-            else go acc'
+recvResponse sock = do
+  result <- IPCSocket.recvLine sock
+  pure $ result >>= \bs ->
+    case eitherDecode (BL.fromStrict bs) of
+      Left err   -> Left (T.pack err)
+      Right resp -> Right resp
 
 -- | Print cluster status in tabular format
 printStatus :: Bool -> [ClusterStatus] -> IO ()

--- a/src/PureMyHA/IPC/Server.hs
+++ b/src/PureMyHA/IPC/Server.hs
@@ -10,7 +10,6 @@ import Control.Concurrent.Async (async)
 import Control.Concurrent.STM (TVar, atomically, readTVarIO)
 import Control.Exception (bracket, try, catch, SomeException, finally)
 import Data.Aeson (encode, eitherDecode)
-import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as BSC
 import qualified Data.ByteString.Lazy as BL
 import qualified Data.ByteString.Lazy.Char8 as BLC
@@ -29,6 +28,7 @@ import PureMyHA.Failover.ErrantGtid (runFixErrantGtid)
 import PureMyHA.Failover.Switchover (runSwitchover, dryRunSwitchover)
 import System.Posix.Files (removeLink)
 import PureMyHA.IPC.Protocol
+import qualified PureMyHA.IPC.Socket as IPCSocket
 import PureMyHA.Topology.State
 import PureMyHA.Types
 
@@ -81,18 +81,11 @@ handleClient sock tvar clusterMap discoveryMap loggerVar = do
     Right () -> pure ()
 
 recvLine :: Socket -> IO String
-recvLine sock = go []
-  where
-    go acc = do
-      chunk <- NSB.recv sock 4096
-      if BS.null chunk
-        then pure (BSC.unpack (BS.concat (reverse acc)))
-        else do
-          let acc' = chunk : acc
-              full = BSC.unpack (BS.concat (reverse acc'))
-          if '\n' `elem` full
-            then pure (takeWhile (/= '\n') full)
-            else go acc'
+recvLine sock = do
+  result <- IPCSocket.recvLine sock
+  pure $ case result of
+    Left _   -> ""
+    Right bs -> BSC.unpack bs
 
 sendResponse :: Socket -> Response -> IO ()
 sendResponse sock resp = do

--- a/src/PureMyHA/IPC/Socket.hs
+++ b/src/PureMyHA/IPC/Socket.hs
@@ -1,0 +1,24 @@
+module PureMyHA.IPC.Socket (recvLine) where
+
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Char8 as BSC
+import Data.Text (Text)
+import Network.Socket (Socket)
+import qualified Network.Socket.ByteString as NSB
+
+-- | Receive bytes from a socket until a newline is found.
+-- Returns 'Right' with the bytes before @'\n'@, or
+-- 'Left' with an error message if the connection is closed.
+recvLine :: Socket -> IO (Either Text BS.ByteString)
+recvLine sock = go []
+  where
+    go acc = do
+      chunk <- NSB.recv sock 4096
+      if BS.null chunk
+        then pure (Left "Connection closed before newline")
+        else do
+          let acc' = chunk : acc
+              full = BS.concat (reverse acc')
+          if BSC.elem '\n' full
+            then pure (Right (BSC.takeWhile (/= '\n') full))
+            else go acc'


### PR DESCRIPTION
## Summary
- Extracts the duplicated "receive chunks from socket until newline" logic from `IPC/Server.hs` and `IPC/Client.hs` into a new shared module `PureMyHA.IPC.Socket`
- New `recvLine :: Socket -> IO (Either Text ByteString)` handles the accumulate-and-scan loop once; each caller adapts the result to its own type
- Removes unused `Data.ByteString` and `Data.ByteString.Char8` imports from `Client.hs`, and `Data.ByteString` from `Server.hs`

Closes #54

## Test plan
- [x] `cabal build all` passes without errors
- [x] `cabal test` — all 197 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)