### PR TITLE
docs: improve architecture diagram for multi-cluster, multi-replica, and HTTP clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,30 @@ See [docs/configuration.md](docs/configuration.md) for required MySQL user privi
 ```mermaid
 graph LR
     CLI["puremyha (CLI)"] <-->|"Unix socket\n/run/puremyhad.sock"| Daemon["puremyhad (daemon)"]
-    LB["Load balancer / K8s probe"] -->|"HTTP :8080\n(read-only)"| Daemon
-    Daemon -->|"per-node threads (STM)"| db1["db1 (source)"]
-    db1 -->|replication| db2["db2 (replica)"]
+    LB["Health probe / Metrics scraper"] -->|"HTTP :8080\n(read-only)"| Daemon
+
+    subgraph cluster1["Cluster 1"]
+        src1["db1 (source)"]
+        rep1a["db2 (replica)"]
+        rep1n["dbN (replica)"]
+        src1 -->|replication| rep1a
+        src1 -->|replication| rep1n
+    end
+
+    subgraph clusterN["Cluster N"]
+        srcN["db1 (source)"]
+        repNa["db2 (replica)"]
+        repNn["dbN (replica)"]
+        srcN -->|replication| repNa
+        srcN -->|replication| repNn
+    end
+
+    Daemon -->|"per-node threads (STM)"| src1
+    Daemon --> rep1a
+    Daemon --> rep1n
+    Daemon -->|"per-node threads (STM)"| srcN
+    Daemon --> repNa
+    Daemon --> repNn
 ```
 
 | Component    | Role |


### PR DESCRIPTION
## Summary

- Add monitoring arrows from `puremyhad` to all replica nodes (not only the source), reflecting that the daemon monitors every node in a cluster
- Show multiple replicas per cluster (`db2`, `dbN`) using Mermaid subgraphs to indicate N-replica support
- Show multiple clusters (`Cluster 1`, `Cluster N`) to make multi-cluster support visible at a glance
- Rename node label `"Load balancer / K8s probe"` → `"Health probe / Metrics scraper"` to cover all HTTP consumers: K8s liveness/readiness probes, LB routing, monitoring dashboards, and Prometheus scraping

Closes #70

## Test plan

- [x] Open the rendered README on GitHub and verify the Mermaid diagram displays correctly
- [x] Confirm monitoring arrows run from `puremyhad` to both source and replica nodes in each cluster
- [x] Confirm two clusters and two replicas per cluster are visible
- [x] Confirm the HTTP node label reads "Health probe / Metrics scraper"

🤖 Generated with [Claude Code](https://claude.com/claude-code)