### PR TITLE
fix: skip enrichErrantGtids TCP connect when source is unreachable

### DIFF
--- a/src/PureMyHA/Monitor/Worker.hs
+++ b/src/PureMyHA/Monitor/Worker.hs
@@ -5,6 +5,7 @@ module PureMyHA.Monitor.Worker
   , monitorNode
   , runWorker
   , suppressBelowThreshold
+  , enrichErrantGtids
   ) where
 
 import Control.Concurrent (threadDelay)
@@ -231,19 +232,22 @@ enrichErrantGtids ns = do
           let srcNodes = Map.lookup srcId (ctNodes topo)
           case srcNodes of
             Nothing -> pure ns
-            Just srcNs -> do
-              let replicaGtid = case nsProbeResult ns of
-                    ProbeSuccess{prReplicaStatus = Just rs} -> rsExecutedGtidSet rs
-                    _ -> ""
-                  sourceGtid = case nsProbeResult srcNs of
-                    ProbeSuccess{prGtidExecuted = g} -> g
-                    ProbeFailure{} -> ""
-                  ci = makeConnectInfo srcId creds
-              result <- withNodeConn mTls ci $ \conn ->
-                gtidSubtract conn replicaGtid sourceGtid
-              case result of
-                Left _         -> pure ns
-                Right errant   -> pure ns { nsErrantGtids = errant }
+            Just srcNs ->
+              if not (nsIsReachable srcNs)
+                then pure ns
+                else do
+                  let replicaGtid = case nsProbeResult ns of
+                        ProbeSuccess{prReplicaStatus = Just rs} -> rsExecutedGtidSet rs
+                        _ -> ""
+                      sourceGtid = case nsProbeResult srcNs of
+                        ProbeSuccess{prGtidExecuted = g} -> g
+                        ProbeFailure{} -> ""
+                      ci = makeConnectInfo srcId creds
+                  result <- withNodeConn mTls ci $ \conn ->
+                    gtidSubtract conn replicaGtid sourceGtid
+                  case result of
+                    Left _         -> pure ns
+                    Right errant   -> pure ns { nsErrantGtids = errant }
 
 recomputeClusterHealth :: App ()
 recomputeClusterHealth = do

--- a/test/PureMyHA/WorkerSpec.hs
+++ b/test/PureMyHA/WorkerSpec.hs
@@ -1,45 +1,101 @@
 module PureMyHA.WorkerSpec (spec) where
 
+import Control.Concurrent.STM (atomically)
 import Test.Hspec
 import Fixtures
-import PureMyHA.Monitor.Worker (suppressBelowThreshold)
+import PureMyHA.Config (ClusterConfig (..), Credentials (..), FailoverConfig (..), MonitoringConfig (..), FailureDetectionConfig (..))
+import PureMyHA.Env (runApp)
+import PureMyHA.Monitor.Worker (suppressBelowThreshold, enrichErrantGtids)
+import PureMyHA.Topology.Discovery (buildClusterTopology)
+import PureMyHA.Topology.State (newDaemonState, updateClusterTopology)
 import PureMyHA.Types
 
+testCC :: ClusterConfig
+testCC = ClusterConfig
+  { ccName                   = "main"
+  , ccNodes                  = []
+  , ccCredentials            = Credentials "user" "/dev/null"
+  , ccReplicationCredentials = Nothing
+  , ccMonitoring             = MonitoringConfig 3 5 30 60 300 1 1
+  , ccFailureDetection       = FailureDetectionConfig 3600 3
+  , ccFailover               = FailoverConfig True 1 [] 60 False Nothing
+  , ccHooks                  = Nothing
+  , ccTLS                    = Nothing
+  }
+
+testFC :: FailoverConfig
+testFC = FailoverConfig
+  { fcAutoFailover              = True
+  , fcMinReplicasForFailover    = 1
+  , fcCandidatePriority         = []
+  , fcWaitRelayLogTimeout       = 60
+  , fcAutoFence                 = False
+  , fcMaxReplicaLagForCandidate = Nothing
+  }
+
 spec :: Spec
-spec = describe "suppressBelowThreshold" $ do
-  let threshold = 3
-      errNs     = healthySource
-                    { nsHealth              = NeedsAttention "refused"
-                    , nsProbeResult         = ProbeFailure "refused"
-                    , nsConsecutiveFailures = 1
-                    }
+spec = do
 
-  it "keeps previous health when failCount is below threshold" $
-    suppressBelowThreshold threshold 1 (Just healthySource) errNs
-      `shouldBe` errNs { nsHealth = Healthy }
+  describe "enrichErrantGtids" $ do
 
-  it "applies NeedsAttention when failCount equals threshold" $
-    suppressBelowThreshold threshold 3 (Just healthySource) errNs
-      `shouldBe` errNs { nsHealth = NeedsAttention "refused" }
+    it "returns ns unchanged when source is unreachable (skips TCP connect)" $ do
+      tvar <- newDaemonState
+      let topo = (buildClusterTopology "main" clusterWithDeadSource)
+                   { ctSourceNodeId = Just (NodeId "db1" 3306) }
+      atomically $ updateClusterTopology tvar topo
+      env <- mkTestEnv tvar testCC testFC
+      result <- runApp env (enrichErrantGtids healthyReplica)
+      nsErrantGtids result `shouldBe` nsErrantGtids healthyReplica
 
-  it "applies NeedsAttention when failCount exceeds threshold" $
-    suppressBelowThreshold threshold 5 (Just healthySource) errNs
-      `shouldBe` errNs { nsHealth = NeedsAttention "refused" }
+    it "returns ns unchanged when no topology exists" $ do
+      tvar <- newDaemonState
+      env <- mkTestEnv tvar testCC testFC
+      result <- runApp env (enrichErrantGtids healthyReplica)
+      nsErrantGtids result `shouldBe` nsErrantGtids healthyReplica
 
-  it "uses Healthy as fallback when no previous state (first probe)" $
-    suppressBelowThreshold threshold 1 Nothing errNs
-      `shouldBe` errNs { nsHealth = Healthy }
+    it "returns ns unchanged when topology has no source node" $ do
+      tvar <- newDaemonState
+      let topo = (buildClusterTopology "main" clusterWithDeadSource)
+                   { ctSourceNodeId = Nothing }
+      atomically $ updateClusterTopology tvar topo
+      env <- mkTestEnv tvar testCC testFC
+      result <- runApp env (enrichErrantGtids healthyReplica)
+      nsErrantGtids result `shouldBe` nsErrantGtids healthyReplica
 
-  it "does not suppress when failCount is 0 (success case)" $
-    suppressBelowThreshold threshold 0 (Just healthySource) healthySource
-      `shouldBe` healthySource
+  describe "suppressBelowThreshold" $ do
+    let threshold = 3
+        errNs     = healthySource
+                      { nsHealth              = NeedsAttention "refused"
+                      , nsProbeResult         = ProbeFailure "refused"
+                      , nsConsecutiveFailures = 1
+                      }
 
-  it "resets to Healthy on success after previous NeedsAttention" $ do
-    let prev = healthySource { nsHealth = NeedsAttention "err", nsConsecutiveFailures = 2 }
-        curr = healthySource { nsConsecutiveFailures = 0 }
-    suppressBelowThreshold threshold 0 (Just prev) curr `shouldBe` curr
+    it "keeps previous health when failCount is below threshold" $
+      suppressBelowThreshold threshold 1 (Just healthySource) errNs
+        `shouldBe` errNs { nsHealth = Healthy }
 
-  it "preserves NeedsAttention from previous state when below threshold" $ do
-    let prev = healthySource { nsHealth = NeedsAttention "prior err", nsConsecutiveFailures = 2 }
-    suppressBelowThreshold threshold 2 (Just prev) errNs
-      `shouldBe` errNs { nsHealth = NeedsAttention "prior err" }
+    it "applies NeedsAttention when failCount equals threshold" $
+      suppressBelowThreshold threshold 3 (Just healthySource) errNs
+        `shouldBe` errNs { nsHealth = NeedsAttention "refused" }
+
+    it "applies NeedsAttention when failCount exceeds threshold" $
+      suppressBelowThreshold threshold 5 (Just healthySource) errNs
+        `shouldBe` errNs { nsHealth = NeedsAttention "refused" }
+
+    it "uses Healthy as fallback when no previous state (first probe)" $
+      suppressBelowThreshold threshold 1 Nothing errNs
+        `shouldBe` errNs { nsHealth = Healthy }
+
+    it "does not suppress when failCount is 0 (success case)" $
+      suppressBelowThreshold threshold 0 (Just healthySource) healthySource
+        `shouldBe` healthySource
+
+    it "resets to Healthy on success after previous NeedsAttention" $ do
+      let prev = healthySource { nsHealth = NeedsAttention "err", nsConsecutiveFailures = 2 }
+          curr = healthySource { nsConsecutiveFailures = 0 }
+      suppressBelowThreshold threshold 0 (Just prev) curr `shouldBe` curr
+
+    it "preserves NeedsAttention from previous state when below threshold" $ do
+      let prev = healthySource { nsHealth = NeedsAttention "prior err", nsConsecutiveFailures = 2 }
+      suppressBelowThreshold threshold 2 (Just prev) errNs
+        `shouldBe` errNs { nsHealth = NeedsAttention "prior err" }


### PR DESCRIPTION
## Summary

- Guard `withNodeConn` in `enrichErrantGtids` with `nsIsReachable srcNs` to skip TCP connection attempts when the source node's last probe was a failure
- Prevents replica monitor workers from blocking on OS-level TCP connect timeout (~75–120s) when the source is down but Docker has not yet sent a TCP RST
- Fixes the race condition in `02-auto-failover.sh` where the cluster gets stuck in `UnreachableSource` instead of transitioning to `DeadSource` within the 90s timeout
- Exports `enrichErrantGtids` and adds 3 unit tests covering: unreachable source, no topology, and no source node ID

Closes #85

## Test plan

- [x] `cabal build all` passes
- [x] `cabal test` passes — 337 tests, 0 failures (3 new tests added for `enrichErrantGtids`)
- [x] `e2e/tests/02-auto-failover.sh` completes within 90s without `UnreachableSource` timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)