### PR TITLE
feat: add HTTP /health check to OCF monitor and sync demo config

### DIFF
--- a/pacemaker-sample/demo/config/puremyha.yaml
+++ b/pacemaker-sample/demo/config/puremyha.yaml
@@ -17,8 +17,21 @@ global:
     connect_timeout: 2s
     replication_lag_warning: 10s
     replication_lag_critical: 30s
+    connect_retries: 2
+    connect_retry_backoff: 1s
   failure_detection:
     recovery_block_period: 3600s
+    consecutive_failures_for_dead: 3
   failover:
     auto_failover: true
     min_replicas_for_failover: 1
+    wait_for_relay_log_apply_timeout: 60s
+
+logging:
+  log_file: /var/log/puremyha.log
+  log_level: info
+
+http:
+  enabled: true
+  listen_address: "127.0.0.1"
+  port: 8080

--- a/pacemaker-sample/ocf/puremyha
+++ b/pacemaker-sample/ocf/puremyha
@@ -10,6 +10,7 @@
 #   pcs resource create puremyhad ocf:puremyha:puremyhad \
 #       config=/etc/puremyha/config.yaml \
 #       socket=/run/puremyhad.sock \
+#       http_port=8080 \
 #       op monitor interval=15s timeout=15s \
 #       op start  timeout=30s \
 #       op stop   timeout=60s
@@ -33,11 +34,13 @@ OCF_RESKEY_binary_default="/usr/sbin/puremyhad"
 OCF_RESKEY_config_default="/etc/puremyha/config.yaml"
 OCF_RESKEY_socket_default="/run/puremyhad.sock"
 OCF_RESKEY_pidfile_default="/run/puremyhad.pid"
+OCF_RESKEY_http_port_default=""
 
 : ${OCF_RESKEY_binary=${OCF_RESKEY_binary_default}}
 : ${OCF_RESKEY_config=${OCF_RESKEY_config_default}}
 : ${OCF_RESKEY_socket=${OCF_RESKEY_socket_default}}
 : ${OCF_RESKEY_pidfile=${OCF_RESKEY_pidfile_default}}
+: ${OCF_RESKEY_http_port=${OCF_RESKEY_http_port_default}}
 
 # --- Metadata ---
 
@@ -72,6 +75,15 @@ puremyha_meta_data() {
       <longdesc lang="en">Path to the PID file written by this RA.</longdesc>
       <shortdesc lang="en">PID file path</shortdesc>
       <content type="string" default="${OCF_RESKEY_pidfile_default}"/>
+    </parameter>
+    <parameter name="http_port" unique="0" required="0">
+      <longdesc lang="en">
+        TCP port of the puremyhad HTTP health endpoint (http.port in config.yaml).
+        When set, the monitor operation calls GET /health via curl and fails if the
+        HTTP server does not respond. Leave empty to skip the HTTP check.
+      </longdesc>
+      <shortdesc lang="en">HTTP health check port (optional)</shortdesc>
+      <content type="string" default="${OCF_RESKEY_http_port_default}"/>
     </parameter>
   </parameters>
   <actions>
@@ -181,6 +193,19 @@ puremyha_monitor() {
     if [ ! -S "${OCF_RESKEY_socket}" ]; then
         ocf_log warn "puremyhad process is running but socket ${OCF_RESKEY_socket} does not exist"
         return ${OCF_ERR_GENERIC}
+    fi
+    # If http_port is configured, verify the HTTP health endpoint is responsive.
+    # Both 200 (healthy) and 503 (degraded) mean puremyhad is serving requests.
+    # Any other result (connection refused, timeout) means the HTTP layer is down.
+    if [ -n "${OCF_RESKEY_http_port}" ]; then
+        local http_status
+        http_status=$(curl -s -o /dev/null -w "%{http_code}" \
+            --max-time 5 \
+            "http://127.0.0.1:${OCF_RESKEY_http_port}/health" 2>/dev/null)
+        if [ "${http_status}" != "200" ] && [ "${http_status}" != "503" ]; then
+            ocf_log warn "puremyhad /health did not respond (HTTP ${http_status})"
+            return ${OCF_ERR_GENERIC}
+        fi
     fi
     return ${OCF_SUCCESS}
 }

--- a/pacemaker-sample/setup.sh
+++ b/pacemaker-sample/setup.sh
@@ -146,9 +146,12 @@ pcs resource create puremyha-vip IPaddr2 \
 
 # --- SECTION 10: Create the puremyhad resource ---
 # Uses the OCF RA installed in Section 5.
+# Set http_port only if http.enabled=true in config.yaml (port must match http.port).
+# The monitor operation will then verify the /health endpoint on every check interval.
 pcs resource create puremyhad ocf:puremyha:puremyhad \
     config=/etc/puremyha/config.yaml \
     socket=/run/puremyhad.sock \
+    http_port=8080 \
     op start   timeout=30s \
     op stop    timeout=30s \
     op monitor interval=15s timeout=15s


### PR DESCRIPTION
## Summary

- **OCF Resource Agent**: Add optional `http_port` parameter to the Pacemaker resource agent. When set, the `monitor` operation calls `GET /health` via `curl` on every check interval. Both `200` (healthy) and `503` (degraded) confirm the HTTP layer is up; any other result (connection refused, timeout) returns `OCF_ERR_GENERIC` and triggers Pacemaker recovery.
- **Demo config**: Align `pacemaker-sample/demo/config/puremyha.yaml` with the current config schema (`config/config.yaml.example`) by adding fields that were missing: `connect_retries`, `connect_retry_backoff`, `consecutive_failures_for_dead`, `wait_for_relay_log_apply_timeout`, `logging` section, and `http` section (`enabled: true`).
- **Setup reference**: Add `http_port=8080` to the `pcs resource create` command in `setup.sh` along with a comment explaining when to use it.

## Test plan

- [x] Verify the OCF agent `monitor` returns `0` (OCF_SUCCESS) when `puremyhad` is running and `curl http://127.0.0.1:8080/health` returns `200` or `503`
- [x] Verify `monitor` returns `1` (OCF_ERR_GENERIC) when the HTTP server is unreachable (e.g., port blocked) while the process is still running
- [x] Verify `monitor` returns `7` (OCF_NOT_RUNNING) when `puremyhad` is stopped
- [x] Verify omitting `http_port` in the resource definition skips the HTTP check (backward-compatible)
- [x] Confirm the updated demo config is accepted by `puremyhad --validate-config`

🤖 Generated with [Claude Code](https://claude.com/claude-code)