### PR TITLE
docs: slim down README and move details to docs/

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ Inspired by the design philosophy of Orchestrator, PureMyHA provides topology di
 - **Pause/Resume Auto-Failover** — Temporarily disable automatic failover for maintenance windows
 - **HTTP Health Check Endpoint** — Optional read-only HTTP listener for load balancer probes and Kubernetes liveness/readiness checks (`GET /health`, `/cluster/:name/status`, `/cluster/:name/topology`)
 - **Prometheus Metrics Endpoint** — `GET /metrics` exposes cluster health, replication lag, consecutive failures, and node role in Prometheus text exposition format for Grafana and other monitoring stacks
-- **Runtime Log Level Control** — Change log verbosity without restarting the daemon via `puremyha set-log-level debug|info|warn|error` (IPC override takes precedence until the next SIGHUP, which resets to the configured `log_level`)
-- **Config Validation** — `puremyha validate-config` validates the config file offline (no daemon required), reporting YAML parse errors, missing required fields, and semantic constraint violations (port ranges, threshold ordering, etc.)
+- **Runtime Log Level Control** — Change log verbosity without restarting the daemon via `puremyha set-log-level debug|info|warn|error`
+- **Config Validation** — `puremyha validate-config` validates the config file offline (no daemon required)
 
 ## Requirements
 
@@ -45,38 +45,7 @@ Inspired by the design philosophy of Orchestrator, PureMyHA provides topology di
 - **OS**: Linux
 - **HA for PureMyHA itself** *(optional)*: Pacemaker + QDevice (recommended) or VIP-watching cron / systemd.timer (simple)
 
-### MySQL Users
-
-PureMyHA uses two distinct MySQL users.
-
-#### Monitoring / management user
-
-Connects to every node for health checks, topology discovery, and failover operations.
-
-```sql
-CREATE USER 'puremyha'@'%' IDENTIFIED BY '...';
-
--- Fine-grained privileges (MySQL 8.0+, recommended):
-GRANT REPLICATION CLIENT      ON *.* TO 'puremyha'@'%';  -- SHOW REPLICA STATUS, SHOW REPLICAS
-GRANT PROCESS                 ON *.* TO 'puremyha'@'%';  -- SHOW PROCESSLIST (topology discovery)
-GRANT REPLICATION_SLAVE_ADMIN ON *.* TO 'puremyha'@'%';  -- STOP/START REPLICA, RESET REPLICA ALL, CHANGE REPLICATION SOURCE TO
-GRANT SYSTEM_VARIABLES_ADMIN  ON *.* TO 'puremyha'@'%';  -- SET GLOBAL read_only
-GRANT REPLICATION_APPLIER     ON *.* TO 'puremyha'@'%';  -- SET GTID_NEXT (errant GTID repair)
-
--- Or with the legacy SUPER privilege:
--- GRANT REPLICATION CLIENT, SUPER ON *.* TO 'puremyha'@'%';
-```
-
-#### Replication user
-
-Used as `SOURCE_USER` in `CHANGE REPLICATION SOURCE TO` when reconnecting replicas after a failover or switchover. This is the same user already configured on each replica's `CHANGE REPLICATION SOURCE TO` statement.
-
-```sql
-CREATE USER 'repl'@'%' IDENTIFIED BY '...';
-GRANT REPLICATION SLAVE ON *.* TO 'repl'@'%';
-```
-
-> **Note:** If you use the same account for both monitoring and replication, omit `replication_credentials` from the config. PureMyHA will fall back to `credentials` automatically.
+See [docs/configuration.md](docs/configuration.md) for required MySQL user privileges and full configuration reference.
 
 ## Architecture
 
@@ -96,14 +65,7 @@ graph LR
 Daemon and CLI communicate over a Unix domain socket (`/run/puremyhad.sock`) using newline-delimited JSON.
 An optional HTTP listener (disabled by default) exposes read-only health check endpoints for external probes.
 
-### Daemon HA
-
-PureMyHA does **not** implement leader election itself. Two approaches are available:
-
-- **Pacemaker (recommended)** — full cluster management with STONITH fencing
-- **VIP-watching cron / systemd.timer (simple)** — lightweight alternative when a VIP is already managed by keepalived
-
-See [docs/daemon-ha.md](docs/daemon-ha.md) for setup instructions for both approaches.
+PureMyHA does **not** implement leader election itself. See [docs/daemon-ha.md](docs/daemon-ha.md) for Pacemaker and VIP-watching setup instructions.
 
 ## Installation
 
@@ -165,8 +127,6 @@ docker rm tmp
 
 ## Configuration
 
-Default path: `/etc/puremyha/config.yaml`
-
 ```yaml
 clusters:
   - name: main
@@ -178,91 +138,27 @@ clusters:
     credentials:
       user: puremyha
       password_file: /etc/puremyha/mysql.pass
-    replication_credentials:           # Optional; falls back to credentials if omitted
-      user: repl
-      password_file: /etc/puremyha/repl.pass
-    # monitoring / failure_detection / failover / hooks can be specified here
-    # to override the global defaults for this cluster only.
 
 global:
   monitoring:
     interval: 3s
     connect_timeout: 2s
-    replication_lag_warning: 10s
-    replication_lag_critical: 30s
-    discovery_interval: 300s   # Optional; 0s = disabled. Default: 300s
   failure_detection:
-    recovery_block_period: 3600s   # Block auto-failover for this long after a failover
-    consecutive_failures_for_dead: 3  # Require N consecutive probe failures before marking a node dead (default: 3)
+    consecutive_failures_for_dead: 3
+    recovery_block_period: 3600s
   failover:
     auto_failover: true
     min_replicas_for_failover: 1
-    wait_for_relay_log_apply_timeout: 60s  # Optional; default: 60s
-    candidate_priority:            # Optional promotion priority (auto-selected by GTID if omitted)
-      - host: db2
-  hooks:
-    pre_failover: /etc/puremyha/hooks/pre_failover.sh
-    post_failover: /etc/puremyha/hooks/post_failover.sh
-    pre_switchover: /etc/puremyha/hooks/pre_switchover.sh
-    post_switchover: /etc/puremyha/hooks/post_switchover.sh
-    on_failure_detection: /etc/puremyha/hooks/on_failure_detection.sh    # Optional
-    post_unsuccessful_failover: /etc/puremyha/hooks/post_unsuccessful_failover.sh  # Optional
-
-http:                                  # Optional HTTP server (disabled by default)
-  enabled: false
-  listen_address: "127.0.0.1"        # Use "0.0.0.0" to listen on all interfaces
-  port: 8080
-  # Endpoints (read-only, GET only):
-  #   GET /health                 → 200 {"status":"ok"} / 503 {"status":"degraded"}
-  #   GET /cluster/:name/status   → ClusterStatus JSON
-  #   GET /cluster/:name/topology → ClusterTopologyView JSON
-  #   GET /metrics                → Prometheus text format metrics (all clusters)
-
-logging:
-  log_file: /var/log/puremyha.log  # Optional; defaults to /var/log/puremyha.log
-  log_level: info                   # Optional; debug | info | warn | error (default: info)
 ```
 
-`monitoring`, `failure_detection`, `failover`, and `hooks` can be set per-cluster or defined as defaults in the `global` section. Per-cluster settings take precedence over `global` on a section-by-section basis. `monitoring`, `failure_detection`, and `failover` are required in at least one of the two. The `logging` section is optional and global (defaults to `/var/log/puremyha.log` and `log_level: info` when omitted).
-
-See `config/config.yaml.example` for a full annotated example.
+See [docs/configuration.md](docs/configuration.md) for the full configuration reference including all fields, per-cluster overrides, and MySQL user setup.
 
 ## Usage
 
-### Start the daemon
-
 ```bash
+# Start the daemon
 puremyhad --config /etc/puremyha/config.yaml
-```
 
-### Daemon management
-
-| Signal | Effect |
-|--------|--------|
-| `SIGTERM` / `SIGINT` | Graceful shutdown — stops all workers and removes the socket file |
-| `SIGHUP` | Hot-reload `monitoring`, `hooks`, `http`, and `log_level` config without restart |
-| `SIGUSR1` | Reopen the log file (for log rotation tools such as logrotate) |
-
-```bash
-# Reload config (e.g. after editing intervals, hooks, or log_level)
-systemctl reload puremyhad        # via systemd (preferred)
-kill -HUP $(pidof puremyhad)      # direct signal (non-systemd)
-
-# Graceful stop
-kill -TERM $(pidof puremyhad)
-```
-
-### Global flags
-
-| Flag | Short | Default | Description |
-|------|-------|---------|-------------|
-| `--socket PATH` | — | `/run/puremyhad.sock` | Daemon socket path |
-| `--cluster NAME` | `-C` | — | Target cluster (omit to apply to all) |
-| `--json` | `-j` | — | Output in JSON format instead of text |
-
-### CLI commands
-
-```bash
 # Show topology and node health
 puremyha status
 
@@ -270,187 +166,23 @@ puremyha status
 puremyha topology
 
 # Manual switchover (planned maintenance)
-puremyha switchover [--to=<host>] [--cluster=<name>]
+puremyha switchover [--to=<host>]
 
-# Dry-run: show which replica would be promoted without executing
-puremyha switchover --dry-run [--to=<host>]
-
-# Acknowledge recovery block (re-enable auto-failover after anti-flap period)
-puremyha ack-recovery [--cluster=<name>]
-
-# Detect errant GTIDs
-puremyha errant-gtid [--cluster=<name>]
-
-# Fix errant GTIDs by injecting empty transactions
-puremyha fix-errant-gtid [--cluster=<name>]
-
-# Demote a node to replica under a specified source (resolve split-brain)
-puremyha demote --host db1 --source db2 [--cluster=<name>]
-
-# Pause replication on a replica (STOP REPLICA + stop monitoring)
-puremyha pause-replica --host db2 [--cluster=<name>]
-
-# Resume replication on a paused replica (START REPLICA + resume monitoring)
-puremyha resume-replica --host db2 [--cluster=<name>]
-
-# Trigger manual topology discovery
-puremyha discovery [--cluster=<name>]
-
-# Pause automatic failover (e.g. during maintenance)
-puremyha pause-failover [--cluster=<name>]
-
-# Resume automatic failover
-puremyha resume-failover [--cluster=<name>]
-
-# Change daemon log level at runtime (no restart required)
-# IPC override takes precedence until the next SIGHUP
-puremyha set-log-level debug|info|warn|error
-
-# Validate config file without connecting to the daemon
-# Checks YAML syntax, required fields, and semantic constraints (port ranges, threshold ordering, etc.)
-puremyha validate-config [--config /etc/puremyha/config.yaml]
-
-# JSON output (for scripting / Prometheus exporters)
-puremyha --json status
-puremyha -j topology
-puremyha -j errant-gtid
-puremyha -j switchover --to db2
-
-# Pipe to jq
-puremyha -j status | jq '.[0].health'
-puremyha -j topology | jq '.[0].nodes[].host'
-
-# validate-config JSON output
-puremyha --json validate-config --config /etc/puremyha/config.yaml
-# → {"valid":true} or {"valid":false,"errors":["cluster 'main': node port 99999 is out of range (1-65535)",...]}
+# Validate config file offline
+puremyha validate-config
 ```
 
-## HTTP Health Check Endpoints
+See [docs/cli.md](docs/cli.md) for the full CLI reference including all commands, global flags, and JSON output examples.
 
-When `http.enabled: true` is set in the config, `puremyhad` exposes a lightweight read-only HTTP server for external health checks. All endpoints are `GET`-only; write operations remain Unix-socket-only.
+## Documentation
 
-| Endpoint | Success | Failure | Use case |
-|----------|---------|---------|----------|
-| `GET /health` | `200 {"status":"ok"}` | `503 {"status":"degraded"}` | Kubernetes liveness probe |
-| `GET /cluster/:name/status` | `200 ClusterStatus JSON` | `404` if cluster not found | Readiness probe / LB routing |
-| `GET /cluster/:name/topology` | `200 ClusterTopologyView JSON` | `404` if cluster not found | Monitoring dashboards |
-
-`/health` returns `200` if at least one cluster is in `Healthy` state, `503` otherwise (e.g. dead source, split-brain, all replicas unreachable).
-
-### Examples
-
-```bash
-# Liveness probe
-curl http://127.0.0.1:8080/health
-# → {"status":"ok"}  (200) or {"status":"degraded"}  (503)
-
-# Cluster status — same JSON shape as `puremyha -j status`
-curl http://127.0.0.1:8080/cluster/main/status | jq .
-# → {"clusterName":"main","health":"Healthy","sourceHost":"db1","nodeCount":2,...}
-
-# Topology — same JSON shape as `puremyha -j topology`
-curl http://127.0.0.1:8080/cluster/main/topology | jq '.nodes[].host'
-```
-
-### Kubernetes probe example
-
-```yaml
-livenessProbe:
-  httpGet:
-    path: /health
-    port: 8080
-  initialDelaySeconds: 10
-  periodSeconds: 5
-
-readinessProbe:
-  httpGet:
-    path: /cluster/main/status
-    port: 8080
-  initialDelaySeconds: 5
-  periodSeconds: 3
-```
-
-### HAProxy backend check example
-
-```
-backend mysql_source
-    option httpchk GET /cluster/main/status
-    server db1 db1:3306 check port 8080
-    server db2 db2:3306 check port 8080
-```
-
-## Logging
-
-PureMyHA writes structured, timestamped logs via [katip](https://hackage.haskell.org/package/katip). The log file path is configured with `logging.log_file` (default: `/var/log/puremyha.log`).
-
-### Log level
-
-The minimum log level is set via `logging.log_level` in the config (default: `info`). Valid values: `debug`, `info`, `warn`, `error`.
-
-```yaml
-logging:
-  log_level: info   # debug | info | warn | error
-```
-
-The level can also be changed at runtime without restarting the daemon:
-
-```bash
-# Increase verbosity for incident investigation
-puremyha set-log-level debug
-
-# Restore to normal
-puremyha set-log-level info
-```
-
-The IPC override takes precedence until the next SIGHUP, which resets the level to whatever is in the config file.
-
-### Logged events
-
-| Event | Level |
-|-------|-------|
-| Daemon started | Info |
-| Node probe failed (below consecutive threshold) | Info |
-| Node unreachable / connect failed (threshold reached) | Warn |
-| Node recovered | Info |
-| Auto-failover started / completed / failed | Info / Error |
-| Switchover started / completed / failed | Info / Error |
-| Config reloaded (SIGHUP) | Info |
-| Config reload failed (SIGHUP) | Warn |
-| Topology refresh: N new node(s) found | Info |
-| Daemon shutting down | Info |
-
-### Example output
-
-```
-[2026-03-17 12:34:56 UTC] [Info] puremyhad started
-[2026-03-17 12:35:01 UTC] [Warn] [main] Node db1 unreachable: Connection refused
-[2026-03-17 12:35:10 UTC] [Info] [main] Auto-failover started
-[2026-03-17 12:35:12 UTC] [Info] [main] Auto-failover completed: new source is db2
-[2026-03-17 12:35:13 UTC] [Info] [main] Node db1 recovered
-```
-
-## Failover Flow
-
-When `DeadSource` is detected, the daemon automatically:
-
-1. Runs `pre_failover` hook
-2. Selects the best replica (highest `Executed_Gtid_Set`, no errant GTIDs, respects `candidate_priority`)
-3. Waits for the candidate to apply all retrieved GTIDs (`wait_for_relay_log_apply_timeout`, default 60 s)
-4. Promotes: `STOP REPLICA` → `RESET REPLICA ALL` → `SET read_only=OFF`
-5. Reconnects remaining replicas: `CHANGE REPLICATION SOURCE TO SOURCE_HOST=... SOURCE_USER=... SOURCE_PASSWORD=... SOURCE_AUTO_POSITION=1`
-6. Runs `post_failover` hook
-7. Sets `recovery_block_period` anti-flap timer
-
-## Failure Scenarios
-
-| Scenario | Definition |
-|---------|------------|
-| `Healthy` | Normal operation |
-| `DeadSource` | Source unreachable and replicas confirm `Replica_IO_Running=No` |
-| `UnreachableSource` | Source unreachable from PureMyHA, but replicas can still reach it (possible network partition) |
-| `DeadSourceAndAllReplicas` | Source and all replicas are unresponsive |
-| `SplitBrainSuspected` | Multiple nodes appear to be acting as source |
-| `NeedsAttention` | Other anomaly (errant GTIDs, stale replication, etc.) |
+- [docs/configuration.md](docs/configuration.md) — Full configuration reference and MySQL user setup
+- [docs/cli.md](docs/cli.md) — CLI commands and global flags
+- [docs/http-api.md](docs/http-api.md) — HTTP health check and Prometheus metrics endpoints
+- [docs/logging.md](docs/logging.md) — Log levels, events, and log rotation
+- [docs/failover.md](docs/failover.md) — Failover flow and failure scenarios
+- [docs/daemon-ha.md](docs/daemon-ha.md) — Daemon HA setup (Pacemaker and VIP-watching)
+- [docs/development.md](docs/development.md) — Build instructions and E2E test setup
 
 ## Technology Stack
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,97 @@
+# CLI Reference
+
+## Global Flags
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--socket PATH` | — | `/run/puremyhad.sock` | Daemon socket path |
+| `--cluster NAME` | `-C` | — | Target cluster (omit to apply to all) |
+| `--json` | `-j` | — | Output in JSON format instead of text |
+
+## Commands
+
+```bash
+# Show topology and node health
+puremyha status
+
+# Show replication tree
+puremyha topology
+
+# Manual switchover (planned maintenance)
+puremyha switchover [--to=<host>] [--cluster=<name>]
+
+# Dry-run: show which replica would be promoted without executing
+puremyha switchover --dry-run [--to=<host>]
+
+# Acknowledge recovery block (re-enable auto-failover after anti-flap period)
+puremyha ack-recovery [--cluster=<name>]
+
+# Detect errant GTIDs
+puremyha errant-gtid [--cluster=<name>]
+
+# Fix errant GTIDs by injecting empty transactions
+puremyha fix-errant-gtid [--cluster=<name>]
+
+# Demote a node to replica under a specified source (resolve split-brain)
+puremyha demote --host db1 --source db2 [--cluster=<name>]
+
+# Pause replication on a replica (STOP REPLICA + stop monitoring)
+puremyha pause-replica --host db2 [--cluster=<name>]
+
+# Resume replication on a paused replica (START REPLICA + resume monitoring)
+puremyha resume-replica --host db2 [--cluster=<name>]
+
+# Trigger manual topology discovery
+puremyha discovery [--cluster=<name>]
+
+# Pause automatic failover (e.g. during maintenance)
+puremyha pause-failover [--cluster=<name>]
+
+# Resume automatic failover
+puremyha resume-failover [--cluster=<name>]
+
+# Change daemon log level at runtime (no restart required)
+# IPC override takes precedence until the next SIGHUP
+puremyha set-log-level debug|info|warn|error
+
+# Validate config file without connecting to the daemon
+# Checks YAML syntax, required fields, and semantic constraints (port ranges, threshold ordering, etc.)
+puremyha validate-config [--config /etc/puremyha/config.yaml]
+```
+
+## JSON Output
+
+Use `--json` / `-j` for scripting and Prometheus exporters:
+
+```bash
+# JSON output
+puremyha --json status
+puremyha -j topology
+puremyha -j errant-gtid
+puremyha -j switchover --to db2
+
+# Pipe to jq
+puremyha -j status | jq '.[0].health'
+puremyha -j topology | jq '.[0].nodes[].host'
+
+# validate-config JSON output
+puremyha --json validate-config --config /etc/puremyha/config.yaml
+# → {"valid":true} or {"valid":false,"errors":["cluster 'main': node port 99999 is out of range (1-65535)",...]}
+```
+
+## Daemon Signals
+
+| Signal | Effect |
+|--------|--------|
+| `SIGTERM` / `SIGINT` | Graceful shutdown — stops all workers and removes the socket file |
+| `SIGHUP` | Hot-reload `monitoring`, `hooks`, `http`, and `log_level` config without restart |
+| `SIGUSR1` | Reopen the log file (for log rotation tools such as logrotate) |
+
+```bash
+# Reload config (e.g. after editing intervals, hooks, or log_level)
+systemctl reload puremyhad        # via systemd (preferred)
+kill -HUP $(pidof puremyhad)      # direct signal (non-systemd)
+
+# Graceful stop
+kill -TERM $(pidof puremyhad)
+```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,102 @@
+# Configuration Reference
+
+Default config path: `/etc/puremyha/config.yaml`
+
+See `config/config.yaml.example` for a full annotated example.
+
+## MySQL Users
+
+PureMyHA uses two distinct MySQL users.
+
+### Monitoring / management user
+
+Connects to every node for health checks, topology discovery, and failover operations.
+
+```sql
+CREATE USER 'puremyha'@'%' IDENTIFIED BY '...';
+
+-- Fine-grained privileges (MySQL 8.0+, recommended):
+GRANT REPLICATION CLIENT      ON *.* TO 'puremyha'@'%';  -- SHOW REPLICA STATUS, SHOW REPLICAS
+GRANT PROCESS                 ON *.* TO 'puremyha'@'%';  -- SHOW PROCESSLIST (topology discovery)
+GRANT REPLICATION_SLAVE_ADMIN ON *.* TO 'puremyha'@'%';  -- STOP/START REPLICA, RESET REPLICA ALL, CHANGE REPLICATION SOURCE TO
+GRANT SYSTEM_VARIABLES_ADMIN  ON *.* TO 'puremyha'@'%';  -- SET GLOBAL read_only
+GRANT REPLICATION_APPLIER     ON *.* TO 'puremyha'@'%';  -- SET GTID_NEXT (errant GTID repair)
+
+-- Or with the legacy SUPER privilege:
+-- GRANT REPLICATION CLIENT, SUPER ON *.* TO 'puremyha'@'%';
+```
+
+### Replication user
+
+Used as `SOURCE_USER` in `CHANGE REPLICATION SOURCE TO` when reconnecting replicas after a failover or switchover. This is the same user already configured on each replica's `CHANGE REPLICATION SOURCE TO` statement.
+
+```sql
+CREATE USER 'repl'@'%' IDENTIFIED BY '...';
+GRANT REPLICATION SLAVE ON *.* TO 'repl'@'%';
+```
+
+> **Note:** If you use the same account for both monitoring and replication, omit `replication_credentials` from the config. PureMyHA will fall back to `credentials` automatically.
+
+## Full Configuration Reference
+
+```yaml
+clusters:
+  - name: main
+    nodes:
+      - host: db1
+        port: 3306
+      - host: db2
+        port: 3306
+    credentials:
+      user: puremyha
+      password_file: /etc/puremyha/mysql.pass
+    replication_credentials:           # Optional; falls back to credentials if omitted
+      user: repl
+      password_file: /etc/puremyha/repl.pass
+    # monitoring / failure_detection / failover / hooks can be specified here
+    # to override the global defaults for this cluster only.
+
+global:
+  monitoring:
+    interval: 3s
+    connect_timeout: 2s
+    replication_lag_warning: 10s
+    replication_lag_critical: 30s
+    discovery_interval: 300s   # Optional; 0s = disabled. Default: 300s
+  failure_detection:
+    recovery_block_period: 3600s   # Block auto-failover for this long after a failover
+    consecutive_failures_for_dead: 3  # Require N consecutive probe failures before marking a node dead (default: 3)
+  failover:
+    auto_failover: true
+    min_replicas_for_failover: 1
+    wait_for_relay_log_apply_timeout: 60s  # Optional; default: 60s
+    candidate_priority:            # Optional promotion priority (auto-selected by GTID if omitted)
+      - host: db2
+  hooks:
+    pre_failover: /etc/puremyha/hooks/pre_failover.sh
+    post_failover: /etc/puremyha/hooks/post_failover.sh
+    pre_switchover: /etc/puremyha/hooks/pre_switchover.sh
+    post_switchover: /etc/puremyha/hooks/post_switchover.sh
+    on_failure_detection: /etc/puremyha/hooks/on_failure_detection.sh    # Optional
+    post_unsuccessful_failover: /etc/puremyha/hooks/post_unsuccessful_failover.sh  # Optional
+
+http:                                  # Optional HTTP server (disabled by default)
+  enabled: false
+  listen_address: "127.0.0.1"        # Use "0.0.0.0" to listen on all interfaces
+  port: 8080
+  # Endpoints (read-only, GET only):
+  #   GET /health                 → 200 {"status":"ok"} / 503 {"status":"degraded"}
+  #   GET /cluster/:name/status   → ClusterStatus JSON
+  #   GET /cluster/:name/topology → ClusterTopologyView JSON
+  #   GET /metrics                → Prometheus text format metrics (all clusters)
+
+logging:
+  log_file: /var/log/puremyha.log  # Optional; defaults to /var/log/puremyha.log
+  log_level: info                   # Optional; debug | info | warn | error (default: info)
+```
+
+## Precedence Rules
+
+`monitoring`, `failure_detection`, `failover`, and `hooks` can be set per-cluster or defined as defaults in the `global` section. Per-cluster settings take precedence over `global` on a section-by-section basis. `monitoring`, `failure_detection`, and `failover` are required in at least one of the two.
+
+The `logging` section is optional and global (defaults to `/var/log/puremyha.log` and `log_level: info` when omitted).

--- a/docs/failover.md
+++ b/docs/failover.md
@@ -1,0 +1,44 @@
+# Failover Behavior
+
+## Automatic Failover Flow
+
+When `DeadSource` is detected, the daemon automatically:
+
+1. Runs `pre_failover` hook
+2. Selects the best replica (highest `Executed_Gtid_Set`, no errant GTIDs, respects `candidate_priority`)
+3. Waits for the candidate to apply all retrieved GTIDs (`wait_for_relay_log_apply_timeout`, default 60 s)
+4. Promotes: `STOP REPLICA` → `RESET REPLICA ALL` → `SET read_only=OFF`
+5. Reconnects remaining replicas: `CHANGE REPLICATION SOURCE TO SOURCE_HOST=... SOURCE_USER=... SOURCE_PASSWORD=... SOURCE_AUTO_POSITION=1`
+6. Runs `post_failover` hook
+7. Sets `recovery_block_period` anti-flap timer
+
+## Failure Scenarios
+
+| Scenario | Definition |
+|---------|------------|
+| `Healthy` | Normal operation |
+| `DeadSource` | Source unreachable and replicas confirm `Replica_IO_Running=No` |
+| `UnreachableSource` | Source unreachable from PureMyHA, but replicas can still reach it (possible network partition) |
+| `DeadSourceAndAllReplicas` | Source and all replicas are unresponsive |
+| `SplitBrainSuspected` | Multiple nodes appear to be acting as source |
+| `NeedsAttention` | Other anomaly (errant GTIDs, stale replication, etc.) |
+
+## Anti-Flap Protection
+
+After a failover completes, automatic failover is blocked for `recovery_block_period` (default: 3600s). To re-enable it manually:
+
+```bash
+puremyha ack-recovery [--cluster=<name>]
+```
+
+## Errant GTID Detection & Repair
+
+Errant GTIDs are detected automatically during candidate selection. They can also be managed manually:
+
+```bash
+# Detect errant GTIDs
+puremyha errant-gtid [--cluster=<name>]
+
+# Fix by injecting empty transactions on the source
+puremyha fix-errant-gtid [--cluster=<name>]
+```

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -1,0 +1,67 @@
+# HTTP API Reference
+
+When `http.enabled: true` is set in the config, `puremyhad` exposes a lightweight read-only HTTP server for external health checks. All endpoints are `GET`-only; write operations remain Unix-socket-only.
+
+## Endpoints
+
+| Endpoint | Success | Failure | Use case |
+|----------|---------|---------|----------|
+| `GET /health` | `200 {"status":"ok"}` | `503 {"status":"degraded"}` | Kubernetes liveness probe |
+| `GET /cluster/:name/status` | `200 ClusterStatus JSON` | `404` if cluster not found | Readiness probe / LB routing |
+| `GET /cluster/:name/topology` | `200 ClusterTopologyView JSON` | `404` if cluster not found | Monitoring dashboards |
+| `GET /metrics` | `200` Prometheus text format | — | Grafana and other monitoring stacks |
+
+`/health` returns `200` if at least one cluster is in `Healthy` state, `503` otherwise (e.g. dead source, split-brain, all replicas unreachable).
+
+`/metrics` exposes cluster health, replication lag, consecutive failures, and node role in Prometheus text exposition format.
+
+## Examples
+
+```bash
+# Liveness probe
+curl http://127.0.0.1:8080/health
+# → {"status":"ok"}  (200) or {"status":"degraded"}  (503)
+
+# Cluster status — same JSON shape as `puremyha -j status`
+curl http://127.0.0.1:8080/cluster/main/status | jq .
+# → {"clusterName":"main","health":"Healthy","sourceHost":"db1","nodeCount":2,...}
+
+# Topology — same JSON shape as `puremyha -j topology`
+curl http://127.0.0.1:8080/cluster/main/topology | jq '.nodes[].host'
+```
+
+## Kubernetes Probe Example
+
+```yaml
+livenessProbe:
+  httpGet:
+    path: /health
+    port: 8080
+  initialDelaySeconds: 10
+  periodSeconds: 5
+
+readinessProbe:
+  httpGet:
+    path: /cluster/main/status
+    port: 8080
+  initialDelaySeconds: 5
+  periodSeconds: 3
+```
+
+## HAProxy Backend Check Example
+
+```
+backend mysql_source
+    option httpchk GET /cluster/main/status
+    server db1 db1:3306 check port 8080
+    server db2 db2:3306 check port 8080
+```
+
+## Configuration
+
+```yaml
+http:
+  enabled: true
+  listen_address: "127.0.0.1"   # Use "0.0.0.0" to listen on all interfaces
+  port: 8080
+```

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,0 +1,58 @@
+# Logging
+
+PureMyHA writes structured, timestamped logs via [katip](https://hackage.haskell.org/package/katip). The log file path is configured with `logging.log_file` (default: `/var/log/puremyha.log`).
+
+## Log Level
+
+The minimum log level is set via `logging.log_level` in the config (default: `info`). Valid values: `debug`, `info`, `warn`, `error`.
+
+```yaml
+logging:
+  log_level: info   # debug | info | warn | error
+```
+
+The level can also be changed at runtime without restarting the daemon:
+
+```bash
+# Increase verbosity for incident investigation
+puremyha set-log-level debug
+
+# Restore to normal
+puremyha set-log-level info
+```
+
+The IPC override takes precedence until the next SIGHUP, which resets the level to whatever is in the config file.
+
+## Logged Events
+
+| Event | Level |
+|-------|-------|
+| Daemon started | Info |
+| Node probe failed (below consecutive threshold) | Info |
+| Node unreachable / connect failed (threshold reached) | Warn |
+| Node recovered | Info |
+| Auto-failover started / completed / failed | Info / Error |
+| Switchover started / completed / failed | Info / Error |
+| Config reloaded (SIGHUP) | Info |
+| Config reload failed (SIGHUP) | Warn |
+| Topology refresh: N new node(s) found | Info |
+| Daemon shutting down | Info |
+
+## Example Output
+
+```
+[2026-03-17 12:34:56 UTC] [Info] puremyhad started
+[2026-03-17 12:35:01 UTC] [Warn] [main] Node db1 unreachable: Connection refused
+[2026-03-17 12:35:10 UTC] [Info] [main] Auto-failover started
+[2026-03-17 12:35:12 UTC] [Info] [main] Auto-failover completed: new source is db2
+[2026-03-17 12:35:13 UTC] [Info] [main] Node db1 recovered
+```
+
+## Log Rotation
+
+Send `SIGUSR1` to reopen the log file after rotation:
+
+```bash
+# logrotate postrotate example
+kill -USR1 $(pidof puremyhad)
+```


### PR DESCRIPTION
## Summary
- README was 473 lines with all documentation in one monolithic file
- Moved detailed sections to dedicated files under `docs/`:
  - `docs/configuration.md` — MySQL user setup and full config YAML reference
  - `docs/cli.md` — global flags, all CLI commands, JSON output examples
  - `docs/http-api.md` — HTTP endpoints, Kubernetes probe, HAProxy example
  - `docs/logging.md` — log levels, events table, log rotation
  - `docs/failover.md` — failover flow steps and failure scenarios
- README is now ~200 lines focused on overview, quick start, and a Documentation links section
- Closes #65

## Test plan
- [ ] Verify all links in README point to existing files in `docs/`
- [ ] Verify each new `docs/*.md` file is complete and self-contained
- [ ] Confirm `cabal build all` and `cabal test` still pass (no source changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)