### PR TITLE
test(e2e): replace direct IPC socket calls with puremyha CLI

### DIFF
--- a/e2e/lib/helpers.sh
+++ b/e2e/lib/helpers.sh
@@ -63,80 +63,61 @@ test_summary() {
 }
 
 # ---------------------------------------------------------------------------
-# IPC helpers (communicate with puremyhad via Unix socket)
+# CLI helpers (communicate with puremyhad via puremyha command)
 # ---------------------------------------------------------------------------
 
-ipc_request() {
-  local json="$1"
-  $COMPOSE exec -T puremyhad sh -c \
-    "printf '%s\n' '$json' | socat - UNIX-CONNECT:/run/puremyhad.sock"
+cli_exec() {
+  $COMPOSE exec -T puremyhad puremyha --json --socket /run/puremyhad.sock "$@"
 }
 
-ipc_status() {
-  ipc_request '{"type":"status"}'
+cli_status() {
+  cli_exec status
 }
 
-ipc_topology() {
-  ipc_request '{"type":"topology"}'
+cli_topology() {
+  cli_exec topology
 }
 
-ipc_switchover() {
+cli_switchover() {
   local to_host="${1:-}"
   local dry_run="${2:-false}"
-  if [ -n "$to_host" ]; then
-    ipc_request "{\"type\":\"switchover\",\"dryRun\":${dry_run},\"toHost\":\"${to_host}\"}"
-  else
-    ipc_request "{\"type\":\"switchover\",\"dryRun\":${dry_run}}"
-  fi
+  local args=()
+  [ -n "$to_host" ] && args+=(--to "$to_host")
+  [ "$dry_run" = "true" ] && args+=(--dry-run)
+  cli_exec switchover "${args[@]}"
 }
 
-ipc_ack_recovery() {
-  ipc_request '{"type":"ack-recovery"}'
+cli_ack_recovery() {
+  cli_exec ack-recovery
 }
 
-ipc_demote() {
+cli_demote() {
   local host="$1" source_host="$2"
-  ipc_request "{\"type\":\"demote\",\"host\":\"${host}\",\"sourceHost\":\"${source_host}\"}"
+  cli_exec demote --host "$host" --source "$source_host"
 }
 
-ipc_pause_replica() {
-  local host="$1"
-  ipc_request "{\"type\":\"pause-replica\",\"host\":\"${host}\"}"
+cli_pause_replica() {
+  cli_exec pause-replica --host "$1"
 }
 
-ipc_resume_replica() {
-  local host="$1"
-  ipc_request "{\"type\":\"resume-replica\",\"host\":\"${host}\"}"
+cli_resume_replica() {
+  cli_exec resume-replica --host "$1"
 }
 
-ipc_pause_failover() {
-  ipc_request '{"type":"pause-failover"}'
+cli_pause_failover() {
+  cli_exec pause-failover
 }
 
-ipc_resume_failover() {
-  ipc_request '{"type":"resume-failover"}'
+cli_resume_failover() {
+  cli_exec resume-failover
 }
 
-ipc_errant_gtid() {
-  ipc_request '{"type":"errant-gtid"}'
+cli_errant_gtid() {
+  cli_exec errant-gtid
 }
 
-ipc_fix_errant_gtid() {
-  ipc_request '{"type":"fix-errant-gtid"}'
-}
-
-ipc_event_history() {
-  ipc_request '{"type":"event-history"}'
-}
-
-ipc_event_history_limit() {
-  local limit="$1"
-  ipc_request "{\"type\":\"event-history\",\"limit\":${limit}}"
-}
-
-ipc_event_history_cluster() {
-  local cluster="$1"
-  ipc_request "{\"type\":\"event-history\",\"cluster\":\"${cluster}\"}"
+cli_fix_errant_gtid() {
+  cli_exec fix-errant-gtid
 }
 
 # ---------------------------------------------------------------------------
@@ -153,25 +134,25 @@ http_get_body() {
   $COMPOSE exec -T puremyhad curl -s "http://127.0.0.1:8080${path}"
 }
 
-# Extract fields from IPC status response
+# Extract fields from CLI status response
 get_health() {
-  ipc_status | jq -r '.data[0].health // empty' 2>/dev/null || echo ""
+  cli_status | jq -r '.[0].health // empty' 2>/dev/null || echo ""
 }
 
 get_source_host() {
-  ipc_status | jq -r '.data[0].sourceHost // empty' 2>/dev/null || echo ""
+  cli_status | jq -r '.[0].sourceHost // empty' 2>/dev/null || echo ""
 }
 
 get_node_count() {
-  ipc_status | jq -r '.data[0].nodeCount // empty' 2>/dev/null || echo ""
+  cli_status | jq -r '.[0].nodeCount // empty' 2>/dev/null || echo ""
 }
 
 get_paused() {
-  ipc_status | jq -r '.data[0].paused // empty' 2>/dev/null || echo ""
+  cli_status | jq -r '.[0].paused // empty' 2>/dev/null || echo ""
 }
 
 get_recovery_blocked() {
-  ipc_status | jq -r '.data[0].recoveryBlockedUntil // "null"' 2>/dev/null || echo "null"
+  cli_status | jq -r '.[0].recoveryBlockedUntil // "null"' 2>/dev/null || echo "null"
 }
 
 # ---------------------------------------------------------------------------
@@ -375,9 +356,9 @@ reset_cluster() {
   wait_for_replication mysql-replica1 60 || true
   wait_for_replication mysql-replica2 60 || true
 
-  # Clear recovery block and resume failover via IPC
-  ipc_ack_recovery >/dev/null 2>&1 || true
-  ipc_resume_failover >/dev/null 2>&1 || true
+  # Clear recovery block and resume failover via CLI
+  cli_ack_recovery >/dev/null 2>&1 || true
+  cli_resume_failover >/dev/null 2>&1 || true
 
   # Clear hook marker files
   $COMPOSE exec -T puremyhad rm -f /tmp/hook_*.log 2>/dev/null || true

--- a/e2e/tests/01-topology-discovery.sh
+++ b/e2e/tests/01-topology-discovery.sh
@@ -18,22 +18,22 @@ source_host=$(get_source_host)
 assert_eq "Source is mysql-source" "mysql-source" "$source_host"
 
 # Check topology details
-topo=$(ipc_topology)
-topo_node_count=$(echo "$topo" | jq '.data[0].nodes | length')
+topo=$(cli_topology)
+topo_node_count=$(echo "$topo" | jq '.[0].nodes | length')
 assert_eq "Topology shows 3 nodes" "3" "$topo_node_count"
 
-source_count=$(echo "$topo" | jq '[.data[0].nodes[] | select(.isSource==true)] | length')
+source_count=$(echo "$topo" | jq '[.[0].nodes[] | select(.isSource==true)] | length')
 assert_eq "Exactly 1 source" "1" "$source_count"
 
-replica_count=$(echo "$topo" | jq '[.data[0].nodes[] | select(.isSource==false)] | length')
+replica_count=$(echo "$topo" | jq '[.[0].nodes[] | select(.isSource==false)] | length')
 assert_eq "Exactly 2 replicas" "2" "$replica_count"
 
 # Verify no connect errors on any node
-error_count=$(echo "$topo" | jq '[.data[0].nodes[] | select(.connectError!=null)] | length')
+error_count=$(echo "$topo" | jq '[.[0].nodes[] | select(.connectError!=null)] | length')
 assert_eq "No connection errors" "0" "$error_count"
 
 # Verify no errant GTIDs
-errant_count=$(echo "$topo" | jq '[.data[0].nodes[] | select(.errantGtids!="" and .errantGtids!=null)] | length')
+errant_count=$(echo "$topo" | jq '[.[0].nodes[] | select(.errantGtids!="" and .errantGtids!=null)] | length')
 assert_eq "No errant GTIDs" "0" "$errant_count"
 
 test_summary

--- a/e2e/tests/04-manual-switchover.sh
+++ b/e2e/tests/04-manual-switchover.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Test: Manual Switchover
-# Tests dry-run and real switchover via IPC.
+# Tests dry-run and real switchover via puremyha CLI.
 set -euo pipefail
 source "$(dirname "$0")/../lib/helpers.sh"
 echo "=== Test 04: Manual Switchover ==="
@@ -12,11 +12,11 @@ echo "  Original source: $orig_source"
 
 # --- Dry-run switchover ---
 echo "  Testing dry-run switchover to mysql-replica2..."
-dry_result=$(ipc_switchover "mysql-replica2" "true")
+dry_result=$(cli_switchover "mysql-replica2" "true")
 echo "  Dry-run response: $dry_result"
 
 # Verify dry-run reports success
-dry_success=$(echo "$dry_result" | jq -r '.data.success // empty')
+dry_success=$(echo "$dry_result" | jq -r '.success // empty')
 assert_not_empty "Dry-run returns success message" "$dry_success"
 
 # Source should be unchanged after dry-run
@@ -25,10 +25,10 @@ assert_eq "Source unchanged after dry-run" "$orig_source" "$current_source"
 
 # --- Real switchover ---
 echo "  Executing switchover to mysql-replica2..."
-switch_result=$(ipc_switchover "mysql-replica2" "false")
+switch_result=$(cli_switchover "mysql-replica2" "false")
 echo "  Switchover response: $switch_result"
 
-switch_success=$(echo "$switch_result" | jq -r '.data.success // empty')
+switch_success=$(echo "$switch_result" | jq -r '.success // empty')
 assert_not_empty "Switchover returns success" "$switch_success"
 
 # Wait for topology to settle

--- a/e2e/tests/05-errant-gtid.sh
+++ b/e2e/tests/05-errant-gtid.sh
@@ -8,8 +8,8 @@ echo "=== Test 05: Errant GTID ==="
 wait_for_health "Healthy" 60
 
 # Verify no errant GTIDs initially
-errant_before=$(ipc_errant_gtid)
-errant_count_before=$(echo "$errant_before" | jq '.data | length')
+errant_before=$(cli_errant_gtid)
+errant_count_before=$(echo "$errant_before" | jq '. | length')
 assert_eq "No errant GTIDs initially" "0" "$errant_count_before"
 
 # Inject an errant transaction on mysql-replica1
@@ -25,8 +25,8 @@ mysql_exec mysql-replica1 "
 # Wait for the monitor to detect the errant GTID
 echo "  Waiting for errant GTID detection..."
 for i in $(seq 1 20); do
-  errant_result=$(ipc_errant_gtid)
-  errant_count=$(echo "$errant_result" | jq '.data | length')
+  errant_result=$(cli_errant_gtid)
+  errant_count=$(echo "$errant_result" | jq '. | length')
   if [ "$errant_count" -ge 1 ]; then
     echo "  Errant GTID detected (${i}s)"
     break
@@ -34,22 +34,22 @@ for i in $(seq 1 20); do
   sleep 1
 done
 
-errant_result=$(ipc_errant_gtid)
-errant_count=$(echo "$errant_result" | jq '.data | length')
+errant_result=$(cli_errant_gtid)
+errant_count=$(echo "$errant_result" | jq '. | length')
 assert_eq "Errant GTID detected" "1" "$errant_count"
 
 # Fix errant GTIDs
 echo "  Fixing errant GTIDs..."
-fix_result=$(ipc_fix_errant_gtid)
+fix_result=$(cli_fix_errant_gtid)
 echo "  Fix response: $fix_result"
-fix_success=$(echo "$fix_result" | jq -r '.data.success // empty')
+fix_success=$(echo "$fix_result" | jq -r '.success // empty')
 assert_not_empty "Fix errant GTID returns success" "$fix_success"
 
 # Wait for the fix to propagate
 echo "  Waiting for fix to propagate..."
 for i in $(seq 1 20); do
-  errant_after=$(ipc_errant_gtid)
-  errant_count_after=$(echo "$errant_after" | jq '.data | length')
+  errant_after=$(cli_errant_gtid)
+  errant_count_after=$(echo "$errant_after" | jq '. | length')
   if [ "$errant_count_after" -eq 0 ]; then
     echo "  Errant GTIDs cleared (${i}s)"
     break
@@ -57,8 +57,8 @@ for i in $(seq 1 20); do
   sleep 1
 done
 
-errant_after=$(ipc_errant_gtid)
-errant_count_after=$(echo "$errant_after" | jq '.data | length')
+errant_after=$(cli_errant_gtid)
+errant_count_after=$(echo "$errant_after" | jq '. | length')
 assert_eq "No errant GTIDs after fix" "0" "$errant_count_after"
 
 test_summary

--- a/e2e/tests/06-anti-flap.sh
+++ b/e2e/tests/06-anti-flap.sh
@@ -25,9 +25,9 @@ assert_neq "Recovery block is set after failover" "null" "$recovery_blocked"
 
 # Acknowledge recovery to clear the block
 echo "  Sending ack-recovery..."
-ack_result=$(ipc_ack_recovery)
+ack_result=$(cli_ack_recovery)
 echo "  Ack response: $ack_result"
-ack_success=$(echo "$ack_result" | jq -r '.data.success // empty')
+ack_success=$(echo "$ack_result" | jq -r '.success // empty')
 assert_eq "Ack recovery succeeds" "Recovery block cleared" "$ack_success"
 
 # Verify block is cleared

--- a/e2e/tests/08-pause-resume-replica.sh
+++ b/e2e/tests/08-pause-resume-replica.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Test: Pause and Resume Replica
-# Tests pausing and resuming replication on a replica via IPC.
+# Tests pausing and resuming replication on a replica via puremyha CLI.
 set -euo pipefail
 source "$(dirname "$0")/../lib/helpers.sh"
 echo "=== Test 08: Pause / Resume Replica ==="
@@ -9,18 +9,18 @@ wait_for_health "Healthy" 60
 
 # --- Pause replication on mysql-replica1 ---
 echo "  Pausing replication on mysql-replica1..."
-pause_result=$(ipc_pause_replica "mysql-replica1")
+pause_result=$(cli_pause_replica "mysql-replica1")
 echo "  Pause response: $pause_result"
 
-pause_success=$(echo "$pause_result" | jq -r '.data.success // empty')
+pause_success=$(echo "$pause_result" | jq -r '.success // empty')
 assert_not_empty "Pause returns success message" "$pause_success"
 
 # Wait for daemon to pick up paused state
 sleep 3
 
 # Verify paused flag in topology
-topo=$(ipc_topology)
-paused=$(echo "$topo" | jq -r '.data[0].nodes[] | select(.host == "mysql-replica1") | .paused')
+topo=$(cli_topology)
+paused=$(echo "$topo" | jq -r '.[0].nodes[] | select(.host == "mysql-replica1") | .paused')
 assert_eq "mysql-replica1 paused == true" "true" "$paused"
 
 # --- Write data on source, verify it does NOT reach paused replica ---
@@ -44,18 +44,18 @@ assert_eq "Data replicated to running replica2" "1" "$running_count"
 
 # --- Resume replication on mysql-replica1 ---
 echo "  Resuming replication on mysql-replica1..."
-resume_result=$(ipc_resume_replica "mysql-replica1")
+resume_result=$(cli_resume_replica "mysql-replica1")
 echo "  Resume response: $resume_result"
 
-resume_success=$(echo "$resume_result" | jq -r '.data.success // empty')
+resume_success=$(echo "$resume_result" | jq -r '.success // empty')
 assert_not_empty "Resume returns success message" "$resume_success"
 
 # Wait for daemon to pick up resumed state and data to catch up
 sleep 5
 
 # Verify paused flag is now false
-topo=$(ipc_topology)
-paused=$(echo "$topo" | jq -r '.data[0].nodes[] | select(.host == "mysql-replica1") | .paused')
+topo=$(cli_topology)
+paused=$(echo "$topo" | jq -r '.[0].nodes[] | select(.host == "mysql-replica1") | .paused')
 assert_eq "mysql-replica1 paused == false" "false" "$paused"
 
 # Verify data caught up on replica1

--- a/e2e/tests/09-demote.sh
+++ b/e2e/tests/09-demote.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Test: Demote (change a replica's replication source)
-# Tests demoting a replica to replicate from a different source via IPC.
+# Tests demoting a replica to replicate from a different source via puremyha CLI.
 set -euo pipefail
 source "$(dirname "$0")/../lib/helpers.sh"
 echo "=== Test 09: Demote ==="
@@ -9,10 +9,10 @@ wait_for_health "Healthy" 60
 
 # --- Step 1: Switchover to mysql-replica1 (make it the new source) ---
 echo "  Switching over to mysql-replica1..."
-switch_result=$(ipc_switchover "mysql-replica1" "false")
+switch_result=$(cli_switchover "mysql-replica1" "false")
 echo "  Switchover response: $switch_result"
 
-switch_success=$(echo "$switch_result" | jq -r '.data.success // empty')
+switch_success=$(echo "$switch_result" | jq -r '.success // empty')
 assert_not_empty "Switchover returns success" "$switch_success"
 
 # Wait for topology to settle
@@ -31,10 +31,10 @@ current_repl_source=$(mysql_exec mysql-replica2 "SELECT HOST FROM performance_sc
 echo "  mysql-replica2 current replication source: $current_repl_source"
 
 echo "  Demoting mysql-replica2 to replicate from mysql-replica1..."
-demote_result=$(ipc_demote "mysql-replica2" "mysql-replica1")
+demote_result=$(cli_demote "mysql-replica2" "mysql-replica1")
 echo "  Demote response: $demote_result"
 
-demote_success=$(echo "$demote_result" | jq -r '.data.success // empty')
+demote_success=$(echo "$demote_result" | jq -r '.success // empty')
 assert_not_empty "Demote returns success message" "$demote_success"
 
 # Wait for replication to re-establish

--- a/e2e/tests/10-pause-resume-failover.sh
+++ b/e2e/tests/10-pause-resume-failover.sh
@@ -14,8 +14,8 @@ assert_eq "Original source is mysql-source" "mysql-source" "$orig_source"
 
 # 2. Pause failover
 echo "  Sending pause-failover..."
-pause_result=$(ipc_pause_failover)
-pause_success=$(echo "$pause_result" | jq -r '.data.success // empty')
+pause_result=$(cli_pause_failover)
+pause_success=$(echo "$pause_result" | jq -r '.success // empty')
 assert_eq "Pause failover succeeds" "Failover paused" "$pause_success"
 
 # 3. Verify paused=true in status
@@ -39,8 +39,8 @@ assert_eq "Source unchanged (failover blocked)" "$orig_source" "$source_after"
 
 # 6. Resume failover
 echo "  Sending resume-failover..."
-resume_result=$(ipc_resume_failover)
-resume_success=$(echo "$resume_result" | jq -r '.data.success // empty')
+resume_result=$(cli_resume_failover)
+resume_success=$(echo "$resume_result" | jq -r '.success // empty')
 assert_eq "Resume failover succeeds" "Failover resumed" "$resume_success"
 
 # 7. Wait for failover to complete

--- a/e2e/tests/13-http-health-check.sh
+++ b/e2e/tests/13-http-health-check.sh
@@ -58,7 +58,7 @@ assert_eq "POST /health returns 405" "405" "$status"
 
 # GET /health returns 503 when source is dead
 # Pause auto-failover so health stays degraded long enough to observe
-ipc_pause_failover >/dev/null 2>&1
+cli_pause_failover >/dev/null 2>&1
 $COMPOSE stop mysql-source
 wait_for_health_not "Healthy" 30
 
@@ -71,6 +71,6 @@ assert_eq "/health body has status=degraded" "degraded" "$degraded_status"
 
 # Restore for cleanup
 $COMPOSE start mysql-source
-ipc_resume_failover >/dev/null 2>&1
+cli_resume_failover >/dev/null 2>&1
 
 test_summary

--- a/e2e/tests/14-prometheus-metrics.sh
+++ b/e2e/tests/14-prometheus-metrics.sh
@@ -59,7 +59,7 @@ assert_contains "consecutive_failures=0 for mysql-source" \
   'puremyha_node_consecutive_failures{cluster="e2e",host="mysql-source",port="3306"} 0' "$body"
 
 # Degraded state: stop source and verify cluster_healthy becomes 0
-ipc_pause_failover >/dev/null 2>&1
+cli_pause_failover >/dev/null 2>&1
 $COMPOSE stop mysql-source
 wait_for_health_not "Healthy" 30
 
@@ -69,6 +69,6 @@ assert_contains "cluster_healthy=0 when degraded" \
 
 # Restore
 $COMPOSE start mysql-source
-ipc_resume_failover >/dev/null 2>&1
+cli_resume_failover >/dev/null 2>&1
 
 test_summary


### PR DESCRIPTION
## Summary

- Replace all `ipc_*` helper functions (raw JSON over Unix socket via `socat`) with `cli_*` equivalents that invoke the `puremyha` binary with `--json` flag
- Update all `jq` paths to match the CLI's unwrapped output format (`.[0].health` instead of `.data[0].health`, `.success` instead of `.data.success`, etc.)
- Remove `ipc_event_history*` helpers which had no CLI equivalent and were unused in any test

## Motivation

The previous approach sent raw JSON payloads directly to the daemon socket using `socat`, which is an internal implementation detail users never interact with. Since `puremyha` is already present in the test container at `/usr/bin/puremyha`, the tests can now serve as a realistic reference for how to use the CLI.

## Files changed

- `e2e/lib/helpers.sh` — core helper rewrite (IPC → CLI section)
- `e2e/tests/01-topology-discovery.sh`
- `e2e/tests/04-manual-switchover.sh`
- `e2e/tests/05-errant-gtid.sh`
- `e2e/tests/06-anti-flap.sh`
- `e2e/tests/08-pause-resume-replica.sh`
- `e2e/tests/09-demote.sh`
- `e2e/tests/10-pause-resume-failover.sh`
- `e2e/tests/13-http-health-check.sh`
- `e2e/tests/14-prometheus-metrics.sh`

## Test plan

- [ ] `make -C e2e e2e-test T=01` — topology discovery
- [ ] `make -C e2e e2e-test T=04` — manual switchover (dry-run + real)
- [ ] `make -C e2e e2e-test T=05` — errant GTID detection and fix
- [ ] `make -C e2e e2e` — full E2E suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)