### PR TITLE
fix: add probe timeout to prevent monitoring thread hang on frozen MySQL

### DIFF
--- a/e2e/tests/21-probe-timeout-failover.sh
+++ b/e2e/tests/21-probe-timeout-failover.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Test: Probe Timeout (frozen source → auto-failover)
+# Pauses the source container (SIGSTOP — kernel TCP alive, MySQL process frozen)
+# and verifies that probe timeouts eventually trigger auto-failover.
+#
+# docker pause keeps the kernel TCP stack alive, so new TCP connections succeed
+# at the OS level but MySQL never responds to queries.  Without a probe timeout
+# the monitoring thread would hang forever; with the fix it fires after
+# connect_timeout × (2 × connect_retries + 1) = 6s per probe (E2E defaults).
+# After consecutive_failures_for_dead (3) timeouts the source is marked Dead
+# and auto-failover triggers once replicas also detect IO=No.
+set -euo pipefail
+source "$(dirname "$0")/../lib/helpers.sh"
+echo "=== Test 21: Probe Timeout (frozen source -> auto-failover) ==="
+
+wait_for_health "Healthy" 60
+
+orig_source=$(get_source_host)
+echo "  Original source: $orig_source"
+assert_eq "Original source is mysql-source" "mysql-source" "$orig_source"
+
+# Shorten replica_net_timeout so the IO thread detects the frozen source
+# within ~10s instead of the default 60s, keeping the overall test time short.
+echo "  Setting replica_net_timeout=10 on replicas..."
+mysql_exec mysql-replica1 "SET GLOBAL replica_net_timeout = 10;"
+mysql_exec mysql-replica2 "SET GLOBAL replica_net_timeout = 10;"
+
+# Pause the source (SIGSTOP).  TCP connections succeed at kernel level but
+# the MySQL process is frozen, so every probe times out.
+echo "  Pausing mysql-source (simulating frozen process)..."
+docker pause e2e-source
+
+# Expected timeline after pause:
+#   probe 1 timeout:  6s  → failCount=1 (suppressed below threshold=3)
+#   probe 2 timeout: +7s  → failCount=2 (still suppressed)
+#   replica IO detects no heartbeat: ~10s (replica_net_timeout=10)
+#   probe 3 timeout: +7s  → failCount=3 → NeedsAttention fires
+#   detectClusterHealth: source=NeedsAttention + replicas IO=No → DeadSource
+#   auto-failover executes (wait_for_relay_log_apply_timeout=10s) → ~10s
+#   total: ~40s; wait up to 90s for safety
+#
+# Wait directly for the source to switch to mysql-replica1.
+# Using wait_for_source rather than a two-phase health check avoids a race
+# where the DeadSource→Healthy transition completes within one polling interval
+# (e.g., when docker pause causes immediate TCP RST on Docker Desktop) and the
+# "not Healthy" window is missed entirely.
+echo "  Waiting for failover to complete (new source = mysql-replica1)..."
+wait_for_source "mysql-replica1" 90
+
+new_source=$(get_source_host)
+echo "  New source after failover: $new_source"
+assert_eq "New source is mysql-replica1 (candidate_priority)" "mysql-replica1" "$new_source"
+
+# Restore replica_net_timeout to MySQL default before reset_cluster runs
+echo "  Restoring replica_net_timeout=60 on replicas..."
+mysql_exec mysql-replica1 "SET GLOBAL replica_net_timeout = 60;" || true
+mysql_exec mysql-replica2 "SET GLOBAL replica_net_timeout = 60;" || true
+
+# Unpause so that reset_cluster can bring the cluster back to its original state
+echo "  Unpausing mysql-source..."
+docker unpause e2e-source
+
+test_summary

--- a/src/PureMyHA/Monitor/Worker.hs
+++ b/src/PureMyHA/Monitor/Worker.hs
@@ -9,19 +9,21 @@ module PureMyHA.Monitor.Worker
   , computeStaleNodes
   , pruneStaleWorkers
   , detectAndPruneStaleWorkers
+  , probeTimeoutMicros
   ) where
 
 import Control.Concurrent (threadDelay)
-import Control.Concurrent.Async (async, wait, cancel, Async)
+import Control.Concurrent.Async (async, wait, cancel, waitCatch, Async)
 import Control.Concurrent.STM (atomically, TVar, newTVarIO, modifyTVar', readTVarIO)
 import Control.Exception (SomeException, catch)
+import System.Timeout (timeout)
 import Control.Monad (when, forM, forM_, unless)
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Reader (ask, asks)
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 import qualified Data.Text as T
-import Data.Time (getCurrentTime)
+import Data.Time (getCurrentTime, NominalDiffTime)
 import PureMyHA.Config
 import PureMyHA.Env
 import PureMyHA.Failover.Auto (runAutoFailover, runAutoFence)
@@ -136,6 +138,14 @@ detectAndPruneStaleWorkers reg cc discovered = do
   pruneStaleWorkers reg staleNodes
   pure staleNodes
 
+-- | Compute the probe timeout in microseconds.
+-- Formula: connect_timeout × (2 × connect_retries + 1)
+-- This covers the worst case of all retry attempts completing with max backoff,
+-- and ensures a hung MySQL (TCP connected but query never responds) is detected.
+probeTimeoutMicros :: NominalDiffTime -> Int -> Int
+probeTimeoutMicros cap retries =
+  round (realToFrac cap * fromIntegral (2 * retries + 1) * 1_000_000 :: Double)
+
 -- | Suppress NeedsAttention health state when consecutive failure count is below
 -- the configured threshold. Falls back to previous health (or Healthy if no prior state).
 suppressBelowThreshold :: Int -> Int -> Maybe NodeState -> NodeState -> NodeState
@@ -167,10 +177,23 @@ monitorNode nid = do
     mTopo <- getClusterTopology tvar (ccName cc)
     pure $ mTopo >>= \t -> Map.lookup nid (ctNodes t)
   let prevFailures = maybe 0 nsConsecutiveFailures mOldNs
-  result <- liftIO $ withNodeConnRetry retries backoff cap logRetry mTls ci $ \conn -> do
-    mRs      <- showReplicaStatus conn
-    gtidExec <- getGtidExecuted conn
-    pure (mRs, gtidExec)
+  -- Run the probe in a separate thread so that timeout can interrupt it via
+  -- waitCatch (STM — always interruptible) rather than wrapping the I/O directly.
+  -- mysql-haskell's readPacket blocks in a C recv() that async exceptions cannot
+  -- reliably interrupt; by moving the I/O to a sibling thread we avoid that.
+  -- The probe thread runs to completion once MySQL responds; it holds no shared
+  -- locks so no deadlock is possible.
+  let tMicros = probeTimeoutMicros cap retries
+  result <- liftIO $ do
+    probeAsync <- async $ withNodeConnRetry retries backoff cap logRetry mTls ci $ \conn -> do
+      mRs      <- showReplicaStatus conn
+      gtidExec <- getGtidExecuted conn
+      pure (mRs, gtidExec)
+    mEither <- timeout tMicros (waitCatch probeAsync)
+    case mEither of
+      Nothing          -> return (Left "probe timeout")
+      Just (Left  e)   -> return (Left (T.pack (show e)))
+      Just (Right r)   -> return r
   let newFailures = case result of { Left _ -> prevFailures + 1; Right _ -> 0 }
   let ns = case result of
         Left err ->
@@ -255,6 +278,9 @@ enrichErrantGtids ns = do
   cc    <- asks envCluster
   creds <- getMonCredentials
   mTls  <- getTLSConfig
+  env   <- ask
+  mc    <- liftIO $ readTVarIO (envMonitoring env)
+  let tMicros = probeTimeoutMicros (mcConnectTimeout mc) (mcConnectRetries mc)
   liftIO $ do
     mTopo <- getClusterTopology tvar (ccName cc)
     case mTopo of
@@ -266,7 +292,7 @@ enrichErrantGtids ns = do
           case srcNodes of
             Nothing -> pure ns
             Just srcNs ->
-              if not (nsIsReachable srcNs)
+              if not (nsIsReachable srcNs) || not (nsIsReachable ns)
                 then pure ns
                 else do
                   let replicaGtid = case nsProbeResult ns of
@@ -276,11 +302,14 @@ enrichErrantGtids ns = do
                         ProbeSuccess{prGtidExecuted = g} -> g
                         ProbeFailure{} -> ""
                       ci = makeConnectInfo srcId creds
-                  result <- withNodeConn mTls ci $ \conn ->
+                  errantAsync <- async $ withNodeConn mTls ci $ \conn ->
                     gtidSubtract conn replicaGtid sourceGtid
-                  case result of
-                    Left _         -> pure ns
-                    Right errant   -> pure ns { nsErrantGtids = errant }
+                  mResult <- timeout tMicros (waitCatch errantAsync)
+                  case mResult of
+                    Nothing                       -> pure ns
+                    Just (Left _)                 -> pure ns
+                    Just (Right (Left _))         -> pure ns
+                    Just (Right (Right errant))   -> pure ns { nsErrantGtids = errant }
 
 recomputeClusterHealth :: App ()
 recomputeClusterHealth = do

--- a/test/PureMyHA/WorkerSpec.hs
+++ b/test/PureMyHA/WorkerSpec.hs
@@ -10,7 +10,7 @@ import Fixtures
 import PureMyHA.Config (ClusterConfig (..), NodeConfig (..), Credentials (..), FailoverConfig (..), MonitoringConfig (..), FailureDetectionConfig (..))
 import PureMyHA.Env (runApp)
 import qualified Data.Set as Set
-import PureMyHA.Monitor.Worker (suppressBelowThreshold, enrichErrantGtids, computeStaleNodes, pruneStaleWorkers, detectAndPruneStaleWorkers)
+import PureMyHA.Monitor.Worker (suppressBelowThreshold, enrichErrantGtids, computeStaleNodes, pruneStaleWorkers, detectAndPruneStaleWorkers, probeTimeoutMicros)
 import PureMyHA.Topology.Discovery (buildClusterTopology)
 import PureMyHA.Topology.State (newDaemonState, updateClusterTopology)
 import PureMyHA.Types
@@ -42,7 +42,27 @@ testFC = FailoverConfig
 spec :: Spec
 spec = do
 
+  describe "probeTimeoutMicros" $ do
+
+    it "computes 6s for default config (2s timeout, 1 retry)" $
+      probeTimeoutMicros 2 1 `shouldBe` 6_000_000
+
+    it "computes 2s when no retries (2s timeout, 0 retries)" $
+      probeTimeoutMicros 2 0 `shouldBe` 2_000_000
+
+    it "scales correctly with higher retries (3s timeout, 2 retries)" $
+      probeTimeoutMicros 3 2 `shouldBe` 15_000_000
+
   describe "enrichErrantGtids" $ do
+
+    it "returns ns unchanged when monitored node is unreachable (skips TCP connect)" $ do
+      tvar <- newDaemonState
+      let topo = (buildClusterTopology "main" clusterWithDeadSource)
+                   { ctSourceNodeId = Just (NodeId "db1" 3306) }
+      atomically $ updateClusterTopology tvar topo
+      env <- mkTestEnv tvar testCC testFC
+      result <- runApp env (enrichErrantGtids unreachableReplica)
+      nsErrantGtids result `shouldBe` nsErrantGtids unreachableReplica
 
     it "returns ns unchanged when source is unreachable (skips TCP connect)" $ do
       tvar <- newDaemonState


### PR DESCRIPTION
## Summary

- **Root cause**: `monitorNode` and `enrichErrantGtids` called `withNodeConnRetry` / `withNodeConn` without any timeout. When MySQL accepts TCP connections at the kernel level but the process is frozen (e.g. `docker pause` / SIGSTOP), the monitoring thread blocks indefinitely in mysql-haskell's `readPacket` — a C-level `recv()` that async exceptions cannot reliably interrupt.
- **Fix (probe)**: Run each probe in a sibling `async` thread and wrap `waitCatch` (STM — always interruptible) with `System.Timeout.timeout`. Timeout fires after `connect_timeout × (2 × connect_retries + 1)` seconds regardless of server responsiveness.
- **Fix (errant GTID check)**: Apply the same `async + timeout(waitCatch)` pattern to the `withNodeConn` call in `enrichErrantGtids`, which replica workers invoke every cycle. Also add `|| not (nsIsReachable ns)` guard so replica workers skip the source connection immediately when their own probe just failed.
- **New helper**: `probeTimeoutMicros :: NominalDiffTime -> Int -> Int` — pure function computing the worst-case timeout; exported and unit-tested.
- **E2E test 21**: pauses the source container with `docker pause` and verifies auto-failover to `mysql-replica1` within 90s.

## Test plan

- [x] `cabal build all` — compiles cleanly
- [x] `cabal test` — 371 examples, 0 failures
- [x] E2E test 21 (`21-probe-timeout-failover.sh`): pause source container → verify failover to `mysql-replica1` within 90s

Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)