### PR TITLE
refactor: add bidirectional parsing and newtypes for GTID types

### DIFF
--- a/src/PureMyHA/Failover/ErrantGtid.hs
+++ b/src/PureMyHA/Failover/ErrantGtid.hs
@@ -13,7 +13,7 @@ import qualified Data.Text as T
 import PureMyHA.Config (ClusterConfig (..))
 import PureMyHA.Env (App, ClusterEnv (..), getMonCredentials)
 import PureMyHA.MySQL.Connection (makeConnectInfo, withNodeConn)
-import PureMyHA.MySQL.GTID (GtidEntry (..), GtidInterval (..), parseGtidIntervals)
+import PureMyHA.MySQL.GTID (GtidEntry (..), GtidInterval (..), GtidUUID (..), TransactionId (..), parseGtidIntervals)
 import PureMyHA.MySQL.Query (injectEmptyTransaction)
 import PureMyHA.Topology.State (getClusterTopology)
 import PureMyHA.Types
@@ -21,7 +21,7 @@ import PureMyHA.Types
 -- | Expand one GtidEntry to individual "uuid:N" strings
 expandGtidEntry :: GtidEntry -> [Text]
 expandGtidEntry GtidEntry{..} =
-  [ geUuid <> ":" <> T.pack (show n)
+  [ getGtidUUID geUuid <> ":" <> T.pack (show (getTransactionId n))
   | GtidInterval{..} <- geIntervals
   , n <- [giStart .. giEnd]
   ]

--- a/src/PureMyHA/MySQL/GTID.hs
+++ b/src/PureMyHA/MySQL/GTID.hs
@@ -1,14 +1,27 @@
 module PureMyHA.MySQL.GTID
   ( isEmptyGtidSet
   , parseGtidIntervals
+  , renderGtidEntry
+  , renderGtidSet
   , gtidTransactionCount
+  , mkGtidInterval
   , GtidInterval (..)
   , GtidEntry (..)
+  , TransactionId (..)
+  , GtidUUID (..)
   ) where
 
 import Data.Text (Text)
 import qualified Data.Text as T
 import Text.Read (readMaybe)
+
+-- | A transaction sequence number within a GTID set.
+newtype TransactionId = TransactionId { getTransactionId :: Integer }
+  deriving (Eq, Ord, Show, Enum)
+
+-- | A MySQL server UUID used as the source identifier in a GTID.
+newtype GtidUUID = GtidUUID { getGtidUUID :: Text }
+  deriving (Eq, Ord, Show)
 
 -- | Check if a GTID set string is empty
 isEmptyGtidSet :: Text -> Bool
@@ -16,15 +29,21 @@ isEmptyGtidSet t = T.null (T.strip t)
 
 -- | A single interval within a GTID set
 data GtidInterval = GtidInterval
-  { giStart :: Integer
-  , giEnd   :: Integer
+  { giStart :: TransactionId
+  , giEnd   :: TransactionId
   } deriving (Eq, Show)
 
 -- | A parsed GTID entry: UUID with its intervals
 data GtidEntry = GtidEntry
-  { geUuid      :: Text
+  { geUuid      :: GtidUUID
   , geIntervals :: [GtidInterval]
   } deriving (Eq, Show)
+
+-- | Smart constructor that validates giStart <= giEnd.
+mkGtidInterval :: Integer -> Integer -> Either String GtidInterval
+mkGtidInterval s e
+  | s <= e    = Right (GtidInterval (TransactionId s) (TransactionId e))
+  | otherwise = Left $ "giStart > giEnd: " <> show s <> " > " <> show e
 
 -- | Parse a GTID set string into structured entries.
 -- Format: "uuid1:n1-n2:n3,uuid2:n4-n5"
@@ -38,20 +57,35 @@ parseGtidIntervals t
       case T.splitOn ":" (T.strip entry) of
         (uuid : intervals) | not (T.null uuid) -> do
           parsed <- mapM parseInterval intervals
-          pure (GtidEntry uuid parsed)
+          pure (GtidEntry (GtidUUID uuid) parsed)
         _ -> Left $ "Invalid GTID entry: " <> T.unpack entry
 
     parseInterval iv =
       case T.splitOn "-" iv of
         [s] ->
           case readMaybe (T.unpack s) of
-            Just n  -> Right (GtidInterval n n)
+            Just n  -> Right (GtidInterval (TransactionId n) (TransactionId n))
             Nothing -> Left $ "Invalid GTID interval: " <> T.unpack iv
         [s, e] ->
           case (readMaybe (T.unpack s), readMaybe (T.unpack e)) of
-            (Just start, Just end) -> Right (GtidInterval start end)
+            (Just start, Just end) -> Right (GtidInterval (TransactionId start) (TransactionId end))
             _ -> Left $ "Invalid GTID interval: " <> T.unpack iv
         _ -> Left $ "Invalid GTID interval: " <> T.unpack iv
+
+-- | Render a single GtidInterval to its string representation.
+renderGtidInterval :: GtidInterval -> Text
+renderGtidInterval (GtidInterval s e)
+  | s == e    = T.pack (show (getTransactionId s))
+  | otherwise = T.pack (show (getTransactionId s)) <> "-" <> T.pack (show (getTransactionId e))
+
+-- | Render a GtidEntry to its string representation (e.g. "uuid:1-5:7-10").
+renderGtidEntry :: GtidEntry -> Text
+renderGtidEntry (GtidEntry uuid ivs) =
+  T.intercalate ":" (getGtidUUID uuid : map renderGtidInterval ivs)
+
+-- | Render a list of GtidEntry to a GTID set string (comma-separated).
+renderGtidSet :: [GtidEntry] -> Text
+renderGtidSet = T.intercalate "," . map renderGtidEntry
 
 -- | GTID セット文字列中のトランザクション総数を返す。
 -- パースエラーまたは空文字列の場合は 0 を返す。
@@ -60,7 +94,7 @@ gtidTransactionCount t =
   case parseGtidIntervals t of
     Left  _       -> 0
     Right entries -> sum
-      [ giEnd iv - giStart iv + 1
+      [ getTransactionId (giEnd iv) - getTransactionId (giStart iv) + 1
       | entry <- entries
       , iv    <- geIntervals entry
       ]

--- a/test/PureMyHA/ErrantGtidSpec.hs
+++ b/test/PureMyHA/ErrantGtidSpec.hs
@@ -2,25 +2,25 @@ module PureMyHA.ErrantGtidSpec (spec) where
 
 import Test.Hspec
 import PureMyHA.Failover.ErrantGtid (expandGtidEntry, collectErrantGtids)
-import PureMyHA.MySQL.GTID (GtidEntry (..), GtidInterval (..))
+import PureMyHA.MySQL.GTID (GtidEntry (..), GtidInterval (..), GtidUUID (..), TransactionId (..))
 
 spec :: Spec
 spec = do
   describe "expandGtidEntry" $ do
     it "expands a single GTID" $
-      expandGtidEntry (GtidEntry "uuid1" [GtidInterval 5 5])
+      expandGtidEntry (GtidEntry (GtidUUID "uuid1") [GtidInterval (TransactionId 5) (TransactionId 5)])
         `shouldBe` ["uuid1:5"]
 
     it "expands a range interval" $
-      expandGtidEntry (GtidEntry "uuid1" [GtidInterval 1 3])
+      expandGtidEntry (GtidEntry (GtidUUID "uuid1") [GtidInterval (TransactionId 1) (TransactionId 3)])
         `shouldBe` ["uuid1:1", "uuid1:2", "uuid1:3"]
 
     it "expands multiple intervals" $
-      expandGtidEntry (GtidEntry "uuid1" [GtidInterval 1 2, GtidInterval 5 6])
+      expandGtidEntry (GtidEntry (GtidUUID "uuid1") [GtidInterval (TransactionId 1) (TransactionId 2), GtidInterval (TransactionId 5) (TransactionId 6)])
         `shouldBe` ["uuid1:1", "uuid1:2", "uuid1:5", "uuid1:6"]
 
     it "returns empty list for no intervals" $
-      expandGtidEntry (GtidEntry "uuid1" [])
+      expandGtidEntry (GtidEntry (GtidUUID "uuid1") [])
         `shouldBe` []
 
   describe "collectErrantGtids" $ do
@@ -28,38 +28,38 @@ spec = do
       collectErrantGtids [] `shouldBe` []
 
     it "collects GTIDs from a single entry" $
-      collectErrantGtids [[GtidEntry "uuid1" [GtidInterval 1 1]]]
+      collectErrantGtids [[GtidEntry (GtidUUID "uuid1") [GtidInterval (TransactionId 1) (TransactionId 1)]]]
         `shouldBe` ["uuid1:1"]
 
     it "expands range across single replica" $
-      collectErrantGtids [[GtidEntry "uuid1" [GtidInterval 1 3]]]
+      collectErrantGtids [[GtidEntry (GtidUUID "uuid1") [GtidInterval (TransactionId 1) (TransactionId 3)]]]
         `shouldBe` ["uuid1:1", "uuid1:2", "uuid1:3"]
 
     it "deduplicates identical GTIDs from two replicas" $
       collectErrantGtids
-        [ [GtidEntry "uuid1" [GtidInterval 1 1]]
-        , [GtidEntry "uuid1" [GtidInterval 1 1]]
+        [ [GtidEntry (GtidUUID "uuid1") [GtidInterval (TransactionId 1) (TransactionId 1)]]
+        , [GtidEntry (GtidUUID "uuid1") [GtidInterval (TransactionId 1) (TransactionId 1)]]
         ]
         `shouldBe` ["uuid1:1"]
 
     it "collects GTIDs from multiple UUIDs" $
       collectErrantGtids
-        [ [GtidEntry "uuid1" [GtidInterval 1 1]]
-        , [GtidEntry "uuid2" [GtidInterval 2 2]]
+        [ [GtidEntry (GtidUUID "uuid1") [GtidInterval (TransactionId 1) (TransactionId 1)]]
+        , [GtidEntry (GtidUUID "uuid2") [GtidInterval (TransactionId 2) (TransactionId 2)]]
         ]
         `shouldBe` ["uuid1:1", "uuid2:2"]
 
     it "deduplicates partial overlap across replicas" $
       collectErrantGtids
-        [ [GtidEntry "uuid1" [GtidInterval 1 2]]
-        , [GtidEntry "uuid1" [GtidInterval 2 3]]
+        [ [GtidEntry (GtidUUID "uuid1") [GtidInterval (TransactionId 1) (TransactionId 2)]]
+        , [GtidEntry (GtidUUID "uuid1") [GtidInterval (TransactionId 2) (TransactionId 3)]]
         ]
         `shouldBe` ["uuid1:1", "uuid1:2", "uuid1:3"]
 
     it "handles one replica with multiple UUIDs" $
       collectErrantGtids
-        [ [ GtidEntry "uuid1" [GtidInterval 1 1]
-          , GtidEntry "uuid2" [GtidInterval 1 1]
+        [ [ GtidEntry (GtidUUID "uuid1") [GtidInterval (TransactionId 1) (TransactionId 1)]
+          , GtidEntry (GtidUUID "uuid2") [GtidInterval (TransactionId 1) (TransactionId 1)]
           ]
         ]
         `shouldBe` ["uuid1:1", "uuid2:1"]

--- a/test/PureMyHA/GTIDSpec.hs
+++ b/test/PureMyHA/GTIDSpec.hs
@@ -1,6 +1,7 @@
 module PureMyHA.GTIDSpec (spec) where
 
 import Test.Hspec
+import Test.QuickCheck
 import PureMyHA.MySQL.GTID
 
 spec :: Spec
@@ -22,30 +23,30 @@ spec = do
     it "parses a single interval" $ do
       let result = parseGtidIntervals "3e11fa47-71ca-11e1-9e33-c80aa9429562:1-5"
       result `shouldBe` Right
-        [ GtidEntry "3e11fa47-71ca-11e1-9e33-c80aa9429562"
-            [GtidInterval 1 5]
+        [ GtidEntry (GtidUUID "3e11fa47-71ca-11e1-9e33-c80aa9429562")
+            [GtidInterval (TransactionId 1) (TransactionId 5)]
         ]
 
     it "parses a single transaction number" $ do
       let result = parseGtidIntervals "3e11fa47-71ca-11e1-9e33-c80aa9429562:1"
       result `shouldBe` Right
-        [ GtidEntry "3e11fa47-71ca-11e1-9e33-c80aa9429562"
-            [GtidInterval 1 1]
+        [ GtidEntry (GtidUUID "3e11fa47-71ca-11e1-9e33-c80aa9429562")
+            [GtidInterval (TransactionId 1) (TransactionId 1)]
         ]
 
     it "parses multiple intervals for same UUID" $ do
       let result = parseGtidIntervals "3e11fa47-71ca-11e1-9e33-c80aa9429562:1-5:7-10"
       result `shouldBe` Right
-        [ GtidEntry "3e11fa47-71ca-11e1-9e33-c80aa9429562"
-            [GtidInterval 1 5, GtidInterval 7 10]
+        [ GtidEntry (GtidUUID "3e11fa47-71ca-11e1-9e33-c80aa9429562")
+            [GtidInterval (TransactionId 1) (TransactionId 5), GtidInterval (TransactionId 7) (TransactionId 10)]
         ]
 
     it "parses multiple UUID entries" $ do
       let gtid = "uuid1:1-5,uuid2:1-3"
           result = parseGtidIntervals gtid
       result `shouldBe` Right
-        [ GtidEntry "uuid1" [GtidInterval 1 5]
-        , GtidEntry "uuid2" [GtidInterval 1 3]
+        [ GtidEntry (GtidUUID "uuid1") [GtidInterval (TransactionId 1) (TransactionId 5)]
+        , GtidEntry (GtidUUID "uuid2") [GtidInterval (TransactionId 1) (TransactionId 3)]
         ]
 
     it "returns Left for invalid format" $
@@ -75,6 +76,62 @@ spec = do
 
     it "handles fixture GTID from CandidateSpec" $
       gtidTransactionCount "uuid1:1-1,uuid2:1-200,uuid3:1-50" `shouldBe` 251
+
+  describe "mkGtidInterval" $ do
+    it "returns Right for valid start <= end" $
+      mkGtidInterval 1 5
+        `shouldBe` Right (GtidInterval (TransactionId 1) (TransactionId 5))
+
+    it "returns Right for equal start and end (point transaction)" $
+      mkGtidInterval 3 3
+        `shouldBe` Right (GtidInterval (TransactionId 3) (TransactionId 3))
+
+    it "returns Left for start > end" $
+      mkGtidInterval 5 1 `shouldSatisfy` isLeft
+
+  describe "renderGtidEntry" $ do
+    it "renders a single interval" $
+      renderGtidEntry (GtidEntry (GtidUUID "uuid1") [GtidInterval (TransactionId 1) (TransactionId 5)])
+        `shouldBe` "uuid1:1-5"
+
+    it "renders a point transaction as a single number" $
+      renderGtidEntry (GtidEntry (GtidUUID "uuid1") [GtidInterval (TransactionId 3) (TransactionId 3)])
+        `shouldBe` "uuid1:3"
+
+    it "renders multiple intervals" $
+      renderGtidEntry (GtidEntry (GtidUUID "uuid1") [GtidInterval (TransactionId 1) (TransactionId 5), GtidInterval (TransactionId 7) (TransactionId 10)])
+        `shouldBe` "uuid1:1-5:7-10"
+
+  describe "renderGtidSet" $ do
+    it "renders an empty list as empty string" $
+      renderGtidSet [] `shouldBe` ""
+
+    it "renders multiple entries" $
+      renderGtidSet
+        [ GtidEntry (GtidUUID "u1") [GtidInterval (TransactionId 1) (TransactionId 5)]
+        , GtidEntry (GtidUUID "u2") [GtidInterval (TransactionId 1) (TransactionId 3)]
+        ]
+        `shouldBe` "u1:1-5,u2:1-3"
+
+  describe "roundtrip" $ do
+    it "parse . renderGtidSet == Right for arbitrary entries" $
+      property $ \entries ->
+        parseGtidIntervals (renderGtidSet entries) === Right entries
+
+instance Arbitrary TransactionId where
+  arbitrary = TransactionId . getPositive <$> arbitrary
+
+instance Arbitrary GtidUUID where
+  arbitrary = GtidUUID <$> elements ["uuid1", "uuid2", "3e11fa47-71ca-11e1-9e33-c80aa9429562"]
+
+instance Arbitrary GtidInterval where
+  arbitrary = do
+    s <- arbitrary
+    e <- TransactionId . (getTransactionId s +) . getNonNegative <$> arbitrary
+    pure (GtidInterval s e)
+
+instance Arbitrary GtidEntry where
+  arbitrary = GtidEntry <$> arbitrary <*> listOf1 arbitrary
 
 isLeft :: Either a b -> Bool
 isLeft (Left _) = True


### PR DESCRIPTION
## Summary
- Introduce `TransactionId` (newtype over `Integer`) and `GtidUUID` (newtype over `Text`) to replace bare primitives in `GtidInterval` and `GtidEntry`, preventing type-level misuse at compile time
- Add `renderGtidEntry :: GtidEntry -> Text` and `renderGtidSet :: [GtidEntry] -> Text` as the render counterpart to `parseGtidIntervals`, completing the bidirectional parsing pattern
- Add `mkGtidInterval :: Integer -> Integer -> Either String GtidInterval` smart constructor that validates `giStart <= giEnd`
- Add QuickCheck roundtrip property (`parse . renderGtidSet == Right`) and unit tests for all new functions (206 tests total, all passing)
- Update `ErrantGtid.hs` and both test files to use the new newtype constructors

Closes #53

## Test plan
- [x] `cabal build all` passes with no errors
- [x] `cabal test` passes all 206 examples (0 failures)
- [x] QuickCheck roundtrip property verified over 100 generated inputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)