### PR TITLE
docs: remove duplicate YAML from docs/configuration.md

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,8 +2,6 @@
 
 Default config path: `/etc/puremyha/config.yaml`
 
-See `config/config.yaml.example` for a full annotated example.
-
 ## MySQL Users
 
 PureMyHA uses two distinct MySQL users.
@@ -39,61 +37,7 @@ GRANT REPLICATION SLAVE ON *.* TO 'repl'@'%';
 
 ## Full Configuration Reference
 
-```yaml
-clusters:
-  - name: main
-    nodes:
-      - host: db1
-        port: 3306
-      - host: db2
-        port: 3306
-    credentials:
-      user: puremyha
-      password_file: /etc/puremyha/mysql.pass
-    replication_credentials:           # Optional; falls back to credentials if omitted
-      user: repl
-      password_file: /etc/puremyha/repl.pass
-    # monitoring / failure_detection / failover / hooks can be specified here
-    # to override the global defaults for this cluster only.
-
-global:
-  monitoring:
-    interval: 3s
-    connect_timeout: 2s
-    replication_lag_warning: 10s
-    replication_lag_critical: 30s
-    discovery_interval: 300s   # Optional; 0s = disabled. Default: 300s
-  failure_detection:
-    recovery_block_period: 3600s   # Block auto-failover for this long after a failover
-    consecutive_failures_for_dead: 3  # Require N consecutive probe failures before marking a node dead (default: 3)
-  failover:
-    auto_failover: true
-    min_replicas_for_failover: 1
-    wait_for_relay_log_apply_timeout: 60s  # Optional; default: 60s
-    candidate_priority:            # Optional promotion priority (auto-selected by GTID if omitted)
-      - host: db2
-  hooks:
-    pre_failover: /etc/puremyha/hooks/pre_failover.sh
-    post_failover: /etc/puremyha/hooks/post_failover.sh
-    pre_switchover: /etc/puremyha/hooks/pre_switchover.sh
-    post_switchover: /etc/puremyha/hooks/post_switchover.sh
-    on_failure_detection: /etc/puremyha/hooks/on_failure_detection.sh    # Optional
-    post_unsuccessful_failover: /etc/puremyha/hooks/post_unsuccessful_failover.sh  # Optional
-
-http:                                  # Optional HTTP server (disabled by default)
-  enabled: false
-  listen_address: "127.0.0.1"        # Use "0.0.0.0" to listen on all interfaces
-  port: 8080
-  # Endpoints (read-only, GET only):
-  #   GET /health                 → 200 {"status":"ok"} / 503 {"status":"degraded"}
-  #   GET /cluster/:name/status   → ClusterStatus JSON
-  #   GET /cluster/:name/topology → ClusterTopologyView JSON
-  #   GET /metrics                → Prometheus text format metrics (all clusters)
-
-logging:
-  log_file: /var/log/puremyha.log  # Optional; defaults to /var/log/puremyha.log
-  log_level: info                   # Optional; debug | info | warn | error (default: info)
-```
+See [`config/config.yaml.example`](../config/config.yaml.example) for the complete annotated configuration file.
 
 ## Precedence Rules
 


### PR DESCRIPTION
## Summary
- `docs/configuration.md` contained a verbatim copy of the config YAML from `config/config.yaml.example`, causing dual maintenance
- The embedded YAML block was also incomplete (missing `connect_retries`, `connect_retry_backoff` fields)
- Replaced the duplicate block with a link to `config/config.yaml.example`, which is the single authoritative reference (also shipped in .deb/.rpm packages)

## Test plan
- [ ] Verify `docs/configuration.md` no longer contains a YAML block
- [ ] Verify the link `../config/config.yaml.example` resolves correctly from within `docs/`
- [ ] `cabal build all` and `cabal test` unaffected (docs-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)