### PR TITLE
docs: replace Japanese comments with English

### DIFF
--- a/src/PureMyHA/Failover/Candidate.hs
+++ b/src/PureMyHA/Failover/Candidate.hs
@@ -95,6 +95,6 @@ priorityRank priorities host =
     (rank:_) -> rank
     []       -> maxBound
 
--- | GTID セット中のトランザクション総数をスコアとして返す。
+-- | Returns the total number of transactions in a GTID set as a score.
 gtidScore :: CandidateInfo -> Integer
 gtidScore = gtidTransactionCount . ciExecutedGtid

--- a/src/PureMyHA/MySQL/GTID.hs
+++ b/src/PureMyHA/MySQL/GTID.hs
@@ -87,8 +87,8 @@ renderGtidEntry (GtidEntry uuid ivs) =
 renderGtidSet :: [GtidEntry] -> Text
 renderGtidSet = T.intercalate "," . map renderGtidEntry
 
--- | GTID セット文字列中のトランザクション総数を返す。
--- パースエラーまたは空文字列の場合は 0 を返す。
+-- | Returns the total number of transactions in a GTID set string.
+-- Returns 0 on parse error or empty string.
 gtidTransactionCount :: Text -> Integer
 gtidTransactionCount t =
   case parseGtidIntervals t of


### PR DESCRIPTION
## Summary
- Replace 3 Japanese-language Haddock/line comments with English equivalents in two modules
- `src/PureMyHA/MySQL/GTID.hs`: `gtidTransactionCount` function docs
- `src/PureMyHA/Failover/Candidate.hs`: `gtidScore` function doc

## Test plan
- [x] `cabal build all` passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)