### PR TITLE
feat: pass PUREMYHA_NODE to on_lag_threshold_exceeded/recovered hooks

### DIFF
--- a/config/config.yaml.example
+++ b/config/config.yaml.example
@@ -64,9 +64,9 @@ global:
     on_fence: /etc/puremyha/hooks/on_fence.sh                                      # optional; fired after a node is auto-fenced
                                                                                     # Env: PUREMYHA_CLUSTER, PUREMYHA_OLD_SOURCE (fenced host), PUREMYHA_NEW_SOURCE (survivor host)
     on_lag_threshold_exceeded: /etc/puremyha/hooks/on_lag_threshold_exceeded.sh    # optional; fired when a replica transitions to Lagging health
-                                                                                    # Env: PUREMYHA_CLUSTER, PUREMYHA_LAG_SECONDS, PUREMYHA_TIMESTAMP
+                                                                                    # Env: PUREMYHA_CLUSTER, PUREMYHA_NODE, PUREMYHA_LAG_SECONDS, PUREMYHA_TIMESTAMP
     on_lag_threshold_recovered: /etc/puremyha/hooks/on_lag_threshold_recovered.sh  # optional; fired when a replica recovers from Lagging health
-                                                                                    # Env: PUREMYHA_CLUSTER, PUREMYHA_TIMESTAMP
+                                                                                    # Env: PUREMYHA_CLUSTER, PUREMYHA_NODE, PUREMYHA_TIMESTAMP
 
 logging:                               # optional logging configuration
   log_file: /var/log/puremyha.log    # default: /var/log/puremyha.log

--- a/docs/features.md
+++ b/docs/features.md
@@ -135,8 +135,8 @@ Shell hooks are called at key lifecycle events. All hooks receive cluster and no
 | `post_failover` | After automatic failover completes |
 | `pre_switchover` | Before manual switchover begins |
 | `post_switchover` | After manual switchover completes |
-| `on_lag_threshold_exceeded` | Replica crosses `replication_lag_critical` |
-| `on_lag_threshold_recovered` | Replica recovers below `replication_lag_critical` |
+| `on_lag_threshold_exceeded` | Replica crosses `replication_lag_critical` — provides `PUREMYHA_NODE` (replica hostname) and `PUREMYHA_LAG_SECONDS` |
+| `on_lag_threshold_recovered` | Replica recovers below `replication_lag_critical` — provides `PUREMYHA_NODE` (replica hostname) |
 
 See [docs/configuration.md](configuration.md) for hook configuration syntax.
 

--- a/e2e/config/hooks/on_lag_threshold_exceeded.sh
+++ b/e2e/config/hooks/on_lag_threshold_exceeded.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+echo "exceeded CLUSTER=$PUREMYHA_CLUSTER NODE=$PUREMYHA_NODE LAG=$PUREMYHA_LAG_SECONDS" > /tmp/hook_lag_exceeded.log
+exit 0

--- a/e2e/config/hooks/on_lag_threshold_recovered.sh
+++ b/e2e/config/hooks/on_lag_threshold_recovered.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+echo "recovered CLUSTER=$PUREMYHA_CLUSTER NODE=$PUREMYHA_NODE" > /tmp/hook_lag_recovered.log
+exit 0

--- a/e2e/config/puremyha.yaml
+++ b/e2e/config/puremyha.yaml
@@ -21,6 +21,8 @@ clusters:
       post_failover: /etc/puremyha/hooks/post_failover.sh
       pre_switchover: /etc/puremyha/hooks/pre_switchover.sh
       post_switchover: /etc/puremyha/hooks/post_switchover.sh
+      on_lag_threshold_exceeded: /etc/puremyha/hooks/on_lag_threshold_exceeded.sh
+      on_lag_threshold_recovered: /etc/puremyha/hooks/on_lag_threshold_recovered.sh
 
 http:
   enabled: true

--- a/e2e/tests/18-replica-lag-threshold.sh
+++ b/e2e/tests/18-replica-lag-threshold.sh
@@ -2,64 +2,92 @@
 # Test: Replica lag threshold — Lagging health state and candidate exclusion
 # When a replica's Seconds_Behind_Source reaches replication_lag_critical,
 # its health transitions to Lagging and it is excluded from failover candidates.
+# Also verifies that on_lag_threshold_exceeded / on_lag_threshold_recovered hooks
+# receive PUREMYHA_NODE set to the lagging replica's hostname.
 set -euo pipefail
 source "$(dirname "$0")/../lib/helpers.sh"
 echo "=== Test 18: Replica lag threshold ==="
 
 wait_for_health "Healthy" 60
 
-# --- Step 1: Stop the replica SQL thread to create artificial lag ---
-echo "  Stopping SQL thread on mysql-replica1 to induce lag..."
-mysql_exec mysql-replica1 "STOP REPLICA SQL_THREAD;"
+# Ensure no leftover hook marker files from previous runs
+$COMPOSE exec -T puremyhad rm -f /tmp/hook_lag_exceeded.log /tmp/hook_lag_recovered.log 2>/dev/null || true
 
-# Write data to the source so Seconds_Behind_Source grows
+# --- Step 1: Introduce SOURCE_DELAY on mysql-replica1 to simulate lag ---
+# SOURCE_DELAY causes the SQL thread to deliberately delay applying transactions,
+# making Seconds_Behind_Source grow above replication_lag_critical (10s in e2e config).
+echo "  Setting SOURCE_DELAY=30 on mysql-replica1..."
+mysql_exec mysql-replica1 "
+  STOP REPLICA;
+  CHANGE REPLICATION SOURCE TO SOURCE_DELAY=30;
+  START REPLICA;
+"
+
+# Write data to source so transactions accumulate in the relay log.
+# With SOURCE_DELAY=30, Seconds_Behind_Source will be ~30s once the IO thread
+# receives the transactions, exceeding the 10s critical threshold.
 echo "  Writing data to source to accumulate lag..."
+mysql_exec mysql-source "CREATE DATABASE IF NOT EXISTS e2e_lag_test;"
+mysql_exec mysql-source "CREATE TABLE IF NOT EXISTS e2e_lag_test.t1 (id INT PRIMARY KEY);"
 for i in $(seq 1 5); do
-  mysql_exec mysql-source "CREATE DATABASE IF NOT EXISTS e2e_lag_test;"
-  mysql_exec mysql-source "CREATE TABLE IF NOT EXISTS e2e_lag_test.t1 (id INT PRIMARY KEY);"
   mysql_exec mysql-source "INSERT IGNORE INTO e2e_lag_test.t1 VALUES ($i);"
-  sleep 2
+  sleep 1
 done
 
-# --- Step 2: Wait for node health to transition away from Healthy ---
-# The e2e config has replication_lag_critical: 10s, so after ~10s of lag
-# the replica should show a non-Healthy state (Lagging or NeedsAttention).
-echo "  Waiting for mysql-replica1 health to change..."
+# --- Step 2: Wait for mysql-replica1 health to transition to Lagging ---
+echo "  Waiting for mysql-replica1 health to transition to Lagging..."
 replica1_health=""
-for i in $(seq 1 30); do
+for i in $(seq 1 60); do
   topo_json=$(cli_topology 2>/dev/null || echo "[]")
   replica1_health=$(echo "$topo_json" | jq -r '.[0].nodes[] | select(.host=="mysql-replica1") | .health' 2>/dev/null || echo "")
-  if [ -n "$replica1_health" ] && [ "$replica1_health" != "Healthy" ]; then
-    echo "  mysql-replica1 health changed to: $replica1_health (${i}s)"
+  if echo "$replica1_health" | grep -q "Lagging"; then
+    echo "  mysql-replica1 health is Lagging (${i}s)"
     break
   fi
   sleep 1
 done
 
-assert_neq "mysql-replica1 is not Healthy while SQL thread stopped" "Healthy" "$replica1_health"
+assert_contains "mysql-replica1 transitions to Lagging" "Lagging" "$replica1_health"
 
-# Verify lag is reported in topology
-lag_value=$(cli_topology 2>/dev/null | jq -r '.[0].nodes[] | select(.host=="mysql-replica1") | .lagSeconds // -1' 2>/dev/null || echo "-1")
-echo "  Replica lag reported: ${lag_value}s"
-if [ "$lag_value" != "-1" ] && [ "$lag_value" != "null" ]; then
-  # Lag should be >= the critical threshold (10s)
-  if [ "$lag_value" -ge 10 ]; then
-    echo "  PASS: Lag ($lag_value) >= critical threshold (10s)"
-    ((PASS_COUNT++)) || true
-  else
-    echo "  NOTE: Lag ($lag_value) below threshold, may not have accumulated enough"
-  fi
-fi
+# --- Step 2b: Verify on_lag_threshold_exceeded hook fired with PUREMYHA_NODE ---
+echo "  Waiting for on_lag_threshold_exceeded hook to fire..."
+hook_exceeded=""
+for i in $(seq 1 15); do
+  hook_exceeded=$($COMPOSE exec -T puremyhad cat /tmp/hook_lag_exceeded.log 2>/dev/null || echo "")
+  [ -n "$hook_exceeded" ] && break
+  sleep 1
+done
+echo "  lag_exceeded hook log: $hook_exceeded"
+assert_not_empty "on_lag_threshold_exceeded hook fired" "$hook_exceeded"
+assert_contains "PUREMYHA_NODE is mysql-replica1" "NODE=mysql-replica1" "$hook_exceeded"
+assert_contains "PUREMYHA_LAG_SECONDS is present" "LAG=" "$hook_exceeded"
 
-# --- Step 3: Restart SQL thread ---
-echo "  Restarting SQL thread on mysql-replica1..."
-mysql_exec mysql-replica1 "START REPLICA SQL_THREAD;"
+# --- Step 3: Remove SOURCE_DELAY so the replica can catch up ---
+echo "  Removing SOURCE_DELAY on mysql-replica1..."
+mysql_exec mysql-replica1 "
+  STOP REPLICA;
+  CHANGE REPLICATION SOURCE TO SOURCE_DELAY=0;
+  START REPLICA;
+"
 
 # --- Step 4: Verify cluster returns to Healthy ---
 echo "  Waiting for replica to catch up and cluster to return to Healthy..."
 wait_for_health "Healthy" 60
 
+# --- Step 4b: Verify on_lag_threshold_recovered hook fired with PUREMYHA_NODE ---
+echo "  Waiting for on_lag_threshold_recovered hook to fire..."
+hook_recovered=""
+for i in $(seq 1 30); do
+  hook_recovered=$($COMPOSE exec -T puremyhad cat /tmp/hook_lag_recovered.log 2>/dev/null || echo "")
+  [ -n "$hook_recovered" ] && break
+  sleep 1
+done
+echo "  lag_recovered hook log: $hook_recovered"
+assert_not_empty "on_lag_threshold_recovered hook fired" "$hook_recovered"
+assert_contains "PUREMYHA_NODE is mysql-replica1" "NODE=mysql-replica1" "$hook_recovered"
+
 echo "  Cleaning up test database..."
 mysql_exec mysql-source "DROP DATABASE IF EXISTS e2e_lag_test;"
 
+test_summary
 echo "=== Test 18 PASSED ==="

--- a/src/PureMyHA/Failover/Auto.hs
+++ b/src/PureMyHA/Failover/Auto.hs
@@ -100,7 +100,7 @@ executeFailover topo = runExceptT $ do
   lift $ commitFailoverState candidateId topo now
   ts <- liftIO getCurrentTimestamp
   mHooks <- lift getHooksConfig
-  let postEnv = HookEnv (ccName cc) (Just (nodeHost candidateId)) oldSourceHost (Just "DeadSource") ts Nothing
+  let postEnv = HookEnv (ccName cc) (Just (nodeHost candidateId)) oldSourceHost (Just "DeadSource") ts Nothing Nothing
   liftIO $ runHookFireForget mHooks hcPostFailover postEnv
   lift $ appLogInfo $ prefix <> "Auto-failover completed: new source is " <> nodeHost candidateId
 
@@ -109,7 +109,7 @@ runPreFailoverHook candidateId oldSourceHost = do
   cc     <- asks envCluster
   mHooks <- getHooksConfig
   ts <- liftIO getCurrentTimestamp
-  let preEnv = HookEnv (ccName cc) (Just (nodeHost candidateId)) oldSourceHost (Just "DeadSource") ts Nothing
+  let preEnv = HookEnv (ccName cc) (Just (nodeHost candidateId)) oldSourceHost (Just "DeadSource") ts Nothing Nothing
   preResult <- liftIO $ runHookOrAbort mHooks hcPreFailover preEnv
   case preResult of
     Left err -> do
@@ -126,7 +126,7 @@ promoteWithOnFailureHook candidateId waitTimeout oldSourceHost = do
       appLogError $ "[" <> unClusterName clusterName <> "] Auto-failover failed: Promote failed: " <> err
       ts <- liftIO getCurrentTimestamp
       mHooks <- getHooksConfig
-      let failEnv = HookEnv clusterName (Just (nodeHost candidateId)) oldSourceHost (Just "PromoteFailed") ts Nothing
+      let failEnv = HookEnv clusterName (Just (nodeHost candidateId)) oldSourceHost (Just "PromoteFailed") ts Nothing Nothing
       liftIO $ runHookFireForget mHooks hcPostUnsuccessfulFailover failEnv
       pure (Left $ "Promote failed: " <> err)
     Right () -> pure (Right ())
@@ -250,7 +250,7 @@ fenceNode clusterName survivorHost ns = do
       liftIO $ atomically $ updateNodeState tvar clusterName (ns { nsFenced = True })
       appLogInfo $ prefix <> "Auto-fence: " <> nodeHost nid <> " fenced (super_read_only=ON)"
       ts <- liftIO getCurrentTimestamp
-      let hookEnv = HookEnv clusterName (Just survivorHost) (Just (nodeHost nid)) Nothing ts Nothing
+      let hookEnv = HookEnv clusterName (Just survivorHost) (Just (nodeHost nid)) Nothing ts Nothing Nothing
       liftIO $ runHookFireForget mHooks hcOnFence hookEnv
 
 -- | Unfence a node: clear super_read_only and reset fenced state in STM.

--- a/src/PureMyHA/Failover/Switchover.hs
+++ b/src/PureMyHA/Failover/Switchover.hs
@@ -63,7 +63,7 @@ runSwitchover mToHost mDrainTimeout = do
           -- Pre-switchover hook (blocking: non-zero exit aborts)
           mHooks <- getHooksConfig
           ts <- liftIO getCurrentTimestamp
-          let preEnv = HookEnv (ccName cc) (Just (nodeHost candidateId)) oldSourceHost Nothing ts Nothing
+          let preEnv = HookEnv (ccName cc) (Just (nodeHost candidateId)) oldSourceHost Nothing ts Nothing Nothing
           preResult <- liftIO $ runHookOrAbort mHooks hcPreSwitchover preEnv
           case preResult of
             Left err -> do
@@ -148,7 +148,7 @@ doSwitchover candidateId oldSourceId oldSourceHost topo mDrainTimeout = do
               -- Post-switchover hook (fire-and-forget)
               mHooks <- getHooksConfig
               ts <- liftIO getCurrentTimestamp
-              let postEnv = HookEnv (ccName cc) (Just (nodeHost candidateId)) oldSourceHost Nothing ts Nothing
+              let postEnv = HookEnv (ccName cc) (Just (nodeHost candidateId)) oldSourceHost Nothing ts Nothing Nothing
               liftIO $ runHookFireForget mHooks hcPostSwitchover postEnv
 
               appLogInfo $ "[" <> unClusterName (ccName cc) <> "] Switchover completed: new source is " <> nodeHost candidateId

--- a/src/PureMyHA/Hook.hs
+++ b/src/PureMyHA/Hook.hs
@@ -24,6 +24,7 @@ data HookEnv = HookEnv
   , hookFailureType :: Maybe Text   -- e.g. "DeadSource", "PromoteFailed"
   , hookTimestamp   :: Text         -- ISO-8601 UTC: "2026-03-17T12:00:00Z"
   , hookLagSeconds  :: Maybe Int    -- e.g. 45 when on_lag_threshold_exceeded fires
+  , hookNode        :: Maybe Text   -- hostname of the replica for lag threshold hooks
   }
 
 getCurrentTimestamp :: IO Text
@@ -41,6 +42,7 @@ runHook scriptPath hookEnv = do
         maybe [] (\h -> [("PUREMYHA_OLD_SOURCE", T.unpack h)]) (hookOldSource hookEnv) ++
         maybe [] (\ft -> [("PUREMYHA_FAILURE_TYPE", T.unpack ft)]) (hookFailureType hookEnv) ++
         maybe [] (\s  -> [("PUREMYHA_LAG_SECONDS", show s)]) (hookLagSeconds hookEnv) ++
+        maybe [] (\n  -> [("PUREMYHA_NODE",        T.unpack n)]) (hookNode hookEnv) ++
         [("PUREMYHA_TIMESTAMP", T.unpack (hookTimestamp hookEnv))]
   result <- try @SomeException $ do
     (_, _, _, ph) <- createProcess (proc scriptPath [T.unpack (unClusterName (hookClusterName hookEnv))])

--- a/src/PureMyHA/Monitor/Worker.hs
+++ b/src/PureMyHA/Monitor/Worker.hs
@@ -5,6 +5,7 @@ module PureMyHA.Monitor.Worker
   , monitorNode
   , runWorker
   , suppressBelowThreshold
+  , buildLagHookEnv
   , enrichErrantGtids
   , computeStaleNodes
   , pruneStaleWorkers
@@ -154,6 +155,20 @@ suppressBelowThreshold threshold failCount mOldNs ns
       ns { nsHealth = maybe Healthy nsHealth mOldNs }
   | otherwise = ns
 
+-- | Build the base HookEnv for lag threshold hooks.
+-- Sets hookNode to the replica's hostname so hook scripts can identify
+-- which replica is lagging in multi-replica topologies.
+buildLagHookEnv :: ClusterName -> NodeId -> T.Text -> HookEnv
+buildLagHookEnv clusterName nid ts =
+  HookEnv { hookClusterName = clusterName
+           , hookNewSource   = Nothing
+           , hookOldSource   = Nothing
+           , hookFailureType = Nothing
+           , hookTimestamp   = ts
+           , hookLagSeconds  = Nothing
+           , hookNode        = Just (nodeHost nid)
+           }
+
 -- | Perform a single monitoring cycle for a node
 monitorNode :: NodeId -> App ()
 monitorNode nid = do
@@ -239,7 +254,7 @@ monitorNode nid = do
     ts     <- getCurrentTimestamp
     let oldHealth = fmap nsHealth mOldNs
         newHealth = nsHealth ns'''
-        baseEnv   = HookEnv (ccName cc) Nothing Nothing Nothing ts Nothing
+        baseEnv   = buildLagHookEnv (ccName cc) nid ts
     case (oldHealth, newHealth) of
       (Just (Lagging _), Lagging _) -> pure ()  -- already lagging, no transition
       (_, Lagging lag) ->
@@ -331,12 +346,12 @@ recomputeClusterHealth = do
           DeadSource -> do
             mHooks <- readTVarIO (envHooks env)
             ts <- getCurrentTimestamp
-            let hookEnv = HookEnv (ccName cc) Nothing Nothing (Just "DeadSource") ts Nothing
+            let hookEnv = HookEnv (ccName cc) Nothing Nothing (Just "DeadSource") ts Nothing Nothing
             runHookFireForget mHooks hcOnFailureDetection hookEnv
           DeadSourceAndAllReplicas -> do
             mHooks <- readTVarIO (envHooks env)
             ts <- getCurrentTimestamp
-            let hookEnv = HookEnv (ccName cc) Nothing Nothing (Just "DeadSourceAndAllReplicas") ts Nothing
+            let hookEnv = HookEnv (ccName cc) Nothing Nothing (Just "DeadSourceAndAllReplicas") ts Nothing Nothing
             runHookFireForget mHooks hcOnFailureDetection hookEnv
           _ -> pure ()
       -- Log all health transitions for observability

--- a/test/PureMyHA/WorkerSpec.hs
+++ b/test/PureMyHA/WorkerSpec.hs
@@ -10,7 +10,8 @@ import Fixtures
 import PureMyHA.Config (ClusterConfig (..), NodeConfig (..), Credentials (..), FailoverConfig (..), MonitoringConfig (..), FailureDetectionConfig (..))
 import PureMyHA.Env (runApp)
 import qualified Data.Set as Set
-import PureMyHA.Monitor.Worker (suppressBelowThreshold, enrichErrantGtids, computeStaleNodes, pruneStaleWorkers, detectAndPruneStaleWorkers, probeTimeoutMicros)
+import PureMyHA.Monitor.Worker (suppressBelowThreshold, enrichErrantGtids, computeStaleNodes, pruneStaleWorkers, detectAndPruneStaleWorkers, probeTimeoutMicros, buildLagHookEnv)
+import PureMyHA.Hook (HookEnv (..))
 import PureMyHA.Topology.Discovery (buildClusterTopology)
 import PureMyHA.Topology.State (newDaemonState, updateClusterTopology)
 import PureMyHA.Types
@@ -237,3 +238,24 @@ spec = do
       stale `shouldBe` []
       registry <- readTVarIO reg
       Map.size registry `shouldBe` 2
+
+  describe "buildLagHookEnv" $ do
+
+    it "sets hookNode to the node's host" $
+      hookNode (buildLagHookEnv "main" (NodeId "db2" 3306) "2026-01-01T00:00:00Z")
+        `shouldBe` Just "db2"
+
+    it "does not set hookNewSource, hookOldSource, hookFailureType, or hookLagSeconds" $ do
+      let e = buildLagHookEnv "main" (NodeId "db2" 3306) "2026-01-01T00:00:00Z"
+      hookNewSource   e `shouldBe` Nothing
+      hookOldSource   e `shouldBe` Nothing
+      hookFailureType e `shouldBe` Nothing
+      hookLagSeconds  e `shouldBe` Nothing
+
+    it "sets hookClusterName correctly" $
+      hookClusterName (buildLagHookEnv "main" (NodeId "db2" 3306) "ts")
+        `shouldBe` "main"
+
+    it "sets hookTimestamp correctly" $
+      hookTimestamp (buildLagHookEnv "main" (NodeId "db2" 3306) "2026-01-01T00:00:00Z")
+        `shouldBe` "2026-01-01T00:00:00Z"


### PR DESCRIPTION
## Summary
- Adds `hookNode :: Maybe Text` field to `HookEnv` in `src/PureMyHA/Hook.hs`, exposed as `PUREMYHA_NODE` environment variable
- Sets `PUREMYHA_NODE` to the lagging replica's hostname for `on_lag_threshold_exceeded` and `on_lag_threshold_recovered` hooks via a new pure helper `buildLagHookEnv` in `Monitor/Worker.hs`
- All other hooks (`pre/post_failover`, `pre/post_switchover`, `on_fence`, `on_failure_detection`) keep `hookNode = Nothing` for full backward compatibility
- Adds 4 unit tests for `buildLagHookEnv` in `test/PureMyHA/WorkerSpec.hs`
- Extends E2E test 18 to verify both hooks fire with `PUREMYHA_NODE=mysql-replica1`; uses `SOURCE_DELAY=30` (instead of stopping the SQL thread) to reliably trigger `Lagging` health

Closes #100

## Test plan
- [x] `cabal build all` passes with no warnings
- [x] `cabal test` passes (375 examples, 0 failures)
- [x] E2E test 18 (`18-replica-lag-threshold.sh`) passes: verifies `on_lag_threshold_exceeded` fires with `NODE=mysql-replica1` and `LAG=`, and `on_lag_threshold_recovered` fires with `NODE=mysql-replica1` after lag clears

🤖 Generated with [Claude Code](https://claude.com/claude-code)