### PR TITLE
fix: omit GET_SOURCE_PUBLIC_KEY when TLS is enabled

### DIFF
--- a/puremyha.cabal
+++ b/puremyha.cabal
@@ -123,6 +123,7 @@ test-suite puremyha-test
     PureMyHA.WorkerSpec
     PureMyHA.HTTPSpec
     PureMyHA.StateSpec
+    PureMyHA.QuerySpec
   build-depends:
     puremyha,
     hspec            >= 2.9,

--- a/src/PureMyHA/Failover/Auto.hs
+++ b/src/PureMyHA/Failover/Auto.hs
@@ -182,7 +182,7 @@ reconnectReplica newSourceId ns = do
   liftIO $ do
     _ <- withNodeConn mTls ci $ \conn -> do
       stopReplica conn
-      changeReplicationSourceTo conn (nodeHost newSourceId) (nodePort newSourceId) replCreds
+      changeReplicationSourceTo conn (nodeHost newSourceId) (nodePort newSourceId) replCreds mTls
       setReadOnly conn
       startReplica conn
     pure ()

--- a/src/PureMyHA/Failover/Demote.hs
+++ b/src/PureMyHA/Failover/Demote.hs
@@ -39,7 +39,7 @@ runDemote demoteHost srcHost = do
           result <- liftIO $ withNodeConn mTls ci $ \conn -> do
             stopReplica conn
             setReadOnly conn
-            changeReplicationSourceTo conn (nodeHost srcId) (nodePort srcId) replCreds
+            changeReplicationSourceTo conn (nodeHost srcId) (nodePort srcId) replCreds mTls
             startReplica conn
           case result of
             Left err -> do

--- a/src/PureMyHA/Failover/Switchover.hs
+++ b/src/PureMyHA/Failover/Switchover.hs
@@ -173,7 +173,7 @@ reconnectToNew newSourceId ns = do
   liftIO $ do
     _ <- withNodeConn mTls ci $ \conn -> do
       _ <- try @SomeException (stopReplica conn)
-      changeReplicationSourceTo conn (nodeHost newSourceId) (nodePort newSourceId) replCreds
+      changeReplicationSourceTo conn (nodeHost newSourceId) (nodePort newSourceId) replCreds mTls
       setReadOnly conn
       startReplica conn
     pure ()

--- a/src/PureMyHA/MySQL/Query.hs
+++ b/src/PureMyHA/MySQL/Query.hs
@@ -14,6 +14,7 @@ module PureMyHA.MySQL.Query
   , gtidSubset
   , injectEmptyTransaction
   , waitForRelayLogApply
+  , needsPublicKeyRetrieval
   ) where
 
 import Data.Text (Text)
@@ -29,7 +30,7 @@ import Database.MySQL.Base
   , Query (..), ColumnDef (..)
   )
 import qualified System.IO.Streams as S
-import PureMyHA.Config (DbCredentials (..))
+import PureMyHA.Config (DbCredentials (..), TLSConfig (..), TLSMode (..))
 import PureMyHA.Types
 
 -- | Convert a lazy ByteString SQL to a Query
@@ -123,15 +124,25 @@ getGtidExecuted conn = do
     ((v:_):_) -> pure (textVal v)
     _         -> pure ""
 
+-- | Returns True when GET_SOURCE_PUBLIC_KEY=1 should be included in
+--   CHANGE REPLICATION SOURCE TO. This is needed when TLS is not in use;
+--   when TLS is active the public key is exchanged via the TLS handshake.
+needsPublicKeyRetrieval :: Maybe TLSConfig -> Bool
+needsPublicKeyRetrieval Nothing   = True
+needsPublicKeyRetrieval (Just tc) = tlsMode tc == TLSDisabled
+
 -- | CHANGE REPLICATION SOURCE TO ... SOURCE_AUTO_POSITION=1
-changeReplicationSourceTo :: MySQLConn -> Text -> Int -> DbCredentials -> IO ()
-changeReplicationSourceTo conn host port DbCredentials{..} = do
-  let sql = "CHANGE REPLICATION SOURCE TO SOURCE_HOST='" <> host
+changeReplicationSourceTo :: MySQLConn -> Text -> Int -> DbCredentials -> Maybe TLSConfig -> IO ()
+changeReplicationSourceTo conn host port DbCredentials{..} mTls = do
+  let pubKeyOpt = if needsPublicKeyRetrieval mTls
+                    then ", GET_SOURCE_PUBLIC_KEY=1"
+                    else ""
+      sql = "CHANGE REPLICATION SOURCE TO SOURCE_HOST='" <> host
             <> "', SOURCE_PORT=" <> T.pack (show port)
             <> ", SOURCE_USER='" <> dbUser <> "'"
             <> ", SOURCE_PASSWORD='" <> dbPassword <> "'"
             <> ", SOURCE_AUTO_POSITION=1"
-            <> ", GET_SOURCE_PUBLIC_KEY=1"
+            <> pubKeyOpt
   _ <- execute_ conn (toQuery (BL.fromStrict (TE.encodeUtf8 sql)))
   pure ()
 

--- a/test/PureMyHA/QuerySpec.hs
+++ b/test/PureMyHA/QuerySpec.hs
@@ -1,0 +1,25 @@
+module PureMyHA.QuerySpec (spec) where
+
+import Test.Hspec
+import PureMyHA.Config (TLSConfig (..), TLSMode (..))
+import PureMyHA.MySQL.Query (needsPublicKeyRetrieval)
+
+spec :: Spec
+spec = describe "needsPublicKeyRetrieval" $ do
+  it "returns True when TLS is not configured" $
+    needsPublicKeyRetrieval Nothing `shouldBe` True
+
+  it "returns True when TLS mode is Disabled" $
+    needsPublicKeyRetrieval (Just tls { tlsMode = TLSDisabled }) `shouldBe` True
+
+  it "returns False when TLS mode is SkipVerify" $
+    needsPublicKeyRetrieval (Just tls { tlsMode = TLSSkipVerify }) `shouldBe` False
+
+  it "returns False when TLS mode is VerifyCA" $
+    needsPublicKeyRetrieval (Just tls { tlsMode = TLSVerifyCA }) `shouldBe` False
+
+  it "returns False when TLS mode is VerifyFull" $
+    needsPublicKeyRetrieval (Just tls { tlsMode = TLSVerifyFull }) `shouldBe` False
+
+  where
+    tls = TLSConfig TLSDisabled Nothing Nothing Nothing Nothing


### PR DESCRIPTION
## Summary
- `changeReplicationSourceTo` previously appended `GET_SOURCE_PUBLIC_KEY=1` unconditionally to every `CHANGE REPLICATION SOURCE TO` statement
- When TLS is active the public key exchange is handled by the TLS handshake, making this option unnecessary and potentially harmful in strict TLS-only environments
- Added a pure helper `needsPublicKeyRetrieval :: Maybe TLSConfig -> Bool` that returns `True` only when TLS is absent or set to `TLSDisabled`
- Updated `changeReplicationSourceTo` to accept `Maybe TLSConfig` and conditionally include the option
- Updated all three call sites (`Failover.Auto`, `Failover.Demote`, `Failover.Switchover`) to pass the already-available `mTls` value

Closes #83

## Test plan
- [x] New unit tests in `test/PureMyHA/QuerySpec.hs` cover all 5 cases: `Nothing`, `TLSDisabled`, `TLSSkipVerify`, `TLSVerifyCA`, `TLSVerifyFull`
- [x] `cabal build all` passes with no new errors
- [x] `cabal test` passes — 322 examples, 0 failures (5 new tests added)

🤖 Generated with [Claude Code](https://claude.com/claude-code)