### PR TITLE
fix: make /health a true liveness probe independent of cluster state

### DIFF
--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -6,12 +6,12 @@ When `http.enabled: true` is set in the config, `puremyhad` exposes a lightweigh
 
 | Endpoint | Success | Failure | Use case |
 |----------|---------|---------|----------|
-| `GET /health` | `200 {"status":"ok"}` | `503 {"status":"degraded"}` | Kubernetes liveness probe |
+| `GET /health` | `200 {"status":"ok"}` | — | Kubernetes liveness probe |
 | `GET /cluster/:name/status` | `200 ClusterStatus JSON` | `404` if cluster not found | Readiness probe / LB routing |
 | `GET /cluster/:name/topology` | `200 ClusterTopologyView JSON` | `404` if cluster not found | Monitoring dashboards |
 | `GET /metrics` | `200` Prometheus text format | — | Grafana and other monitoring stacks |
 
-`/health` returns `200` if at least one cluster is in `Healthy` state, `503` otherwise (e.g. dead source, split-brain, all replicas unreachable).
+`/health` returns `200` whenever the PureMyHA daemon is running and responsive. Use `/cluster/:name/status` to check individual cluster health.
 
 `/metrics` exposes cluster health, replication lag, consecutive failures, and node role in Prometheus text exposition format.
 
@@ -20,7 +20,7 @@ When `http.enabled: true` is set in the config, `puremyhad` exposes a lightweigh
 ```bash
 # Liveness probe
 curl http://127.0.0.1:8080/health
-# → {"status":"ok"}  (200) or {"status":"degraded"}  (503)
+# → {"status":"ok"}  (200)
 
 # Cluster status — same JSON shape as `puremyha -j status`
 curl http://127.0.0.1:8080/cluster/main/status | jq .

--- a/e2e/tests/13-http-health-check.sh
+++ b/e2e/tests/13-http-health-check.sh
@@ -56,18 +56,23 @@ assert_eq "Unknown route returns 404" "404" "$status"
 status=$($COMPOSE exec -T puremyhad curl -s -o /dev/null -w "%{http_code}" -X POST "http://127.0.0.1:8080/health")
 assert_eq "POST /health returns 405" "405" "$status"
 
-# GET /health returns 503 when source is dead
+# GET /health returns 200 even when source is dead (liveness probe — daemon is still running)
 # Pause auto-failover so health stays degraded long enough to observe
 cli_pause_failover >/dev/null 2>&1
 $COMPOSE stop mysql-source
 wait_for_health_not "Healthy" 30
 
 status=$(http_get "/health")
-assert_eq "GET /health returns 503 when cluster degraded" "503" "$status"
+assert_eq "GET /health returns 200 even when cluster degraded" "200" "$status"
 
 body=$(http_get_body "/health")
 degraded_status=$(echo "$body" | jq -r '.status')
-assert_eq "/health body has status=degraded" "degraded" "$degraded_status"
+assert_eq "/health body has status=ok even when cluster degraded" "ok" "$degraded_status"
+
+# Cluster status reflects the degraded state
+cluster_status=$(http_get_body "/cluster/e2e/status")
+cluster_health=$(echo "$cluster_status" | jq -r '.health')
+assert_eq "Cluster status reflects DeadSource" "DeadSource" "$cluster_health"
 
 # Restore for cleanup
 $COMPOSE start mysql-source

--- a/src/PureMyHA/HTTP/Server.hs
+++ b/src/PureMyHA/HTTP/Server.hs
@@ -11,7 +11,7 @@ import Data.String (fromString)
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
-import Network.HTTP.Types (status200, status404, status503, status405, methodGet, Header)
+import Network.HTTP.Types (status200, status404, status405, methodGet, Header)
 import Network.Wai (Application, Request (..), Response, responseLBS)
 import Network.Wai.Handler.Warp (defaultSettings, runSettings, setHost, setPort)
 
@@ -39,19 +39,15 @@ httpApp tvar req respond
   | requestMethod req /= methodGet =
       respond $ responseLBS status405 [jsonCT] (encode (object ["error" .= ("method not allowed" :: Text)]))
   | otherwise = case pathInfo req of
-      ["health"]                    -> handleHealth tvar >>= respond
+      ["health"]                    -> handleHealth >>= respond
       ["cluster", name, "status"]   -> handleStatus tvar name >>= respond
       ["cluster", name, "topology"] -> handleTopology tvar name >>= respond
       ["metrics"]                   -> handleMetrics tvar >>= respond
       _ -> respond $ responseLBS status404 [jsonCT] (encode (object ["error" .= ("not found" :: Text)]))
 
-handleHealth :: TVarDaemonState -> IO Response
-handleHealth tvar = do
-  ds <- readDaemonState tvar
-  let anyHealthy = any (\ct -> ctHealth ct == Healthy) (Map.elems (dsClusters ds))
-  if anyHealthy
-    then pure $ responseLBS status200 [jsonCT] (encode (object ["status" .= ("ok" :: Text)]))
-    else pure $ responseLBS status503 [jsonCT] (encode (object ["status" .= ("degraded" :: Text)]))
+handleHealth :: IO Response
+handleHealth =
+  pure $ responseLBS status200 [jsonCT] (encode (object ["status" .= ("ok" :: Text)]))
 
 handleStatus :: TVarDaemonState -> Text -> IO Response
 handleStatus tvar name = do

--- a/test/PureMyHA/HTTPSpec.hs
+++ b/test/PureMyHA/HTTPSpec.hs
@@ -4,7 +4,7 @@ import Control.Concurrent.STM (atomically)
 import qualified Data.ByteString.Lazy.Char8 as BSL8
 import Data.IORef
 import qualified Data.Map.Strict as Map
-import Network.HTTP.Types (methodGet, methodPost, status200, status404, status405, status503)
+import Network.HTTP.Types (methodGet, methodPost, status200, status404, status405)
 import Network.Wai (defaultRequest, Request (..), Response, responseStatus)
 import Network.Wai.Internal (ResponseReceived (..))
 import Test.Hspec
@@ -92,19 +92,13 @@ spec = do
       resp <- runApp (httpApp tvar) req
       responseStatus resp `shouldBe` status404
 
-    it "returns 200 for /health when cluster is healthy" $ do
+    it "returns 200 for /health when daemon is running" $ do
       tvar <- newDaemonState
-      let ct = ClusterTopology
-                { ctClusterName = "test", ctNodes = clusterHealthy
-                , ctSourceNodeId = Just (NodeId "db1" 3306), ctHealth = Healthy
-                , ctObservedHealthy = True, ctRecoveryBlockedUntil = Nothing
-                , ctLastFailoverAt = Nothing, ctPaused = False }
-      atomically $ updateClusterTopology tvar ct
       let req = defaultRequest { requestMethod = methodGet, pathInfo = ["health"] }
       resp <- runApp (httpApp tvar) req
       responseStatus resp `shouldBe` status200
 
-    it "returns 503 for /health when no healthy cluster" $ do
+    it "returns 200 for /health even when no cluster is healthy" $ do
       tvar <- newDaemonState
       let ct = ClusterTopology
                 { ctClusterName = "test", ctNodes = clusterWithDeadSource
@@ -114,7 +108,7 @@ spec = do
       atomically $ updateClusterTopology tvar ct
       let req = defaultRequest { requestMethod = methodGet, pathInfo = ["health"] }
       resp <- runApp (httpApp tvar) req
-      responseStatus resp `shouldBe` status503
+      responseStatus resp `shouldBe` status200
 
     it "returns 200 for /cluster/<name>/status when cluster exists" $ do
       tvar <- newDaemonState


### PR DESCRIPTION
## Summary

- `/health` previously returned `503` when no managed cluster was `Healthy`, conflating **daemon liveness** with **cluster health**
- This caused Kubernetes to restart a healthy `puremyhad` process whenever a managed database cluster was degraded
- `/health` now always returns `200 {"status":"ok"}` as long as the daemon is running and responsive
- Individual cluster health is available via `GET /cluster/:name/status`, which is the appropriate endpoint for readiness probes

## Changes

| File | Change |
|------|--------|
| `src/PureMyHA/HTTP/Server.hs` | Remove cluster health check from `handleHealth`; always return 200 |
| `test/PureMyHA/HTTPSpec.hs` | Update unit tests to reflect new liveness-only semantics |
| `e2e/tests/13-http-health-check.sh` | Update E2E test: expect 200 on degraded cluster; verify cluster state via `/cluster/e2e/status` |
| `docs/http-api.md` | Update endpoint description and examples |

## Test plan

- [x] `cabal build` passes with no new warnings
- [x] `cabal test` — all 348 tests pass
- [ ] E2E test `13-http-health-check.sh` — verifies 200 on both healthy and degraded cluster states

🤖 Generated with [Claude Code](https://claude.com/claude-code)