### PR TITLE
refactor: introduce HostName newtype for host values (ISSUE #112)

### DIFF
--- a/app/CLI/Main.hs
+++ b/app/CLI/Main.hs
@@ -12,7 +12,7 @@ import PureMyHA.Config (loadConfig, validateConfig)
 import PureMyHA.IPC.Client
 import PureMyHA.IPC.Protocol
 import PureMyHA.IPC.Server (defaultSocketPath)
-import PureMyHA.Types (ClusterName (..))
+import PureMyHA.Types (ClusterName (..), HostName (..))
 
 data CLIOptions = CLIOptions
   { optSocketPath  :: FilePath
@@ -24,20 +24,20 @@ data CLIOptions = CLIOptions
 data Command
   = CmdStatus
   | CmdTopology
-  | CmdSwitchover (Maybe Text) Bool (Maybe Int)
+  | CmdSwitchover (Maybe HostName) Bool (Maybe Int)
   | CmdAckRecovery
   | CmdErrantGtid
   | CmdFixErrantGtid
-  | CmdDemote Text Text   -- host, source
+  | CmdDemote HostName HostName   -- host, source
   | CmdDiscovery
-  | CmdPauseReplica  Text
-  | CmdResumeReplica Text
+  | CmdPauseReplica  HostName
+  | CmdResumeReplica HostName
   | CmdPauseFailover
   | CmdResumeFailover
   | CmdSetLogLevel Text
   | CmdValidateConfig FilePath
-  | CmdUnfence Text
-  | CmdClone Text (Maybe Text)   -- recipient, donor?
+  | CmdUnfence HostName
+  | CmdClone HostName (Maybe HostName)   -- recipient, donor?
 
 cliOptions :: Parser CLIOptions
 cliOptions = CLIOptions
@@ -92,14 +92,14 @@ cliOptions = CLIOptions
 
 demoteCmd :: Parser Command
 demoteCmd = CmdDemote
-  <$> strOption (long "host"   <> metavar "HOST" <> help "Node to demote")
-  <*> strOption (long "source" <> metavar "HOST" <> help "New replication source host")
+  <$> (HostName <$> strOption (long "host"   <> metavar "HOST" <> help "Node to demote"))
+  <*> (HostName <$> strOption (long "source" <> metavar "HOST" <> help "New replication source host"))
 
 pauseReplicaCmd :: Parser Command
-pauseReplicaCmd = CmdPauseReplica <$> strOption (long "host" <> metavar "HOST" <> help "Node to pause")
+pauseReplicaCmd = CmdPauseReplica <$> (HostName <$> strOption (long "host" <> metavar "HOST" <> help "Node to pause"))
 
 resumeReplicaCmd :: Parser Command
-resumeReplicaCmd = CmdResumeReplica <$> strOption (long "host" <> metavar "HOST" <> help "Node to resume")
+resumeReplicaCmd = CmdResumeReplica <$> (HostName <$> strOption (long "host" <> metavar "HOST" <> help "Node to resume"))
 
 setLogLevelCmd :: Parser Command
 setLogLevelCmd = CmdSetLogLevel
@@ -107,13 +107,13 @@ setLogLevelCmd = CmdSetLogLevel
 
 unfenceCmd :: Parser Command
 unfenceCmd = CmdUnfence
-  <$> strOption (long "host" <> metavar "HOST" <> help "Host to unfence (clears super_read_only)")
+  <$> (HostName <$> strOption (long "host" <> metavar "HOST" <> help "Host to unfence (clears super_read_only)"))
 
 cloneCmd :: Parser Command
 cloneCmd = CmdClone
-  <$> strOption (long "recipient" <> metavar "HOST[:PORT]"
-        <> help "Replica node to re-seed")
-  <*> optional (strOption (long "donor" <> metavar "HOST[:PORT]"
+  <$> (HostName <$> strOption (long "recipient" <> metavar "HOST[:PORT]"
+        <> help "Replica node to re-seed"))
+  <*> optional (HostName <$> strOption (long "donor" <> metavar "HOST[:PORT]"
         <> help "Donor node (default: replica with most advanced GTID)"))
 
 validateConfigCmd :: Parser Command
@@ -127,7 +127,7 @@ validateConfigCmd = CmdValidateConfig
 
 switchoverCmd :: Parser Command
 switchoverCmd = CmdSwitchover
-  <$> optional (strOption
+  <$> optional (HostName <$> strOption
         ( long "to"
         <> metavar "HOST"
         <> help "Target host to promote" ))

--- a/src/PureMyHA/Clone.hs
+++ b/src/PureMyHA/Clone.hs
@@ -55,8 +55,10 @@ selectDonorAuto nodes recipientId =
 -- | Re-seed a replica using the MySQL CLONE plugin.
 -- Connects to the recipient and issues CLONE INSTANCE FROM <donor>.
 -- The recipient MySQL process will restart after cloning completes.
-runClone :: Text -> Maybe Text -> App (Either Text ())
-runClone recipientSpec mDonorSpec = do
+runClone :: HostName -> Maybe HostName -> App (Either Text ())
+runClone recipientSpec_ mDonorSpec_ = do
+  let recipientSpec = unHostName recipientSpec_
+      mDonorSpec    = fmap unHostName mDonorSpec_
   tvar          <- asks envDaemonState
   clusterName   <- getClusterName
   let clName    = unClusterName clusterName
@@ -66,7 +68,7 @@ runClone recipientSpec mDonorSpec = do
     Just topo -> do
       let nodes = ctNodes topo
           (recipientHost, _) = parseHostPort recipientSpec
-      case findNodeByHost recipientHost nodes of
+      case findNodeByHost (HostName recipientHost) nodes of
         Nothing -> pure $ Left $ "Recipient not found in cluster: " <> recipientHost
         Just recipientNs -> do
           let recipientId = nsNodeId recipientNs
@@ -79,7 +81,7 @@ runClone recipientSpec mDonorSpec = do
               eDonorId <- case mDonorSpec of
                 Just donorSpec -> do
                   let (donorHost, _) = parseHostPort donorSpec
-                  case findNodeByHost donorHost nodes of
+                  case findNodeByHost (HostName donorHost) nodes of
                     Nothing -> pure $ Left $ "Donor not found in cluster: " <> donorHost
                     Just donorNs
                       | nsNodeId donorNs == recipientId ->
@@ -91,7 +93,7 @@ runClone recipientSpec mDonorSpec = do
                 Right donorId -> do
                   mTls  <- getTLSConfig
                   creds <- getMonCredentials
-                  let donorHost     = nodeHost donorId
+                  let donorHost     = unHostName (nodeHost donorId)
                       donorPort     = nodePort donorId
                       donorCi       = makeConnectInfo donorId creds
                       recipientCi   = makeConnectInfo recipientId creds

--- a/src/PureMyHA/Failover/Auto.hs
+++ b/src/PureMyHA/Failover/Auto.hs
@@ -90,26 +90,26 @@ executeFailover topo = runExceptT $ do
         appLogError (prefix <> "Auto-failover failed: " <> err)
         pure (Left err)
       Right c -> pure (Right c)
-  let oldSourceHost = fmap nodeHost (ctSourceNodeId topo)
+  let oldSourceHost = fmap (unHostName . nodeHost) (ctSourceNodeId topo)
       waitTimeout   = truncate (fcWaitRelayLogTimeout fc) :: Int
   ExceptT $ runPreFailoverHook candidateId oldSourceHost
-  lift $ appLogInfo $ prefix <> "Waiting for relay log apply on " <> nodeHost candidateId <> "..."
+  lift $ appLogInfo $ prefix <> "Waiting for relay log apply on " <> unHostName (nodeHost candidateId) <> "..."
   ExceptT $ promoteWithOnFailureHook candidateId waitTimeout oldSourceHost
   lift $ reconnectOtherReplicas candidateId topo
   now <- liftIO getCurrentTime
   lift $ commitFailoverState candidateId topo now
   ts <- liftIO getCurrentTimestamp
   mHooks <- lift getHooksConfig
-  let postEnv = HookEnv (ccName cc) (Just (nodeHost candidateId)) oldSourceHost (Just "DeadSource") ts Nothing Nothing
+  let postEnv = HookEnv (ccName cc) (Just (unHostName (nodeHost candidateId))) oldSourceHost (Just "DeadSource") ts Nothing Nothing
   liftIO $ runHookFireForget mHooks hcPostFailover postEnv
-  lift $ appLogInfo $ prefix <> "Auto-failover completed: new source is " <> nodeHost candidateId
+  lift $ appLogInfo $ prefix <> "Auto-failover completed: new source is " <> unHostName (nodeHost candidateId)
 
 runPreFailoverHook :: NodeId -> Maybe Text -> App (Either Text ())
 runPreFailoverHook candidateId oldSourceHost = do
   cc     <- asks envCluster
   mHooks <- getHooksConfig
   ts <- liftIO getCurrentTimestamp
-  let preEnv = HookEnv (ccName cc) (Just (nodeHost candidateId)) oldSourceHost (Just "DeadSource") ts Nothing Nothing
+  let preEnv = HookEnv (ccName cc) (Just (unHostName (nodeHost candidateId))) oldSourceHost (Just "DeadSource") ts Nothing Nothing
   preResult <- liftIO $ runHookOrAbort mHooks hcPreFailover preEnv
   case preResult of
     Left err -> do
@@ -126,7 +126,7 @@ promoteWithOnFailureHook candidateId waitTimeout oldSourceHost = do
       appLogError $ "[" <> unClusterName clusterName <> "] Auto-failover failed: Promote failed: " <> err
       ts <- liftIO getCurrentTimestamp
       mHooks <- getHooksConfig
-      let failEnv = HookEnv clusterName (Just (nodeHost candidateId)) oldSourceHost (Just "PromoteFailed") ts Nothing Nothing
+      let failEnv = HookEnv clusterName (Just (unHostName (nodeHost candidateId))) oldSourceHost (Just "PromoteFailed") ts Nothing Nothing
       liftIO $ runHookFireForget mHooks hcPostUnsuccessfulFailover failEnv
       pure (Left $ "Promote failed: " <> err)
     Right () -> pure (Right ())
@@ -164,8 +164,8 @@ promoteCandidate nid waitTimeout = do
     result <- withNodeConn mTls ci $ \conn -> do
       caughtUp <- waitForRelayLogApply conn waitTimeout
       if caughtUp
-        then logInfo logger $ "[" <> unClusterName clusterName <> "] Relay log apply completed on " <> nodeHost nid
-        else logError logger $ "[" <> unClusterName clusterName <> "] WARNING: Relay log apply timed out on " <> nodeHost nid <> ", proceeding with promotion"
+        then logInfo logger $ "[" <> unClusterName clusterName <> "] Relay log apply completed on " <> unHostName (nodeHost nid)
+        else logError logger $ "[" <> unClusterName clusterName <> "] WARNING: Relay log apply timed out on " <> unHostName (nodeHost nid) <> ", proceeding with promotion"
       stopReplica conn
       resetReplicaAll conn
       setReadWrite conn
@@ -182,7 +182,7 @@ reconnectReplica newSourceId ns = do
   liftIO $ do
     _ <- withNodeConn mTls ci $ \conn -> do
       stopReplica conn
-      changeReplicationSourceTo conn (nodeHost newSourceId) (nodePort newSourceId) replCreds mTls
+      changeReplicationSourceTo conn (unHostName (nodeHost newSourceId)) (nodePort newSourceId) replCreds mTls
       setReadOnly conn
       startReplica conn
     pure ()
@@ -225,7 +225,7 @@ doAutoFence = do
             Nothing -> appLogError $ prefix <> "Auto-fence: no survivor could be selected"
             Just survivorId -> do
               let toFence = filter (\ns -> nsNodeId ns /= survivorId) unfenced
-                  survivorHost = nodeHost survivorId
+                  survivorHost = unHostName (nodeHost survivorId)
               appLogInfo $ prefix <> "Auto-fence: split-brain detected, survivor=" <> survivorHost
                         <> ", fencing " <> T.pack (show (length toFence)) <> " node(s)"
               forM_ toFence $ \ns -> fenceNode clusterName survivorHost ns
@@ -245,16 +245,16 @@ fenceNode clusterName survivorHost ns = do
   result <- liftIO $ withNodeConnRetry 1 0 cap (const (pure ())) mTls ci setSuperReadOnly
   case result of
     Left err ->
-      appLogError $ prefix <> "Auto-fence failed on " <> nodeHost nid <> ": " <> err
+      appLogError $ prefix <> "Auto-fence failed on " <> unHostName (nodeHost nid) <> ": " <> err
     Right () -> do
       liftIO $ atomically $ updateNodeState tvar clusterName (ns { nsFenced = True })
-      appLogInfo $ prefix <> "Auto-fence: " <> nodeHost nid <> " fenced (super_read_only=ON)"
+      appLogInfo $ prefix <> "Auto-fence: " <> unHostName (nodeHost nid) <> " fenced (super_read_only=ON)"
       ts <- liftIO getCurrentTimestamp
-      let hookEnv = HookEnv clusterName (Just survivorHost) (Just (nodeHost nid)) Nothing ts Nothing Nothing
+      let hookEnv = HookEnv clusterName (Just survivorHost) (Just (unHostName (nodeHost nid))) Nothing ts Nothing Nothing
       liftIO $ runHookFireForget mHooks hcOnFence hookEnv
 
 -- | Unfence a node: clear super_read_only and reset fenced state in STM.
-doUnfence :: Text -> App (Either Text ())
+doUnfence :: HostName -> App (Either Text ())
 doUnfence host = do
   clusterName <- getClusterName
   tvar        <- asks envDaemonState
@@ -264,7 +264,7 @@ doUnfence host = do
     Nothing -> pure (Left "Cluster not found")
     Just topo ->
       case findNodeByHost host (ctNodes topo) of
-        Nothing -> pure (Left $ "Host not found in cluster: " <> host)
+        Nothing -> pure (Left $ "Host not found in cluster: " <> unHostName host)
         Just ns -> do
           creds <- getMonCredentials
           mTls  <- getTLSConfig
@@ -272,10 +272,10 @@ doUnfence host = do
           result <- liftIO $ withNodeConn mTls ci clearSuperReadOnly
           case result of
             Left err -> do
-              appLogError $ prefix <> "Unfence failed on " <> host <> ": " <> err
+              appLogError $ prefix <> "Unfence failed on " <> unHostName host <> ": " <> err
               pure (Left $ "Unfence failed: " <> err)
             Right () -> do
               liftIO $ atomically $ updateNodeState tvar clusterName (ns { nsFenced = False })
-              appLogInfo $ prefix <> "Unfenced " <> host
+              appLogInfo $ prefix <> "Unfenced " <> unHostName host
                         <> " (super_read_only cleared). WARNING: verify data consistency before resuming writes."
               pure (Right ())

--- a/src/PureMyHA/Failover/Candidate.hs
+++ b/src/PureMyHA/Failover/Candidate.hs
@@ -43,7 +43,7 @@ selectCandidate
   -> Maybe Int              -- ^ max lag in seconds for auto-select candidates (Nothing = no limit)
   -> Map NodeId NodeState
   -> [CandidatePriority]
-  -> Maybe Text             -- ^ explicit --to host override
+  -> Maybe HostName         -- ^ explicit --to host override
   -> Either Text NodeId
 selectCandidate neverPromote mMaxLag nodes priorities mToHost =
   case mToHost of
@@ -53,11 +53,11 @@ selectCandidate neverPromote mMaxLag nodes priorities mToHost =
             (\ns -> nodeHost (nsNodeId ns) == toHost && not (isSource ns))
             nodes
       in case matching of
-           []  -> Left $ "Host not found as replica: " <> toHost
+           []  -> Left $ "Host not found as replica: " <> unHostName toHost
            (ns:_)
-             | toHost `elem` neverPromote -> Left $ "Cannot promote: host is in never_promote list: " <> toHost
-             | hasErrantGtid ns -> Left $ "Cannot promote: node has errant GTIDs: " <> toHost
-             | hasConnectError ns -> Left $ "Cannot promote: node unreachable: " <> toHost
+             | unHostName toHost `elem` neverPromote -> Left $ "Cannot promote: host is in never_promote list: " <> unHostName toHost
+             | hasErrantGtid ns -> Left $ "Cannot promote: node has errant GTIDs: " <> unHostName toHost
+             | hasConnectError ns -> Left $ "Cannot promote: node unreachable: " <> unHostName toHost
              | otherwise -> Right (nsNodeId ns)
     Nothing ->
       -- Auto-select: filter, rank, pick best
@@ -80,7 +80,7 @@ isEligibleCandidate neverPromote mMaxLag ns =
   && not (hasConnectError ns)
   && not (isLagging ns)
   && not (exceedsMaxLag mMaxLag ns)
-  && nodeHost (nsNodeId ns) `notElem` neverPromote
+  && unHostName (nodeHost (nsNodeId ns)) `notElem` neverPromote
 
 isLagging :: NodeState -> Bool
 isLagging ns = case nsHealth ns of
@@ -103,7 +103,7 @@ hasConnectError ns = case nsProbeResult ns of
   ProbeSuccess{}                   -> False
 
 isNeverPromote :: [Text] -> NodeState -> Bool
-isNeverPromote neverPromote ns = nodeHost (nsNodeId ns) `elem` neverPromote
+isNeverPromote neverPromote ns = unHostName (nodeHost (nsNodeId ns)) `elem` neverPromote
 
 toCandidateInfo :: [CandidatePriority] -> NodeState -> CandidateInfo
 toCandidateInfo priorities ns = CandidateInfo
@@ -114,9 +114,9 @@ toCandidateInfo priorities ns = CandidateInfo
   , ciPriorityRank = priorityRank priorities (nodeHost (nsNodeId ns))
   }
 
-priorityRank :: [CandidatePriority] -> Text -> Int
+priorityRank :: [CandidatePriority] -> HostName -> Int
 priorityRank priorities host =
-  case mapMaybe (\(i, p) -> if cpHost p == host then Just i else Nothing)
+  case mapMaybe (\(i, p) -> if cpHost p == unHostName host then Just i else Nothing)
          (zip [0..] priorities) of
     (rank:_) -> rank
     []       -> maxBound
@@ -132,7 +132,7 @@ gtidScore = gtidTransactionCount . ciExecutedGtid
 -- Nodes in the never_promote list are excluded from survivor selection.
 selectSurvivor :: [Text] -> [CandidatePriority] -> [NodeState] -> Maybe NodeId
 selectSurvivor neverPromote _priorities nodes =
-  let eligible = filter (\ns -> nodeHost (nsNodeId ns) `notElem` neverPromote) nodes
+  let eligible = filter (\ns -> unHostName (nodeHost (nsNodeId ns)) `notElem` neverPromote) nodes
       infos    = map (toSourceCandidateInfo []) eligible
       ranked   = sortBy (comparing (Down . gtidScore)) infos
   in case ranked of

--- a/src/PureMyHA/Failover/Demote.hs
+++ b/src/PureMyHA/Failover/Demote.hs
@@ -14,8 +14,8 @@ import PureMyHA.Types
 
 -- | Demote a node to replica under a specified source
 runDemote
-  :: Text       -- ^ host to demote
-  -> Text       -- ^ new source host
+  :: HostName   -- ^ host to demote
+  -> HostName   -- ^ new source host
   -> App (Either Text ())
 runDemote demoteHost srcHost = do
   tvar      <- asks envDaemonState
@@ -28,18 +28,18 @@ runDemote demoteHost srcHost = do
     Nothing -> pure (Left "Cluster not found")
     Just topo ->
       case (findNodeByHost demoteHost (ctNodes topo), findNodeByHost srcHost (ctNodes topo)) of
-        (Nothing, _) -> pure (Left $ "Node not found: " <> demoteHost)
-        (_, Nothing) -> pure (Left $ "Node not found: " <> srcHost)
+        (Nothing, _) -> pure (Left $ "Node not found: " <> unHostName demoteHost)
+        (_, Nothing) -> pure (Left $ "Node not found: " <> unHostName srcHost)
         (Just demoteNs, Just srcNs) -> do
           let demoteId = nsNodeId demoteNs
               srcId    = nsNodeId srcNs
               ci       = makeConnectInfo demoteId monCreds
-          appLogInfo $ "[" <> unClusterName (ccName cc) <> "] Demoting " <> demoteHost
-                    <> " to replica under " <> srcHost
+          appLogInfo $ "[" <> unClusterName (ccName cc) <> "] Demoting " <> unHostName demoteHost
+                    <> " to replica under " <> unHostName srcHost
           result <- liftIO $ withNodeConn mTls ci $ \conn -> do
             stopReplica conn
             setReadOnly conn
-            changeReplicationSourceTo conn (nodeHost srcId) (nodePort srcId) replCreds mTls
+            changeReplicationSourceTo conn (unHostName (nodeHost srcId)) (nodePort srcId) replCreds mTls
             startReplica conn
           case result of
             Left err -> do
@@ -49,5 +49,5 @@ runDemote demoteHost srcHost = do
               liftIO $ atomically $ updateNodeState tvar (ccName cc)
                 (demoteNs { nsRole = Replica })
               appLogInfo $ "[" <> unClusterName (ccName cc) <> "] Demote completed: "
-                        <> demoteHost <> " is now a replica"
+                        <> unHostName demoteHost <> " is now a replica"
               pure (Right ())

--- a/src/PureMyHA/Failover/PauseReplica.hs
+++ b/src/PureMyHA/Failover/PauseReplica.hs
@@ -14,14 +14,14 @@ import PureMyHA.Types
 
 -- | Pause replication on a replica node for maintenance
 runPauseReplica
-  :: Text       -- ^ host to pause
+  :: HostName   -- ^ host to pause
   -> App (Either Text ())
 runPauseReplica targetHost =
   withTargetNode "Pausing" targetHost stopReplica (\ns -> ns { nsPaused = True })
 
 -- | Resume replication on a paused replica node
 runResumeReplica
-  :: Text       -- ^ host to resume
+  :: HostName   -- ^ host to resume
   -> App (Either Text ())
 runResumeReplica targetHost =
   withTargetNode "Resuming" targetHost startReplica (\ns -> ns { nsPaused = False })
@@ -29,7 +29,7 @@ runResumeReplica targetHost =
 -- | Common logic for pause/resume: find node, connect, run action, update state.
 withTargetNode
   :: Text                            -- ^ action name for logging (e.g. "Pausing")
-  -> Text                            -- ^ target host
+  -> HostName                        -- ^ target host
   -> (MySQLConn -> IO ())            -- ^ MySQL action to execute
   -> (NodeState -> NodeState)        -- ^ state update on success
   -> App (Either Text ())
@@ -43,10 +43,10 @@ withTargetNode actionName targetHost mysqlAction stateUpdate = do
     Nothing -> pure (Left "Cluster not found")
     Just topo ->
       case findNodeByHost targetHost (ctNodes topo) of
-        Nothing -> pure (Left $ "Node not found: " <> targetHost)
+        Nothing -> pure (Left $ "Node not found: " <> unHostName targetHost)
         Just targetNs -> do
           let ci = makeConnectInfo (nsNodeId targetNs) creds
-          appLogInfo $ "[" <> unClusterName (ccName cc) <> "] " <> actionName <> " replication on " <> targetHost
+          appLogInfo $ "[" <> unClusterName (ccName cc) <> "] " <> actionName <> " replication on " <> unHostName targetHost
           result <- liftIO $ withNodeConn mTls ci $ \conn -> mysqlAction conn
           case result of
             Left err -> do
@@ -54,7 +54,7 @@ withTargetNode actionName targetHost mysqlAction stateUpdate = do
               pure (Left err)
             Right () -> do
               liftIO $ atomically $ updateNodeState tvar (ccName cc) (stateUpdate targetNs)
-              appLogInfo $ "[" <> unClusterName (ccName cc) <> "] Replication " <> actionResult <> " on " <> targetHost
+              appLogInfo $ "[" <> unClusterName (ccName cc) <> "] Replication " <> actionResult <> " on " <> unHostName targetHost
               pure (Right ())
   where
     actionResult = case actionName of

--- a/src/PureMyHA/Failover/Switchover.hs
+++ b/src/PureMyHA/Failover/Switchover.hs
@@ -37,7 +37,7 @@ switchoverReconnectTargets nodes candidateId =
 
 -- | Execute a manual switchover
 runSwitchover
-  :: Maybe Text        -- ^ --to host
+  :: Maybe HostName    -- ^ --to host
   -> Maybe Int         -- ^ --drain-timeout seconds (Nothing = no drain)
   -> App (Either Text ())
 runSwitchover mToHost mDrainTimeout = do
@@ -56,14 +56,14 @@ runSwitchover mToHost mDrainTimeout = do
           pure (Left err)
         Right candidateId -> do
           let oldSourceId   = ctSourceNodeId topo
-              oldSourceHost = fmap nodeHost oldSourceId
+              oldSourceHost = fmap (unHostName . nodeHost) oldSourceId
 
           appLogInfo $ "[" <> unClusterName (ccName cc) <> "] Switchover started"
 
           -- Pre-switchover hook (blocking: non-zero exit aborts)
           mHooks <- getHooksConfig
           ts <- liftIO getCurrentTimestamp
-          let preEnv = HookEnv (ccName cc) (Just (nodeHost candidateId)) oldSourceHost Nothing ts Nothing Nothing
+          let preEnv = HookEnv (ccName cc) (Just (unHostName (nodeHost candidateId))) oldSourceHost Nothing ts Nothing Nothing
           preResult <- liftIO $ runHookOrAbort mHooks hcPreSwitchover preEnv
           case preResult of
             Left err -> do
@@ -148,10 +148,10 @@ doSwitchover candidateId oldSourceId oldSourceHost topo mDrainTimeout = do
               -- Post-switchover hook (fire-and-forget)
               mHooks <- getHooksConfig
               ts <- liftIO getCurrentTimestamp
-              let postEnv = HookEnv (ccName cc) (Just (nodeHost candidateId)) oldSourceHost Nothing ts Nothing Nothing
+              let postEnv = HookEnv (ccName cc) (Just (unHostName (nodeHost candidateId))) oldSourceHost Nothing ts Nothing Nothing
               liftIO $ runHookFireForget mHooks hcPostSwitchover postEnv
 
-              appLogInfo $ "[" <> unClusterName (ccName cc) <> "] Switchover completed: new source is " <> nodeHost candidateId
+              appLogInfo $ "[" <> unClusterName (ccName cc) <> "] Switchover completed: new source is " <> unHostName (nodeHost candidateId)
               pure (Right ())
 
 waitForCatchup :: Maybe TLSConfig -> ConnectInfo -> Maybe Text -> Int -> IO Bool
@@ -182,7 +182,7 @@ reconnectToNew newSourceId ns = do
   liftIO $ do
     _ <- withNodeConn mTls ci $ \conn -> do
       _ <- try @SomeException (stopReplica conn)
-      changeReplicationSourceTo conn (nodeHost newSourceId) (nodePort newSourceId) replCreds mTls
+      changeReplicationSourceTo conn (unHostName (nodeHost newSourceId)) (nodePort newSourceId) replCreds mTls
       setReadOnly conn
       startReplica conn
     pure ()
@@ -220,7 +220,7 @@ waitThenKill mTls srcCi clusterName timeoutSecs = go timeoutSecs
 
 -- | Dry-run switchover: validate and select candidate without executing SQL
 dryRunSwitchover
-  :: Maybe Text          -- ^ --to host
+  :: Maybe HostName      -- ^ --to host
   -> App (Either Text Text)
 dryRunSwitchover mToHost = do
   tvar <- asks envDaemonState
@@ -233,4 +233,4 @@ dryRunSwitchover mToHost = do
       case selectCandidate (fcNeverPromote fc) (fmap unPositiveInt (fcMaxReplicaLagForCandidate fc)) (ctNodes topo) (fcCandidatePriority fc) mToHost of
         Left  err         -> pure (Left err)
         Right candidateId ->
-          pure (Right ("Dry run: would promote " <> nodeHost candidateId <> " to source"))
+          pure (Right ("Dry run: would promote " <> unHostName (nodeHost candidateId) <> " to source"))

--- a/src/PureMyHA/HTTP/Server.hs
+++ b/src/PureMyHA/HTTP/Server.hs
@@ -120,7 +120,7 @@ clusterLabels name = "cluster=" <> quoted (unClusterName name)
 nodeLabels :: ClusterName -> NodeState -> Text
 nodeLabels clusterName ns =
   "cluster=" <> quoted (unClusterName clusterName)
-  <> ",host=" <> quoted (nodeHost (nsNodeId ns))
+  <> ",host=" <> quoted (unHostName (nodeHost (nsNodeId ns)))
   <> ",port=" <> quoted (T.pack (show (nodePort (nsNodeId ns))))
 
 quoted :: Text -> Text

--- a/src/PureMyHA/IPC/Client.hs
+++ b/src/PureMyHA/IPC/Client.hs
@@ -57,7 +57,7 @@ printStatus False statuses = do
 printClusterStatus :: ClusterStatus -> IO ()
 printClusterStatus cs = do
   let health      = showHealth (csHealth cs)
-      source      = maybe "-" T.unpack (csSourceHost cs)
+      source      = maybe "-" (T.unpack . unHostName) (csSourceHost cs)
       nodes       = show (csNodeCount cs)
       paused      = if csPaused cs then "yes" else "no"
       blocked     = maybe "-" showTime (csRecoveryBlockedUntil cs)
@@ -86,7 +86,7 @@ printClusterTopology ctv = do
 printNode :: Bool -> NodeStateView -> IO ()
 printNode isSrc nsv = do
   let prefix = if isSrc then "[SOURCE] " else "  [REPLICA] "
-      host   = T.unpack (nsvHost nsv) <> ":" <> show (nsvPort nsv)
+      host   = T.unpack (unHostName (nsvHost nsv)) <> ":" <> show (nsvPort nsv)
       status = if nsvPaused nsv
                  then "[PAUSED]"
                  else "[" <> showHealth (nsvHealth nsv) <> "]"
@@ -113,7 +113,7 @@ printErrantGtids False infos = do
 
 printErrantGtidInfo :: ErrantGtidInfo -> IO ()
 printErrantGtidInfo eg =
-  TIO.putStrLn $ "  " <> nodeHost (egiNodeId eg) <> ":" <>
+  TIO.putStrLn $ "  " <> unHostName (nodeHost (egiNodeId eg)) <> ":" <>
     T.pack (show (nodePort (egiNodeId eg))) <> " -> " <> egiErrantGtid eg
 
 showHealth :: NodeHealth -> String

--- a/src/PureMyHA/IPC/Protocol.hs
+++ b/src/PureMyHA/IPC/Protocol.hs
@@ -15,6 +15,7 @@ import Data.Text (Text)
 import GHC.Generics (Generic)
 import PureMyHA.Types
   ( ClusterName
+  , HostName (..)
   , NodeHealth (..)
   , ClusterStatus (..)
   , ClusterTopologyView (..)
@@ -138,25 +139,25 @@ data Request
   | ReqTopology { reqCluster :: Maybe ClusterName }
   | ReqSwitchover
       { reqCluster      :: Maybe ClusterName
-      , reqToHost       :: Maybe Text
+      , reqToHost       :: Maybe HostName
       , reqDryRun       :: Bool
       , reqDrainTimeout :: Maybe Int  -- ^ seconds; Nothing = no drain
       }
   | ReqAckRecovery { reqCluster :: Maybe ClusterName }
   | ReqErrantGtid { reqCluster :: Maybe ClusterName }
   | ReqFixErrantGtid { reqCluster :: Maybe ClusterName }
-  | ReqDemote { reqCluster :: Maybe ClusterName, reqDemoteHost :: Text, reqDemoteSourceHost :: Text }
+  | ReqDemote { reqCluster :: Maybe ClusterName, reqDemoteHost :: HostName, reqDemoteSourceHost :: HostName }
   | ReqDiscovery { reqCluster :: Maybe ClusterName }
-  | ReqPauseReplica  { reqCluster :: Maybe ClusterName, reqPauseHost  :: Text }
-  | ReqResumeReplica { reqCluster :: Maybe ClusterName, reqResumeHost :: Text }
+  | ReqPauseReplica  { reqCluster :: Maybe ClusterName, reqPauseHost  :: HostName }
+  | ReqResumeReplica { reqCluster :: Maybe ClusterName, reqResumeHost :: HostName }
   | ReqPauseFailover  { reqCluster :: Maybe ClusterName }
   | ReqResumeFailover { reqCluster :: Maybe ClusterName }
   | ReqSetLogLevel    { reqLogLevel :: Text }
-  | ReqUnfence { reqCluster :: Maybe ClusterName, reqUnfenceHost :: Text }
+  | ReqUnfence { reqCluster :: Maybe ClusterName, reqUnfenceHost :: HostName }
   | ReqClone
       { reqCloneCluster   :: Maybe ClusterName
-      , reqCloneRecipient :: Text
-      , reqCloneDonor     :: Maybe Text
+      , reqCloneRecipient :: HostName
+      , reqCloneDonor     :: Maybe HostName
       }
   deriving (Show, Eq, Generic)
 

--- a/src/PureMyHA/IPC/Server.hs
+++ b/src/PureMyHA/IPC/Server.hs
@@ -137,7 +137,7 @@ handleRequest tvar clusterMap discoveryMap loggerVar req = case req of
 
   ReqDemote mCluster host srcHost ->
     runClusterOp mCluster clusterMap
-      (\env -> runApp env $ runDemote host srcHost) ("Demote completed: " <> host <> " is now a replica")
+      (\env -> runApp env $ runDemote host srcHost) ("Demote completed: " <> unHostName host <> " is now a replica")
 
   ReqDiscovery mCluster ->
     case lookupByCluster mCluster discoveryMap of
@@ -150,11 +150,11 @@ handleRequest tvar clusterMap discoveryMap loggerVar req = case req of
 
   ReqPauseReplica mCluster host ->
     runClusterOp mCluster clusterMap
-      (\env -> runApp env $ runPauseReplica host) ("Replication paused on " <> host)
+      (\env -> runApp env $ runPauseReplica host) ("Replication paused on " <> unHostName host)
 
   ReqResumeReplica mCluster host ->
     runClusterOp mCluster clusterMap
-      (\env -> runApp env $ runResumeReplica host) ("Replication resumed on " <> host)
+      (\env -> runApp env $ runResumeReplica host) ("Replication resumed on " <> unHostName host)
 
   ReqPauseFailover mCluster ->
     withClusterEnv mCluster clusterMap $ \env -> do
@@ -179,14 +179,14 @@ handleRequest tvar clusterMap discoveryMap loggerVar req = case req of
       result <- runApp env (doUnfence host)
       pure $ RespOperation $ case result of
         Left err -> OperationFailure err
-        Right () -> OperationSuccess ("Node unfenced: " <> host)
+        Right () -> OperationSuccess ("Node unfenced: " <> unHostName host)
 
   ReqClone mCluster recipient mDonor ->
     withClusterEnv mCluster clusterMap $ \env -> do
       result <- runApp env (runClone recipient mDonor)
       pure $ RespOperation $ case result of
         Left err -> OperationFailure err
-        Right () -> OperationSuccess ("Clone completed: " <> recipient <> " re-seeded successfully")
+        Right () -> OperationSuccess ("Clone completed: " <> unHostName recipient <> " re-seeded successfully")
 
 filterClusters :: Maybe ClusterName -> Map ClusterName ClusterTopology -> [ClusterTopology]
 filterClusters Nothing  m = Map.elems m

--- a/src/PureMyHA/Monitor/Detector.hs
+++ b/src/PureMyHA/Monitor/Detector.hs
@@ -110,5 +110,5 @@ identifySource nodes =
 getSourceId :: NodeState -> Maybe NodeId
 getSourceId ns = case nsProbeResult ns of
   ProbeSuccess{prReplicaStatus = Just rs}
-    | rsSourceHost rs /= "" -> Just (NodeId (rsSourceHost rs) (rsSourcePort rs))
+    | unHostName (rsSourceHost rs) /= "" -> Just (NodeId (rsSourceHost rs) (rsSourcePort rs))
   _ -> Nothing

--- a/src/PureMyHA/Monitor/Worker.hs
+++ b/src/PureMyHA/Monitor/Worker.hs
@@ -44,7 +44,7 @@ type WorkerRegistry = TVar (Map.Map NodeId (Async ()))
 startMonitorWorkers :: App (WorkerRegistry, [Async ()])
 startMonitorWorkers = do
   env <- ask
-  let nodes = map (\nc -> NodeId (ncHost nc) (unPort (ncPort nc))) (NE.toList (ccNodes (envCluster env)))
+  let nodes = map (\nc -> NodeId (HostName (ncHost nc)) (unPort (ncPort nc))) (NE.toList (ccNodes (envCluster env)))
   liftIO $ do
     reg <- newTVarIO Map.empty
     asyncs <- forM nodes $ \nid -> do
@@ -135,7 +135,7 @@ detectAndPruneStaleWorkers :: WorkerRegistry -> ClusterConfig -> Set.Set NodeId 
 detectAndPruneStaleWorkers reg cc discovered = do
   knownNodes <- Map.keysSet <$> readTVarIO reg
   let configuredNodes = Set.fromList
-        (map (\nc -> NodeId (ncHost nc) (unPort (ncPort nc))) (NE.toList (ccNodes cc)))
+        (map (\nc -> NodeId (HostName (ncHost nc)) (unPort (ncPort nc))) (NE.toList (ccNodes cc)))
       staleNodes = Set.toList (computeStaleNodes knownNodes discovered configuredNodes)
   pruneStaleWorkers reg staleNodes
   pure staleNodes
@@ -167,7 +167,7 @@ buildLagHookEnv clusterName nid ts =
            , hookFailureType = Nothing
            , hookTimestamp   = ts
            , hookLagSeconds  = Nothing
-           , hookNode        = Just (nodeHost nid)
+           , hookNode        = Just (unHostName (nodeHost nid))
            }
 
 -- | Perform a single monitoring cycle for a node
@@ -187,7 +187,7 @@ monitorNode nid = do
       backoff   = mcConnectRetryBackoff mc
       cap       = unPositiveDuration (mcConnectTimeout mc)
       logRetry msg = readTVarIO (envLogger env) >>= \l ->
-        logDebug l ("[" <> unClusterName (ccName cc) <> "] Node " <> nodeHost nid <> ": " <> msg)
+        logDebug l ("[" <> unClusterName (ccName cc) <> "] Node " <> unHostName (nodeHost nid) <> ": " <> msg)
   -- Read old state before connecting for prevFailures count
   mOldNs <- liftIO $ do
     mTopo <- getClusterTopology tvar (ccName cc)
@@ -244,7 +244,7 @@ monitorNode nid = do
   liftIO $ when (newFailures > 0 && newFailures < threshold) $ do
     logger <- readTVarIO (envLogger env)
     case result of
-      Left err -> logInfo logger $ "[" <> unClusterName (ccName cc) <> "] Node " <> nodeHost nid
+      Left err -> logInfo logger $ "[" <> unClusterName (ccName cc) <> "] Node " <> unHostName (nodeHost nid)
                     <> " probe failed (" <> T.pack (show newFailures) <> "/"
                     <> T.pack (show threshold) <> "): " <> err
       Right _  -> pure ()
@@ -286,7 +286,7 @@ logHealthChange nid mOld new = do
         liftIO $ logWarn logger $ "[" <> unClusterName clusterName <> "] Node " <> host <> " initial connect failed: " <> err
       _ -> pure ()
   where
-    host = nodeHost nid
+    host = unHostName (nodeHost nid)
 
 enrichErrantGtids :: NodeState -> App NodeState
 enrichErrantGtids ns = do

--- a/src/PureMyHA/MySQL/Connection.hs
+++ b/src/PureMyHA/MySQL/Connection.hs
@@ -15,12 +15,12 @@ import Data.Time (NominalDiffTime)
 import Database.MySQL.Base (ConnectInfo (..), defaultConnectInfo, close, MySQLConn)
 import PureMyHA.Config (DbCredentials (..), TLSConfig)
 import PureMyHA.MySQL.Auth (connectWithAuth)
-import PureMyHA.Types (NodeId (..))
+import PureMyHA.Types (NodeId (..), HostName (..))
 
 -- | Build ConnectInfo from NodeId and credentials
 makeConnectInfo :: NodeId -> DbCredentials -> ConnectInfo
 makeConnectInfo NodeId{..} DbCredentials{..} = defaultConnectInfo
-  { ciHost     = T.unpack nodeHost
+  { ciHost     = T.unpack (unHostName nodeHost)
   , ciPort     = fromIntegral nodePort
   , ciUser     = TE.encodeUtf8 dbUser
   , ciPassword = TE.encodeUtf8 dbPassword

--- a/src/PureMyHA/MySQL/Query.hs
+++ b/src/PureMyHA/MySQL/Query.hs
@@ -62,7 +62,7 @@ showReplicaStatus conn = do
 parseReplicaStatus :: [(Text, MySQLValue)] -> Maybe ReplicaStatus
 parseReplicaStatus kvs =
   Just ReplicaStatus
-    { rsSourceHost          = look "Source_Host"
+    { rsSourceHost          = HostName (look "Source_Host")
     , rsSourcePort          = intVal (raw "Source_Port")
     , rsReplicaIORunning    = parseIORunning (look "Replica_IO_Running")
     , rsReplicaSQLRunning   = if look "Replica_SQL_Running" == "Yes" then SQLRunning else SQLStopped
@@ -120,7 +120,7 @@ showReplicas conn defaultPort = do
   let allHosts = srHosts ++ plHosts
   nodes <- mapM (\h -> do
     ip <- resolveHostToIP h
-    pure (NodeId ip defaultPort)) allHosts
+    pure (NodeId (HostName ip) defaultPort)) allHosts
   let deduped = nubBy (\a b -> nodeHost a == nodeHost b && nodePort a == nodePort b) nodes
   pure (deduped, expectedCount, allHosts)
 

--- a/src/PureMyHA/Topology/Discovery.hs
+++ b/src/PureMyHA/Topology/Discovery.hs
@@ -33,7 +33,7 @@ discoverTopology = do
   creds  <- getMonCredentials
   mTls   <- getTLSConfig
   logger <- asks envLogger >>= liftIO . readTVarIO
-  let seedNodes = map (\nc -> NodeId (ncHost nc) (unPort (ncPort nc))) (NE.toList (ccNodes cc))
+  let seedNodes = map (\nc -> NodeId (HostName (ncHost nc)) (unPort (ncPort nc))) (NE.toList (ccNodes cc))
   nodeStates <- liftIO $ discoverAll mTls creds (Set.fromList seedNodes) Set.empty Map.empty logger
   pure (buildClusterTopology (ccName cc) nodeStates)
 
@@ -73,7 +73,7 @@ discoverAll mTls creds queue visited acc logger
       logInfo logger $ "[discovery] Queue empty, discovery complete (" <> T.pack (show (Map.size acc)) <> " node(s))"
       pure acc
   | otherwise = do
-      logInfo logger $ "[discovery] Queue: " <> T.pack (show (map (\n -> nodeHost n <> ":" <> T.pack (show (nodePort n))) (Set.toList queue)))
+      logInfo logger $ "[discovery] Queue: " <> T.pack (show (map (\n -> unHostName (nodeHost n) <> ":" <> T.pack (show (nodePort n))) (Set.toList queue)))
       let (nid, rest) = Set.deleteFindMin queue
       if Set.member nid visited
         then discoverAll mTls creds rest visited acc logger
@@ -89,7 +89,7 @@ discoverAll mTls creds queue visited acc logger
 -- via SHOW PROCESSLIST (only populated when the node is a source).
 probeNode :: Maybe TLSConfig -> DbCredentials -> NodeId -> Logger -> IO (NodeState, [NodeId])
 probeNode mTls creds nid logger = do
-  logInfo logger $ "[discovery] Probing " <> nodeHost nid <> ":" <> T.pack (show (nodePort nid))
+  logInfo logger $ "[discovery] Probing " <> unHostName (nodeHost nid) <> ":" <> T.pack (show (nodePort nid))
   now <- getCurrentTime
   let ci = makeConnectInfo nid creds
   result <- withNodeConn mTls ci $ \conn -> do
@@ -97,25 +97,25 @@ probeNode mTls creds nid logger = do
     gtidExec       <- getGtidExecuted conn
     replicaIds <- case mReplicaStatus of
       Just rs -> do
-        logInfo logger $ "[discovery] " <> nodeHost nid <> " is a replica of " <> rsSourceHost rs <> ":" <> T.pack (show (rsSourcePort rs))
+        logInfo logger $ "[discovery] " <> unHostName (nodeHost nid) <> " is a replica of " <> unHostName (rsSourceHost rs) <> ":" <> T.pack (show (rsSourcePort rs))
         pure []
       Nothing -> do
         -- source node: discover downstream replicas via SHOW REPLICAS + SHOW PROCESSLIST
         (discovered, expected, rawHosts) <- showReplicas conn (nodePort nid)
-        logInfo logger $ "[" <> nodeHost nid <> "] Raw hosts from SHOW REPLICAS/PROCESSLIST: "
+        logInfo logger $ "[" <> unHostName (nodeHost nid) <> "] Raw hosts from SHOW REPLICAS/PROCESSLIST: "
           <> T.pack (show rawHosts)
-        logInfo logger $ "[" <> nodeHost nid <> "] Resolved replica NodeIds: "
-          <> T.pack (show (map (\n -> nodeHost n <> ":" <> T.pack (show (nodePort n))) discovered))
+        logInfo logger $ "[" <> unHostName (nodeHost nid) <> "] Resolved replica NodeIds: "
+          <> T.pack (show (map (\n -> unHostName (nodeHost n) <> ":" <> T.pack (show (nodePort n))) discovered))
           <> " (SHOW REPLICAS reports " <> T.pack (show expected) <> " replica(s))"
         when (length discovered < expected) $
-          logInfo logger $ "[" <> nodeHost nid <> "] WARNING: found "
+          logInfo logger $ "[" <> unHostName (nodeHost nid) <> "] WARNING: found "
             <> T.pack (show (length discovered)) <> " of " <> T.pack (show expected)
             <> " expected replica(s). Ensure the monitoring user has PROCESS privilege "
             <> "or set report_host on each replica."
         pure discovered
     pure (mReplicaStatus, gtidExec, replicaIds)
   case result of
-    Left err -> logInfo logger $ "[discovery] " <> nodeHost nid <> " probe failed: " <> err
+    Left err -> logInfo logger $ "[discovery] " <> unHostName (nodeHost nid) <> " probe failed: " <> err
     Right _  -> pure ()
   let (probeResult, discoveredReplicas) = case result of
         Left err                     -> (Left err, [])
@@ -160,7 +160,7 @@ nextDiscoveryTargets ns visited rest =
   case nsProbeResult ns of
     ProbeSuccess{prReplicaStatus = Just rs} ->
       let srcId = NodeId (rsSourceHost rs) (rsSourcePort rs)
-      in if Set.notMember srcId visited && rsSourceHost rs /= ""
+      in if Set.notMember srcId visited && unHostName (rsSourceHost rs) /= ""
            then Set.insert srcId rest
            else rest
     _ -> rest

--- a/src/PureMyHA/Types.hs
+++ b/src/PureMyHA/Types.hs
@@ -2,6 +2,7 @@
 module PureMyHA.Types
   ( NodeId (..)
   , ClusterName (..)
+  , HostName (..)
   , IORunning (..)
   , SQLThreadState (..)
   , ReplicaStatus (..)
@@ -42,8 +43,20 @@ instance FromJSON ClusterName where
 instance ToJSON ClusterName where
   toJSON (ClusterName t) = toJSON t
 
+newtype HostName = HostName { unHostName :: Text }
+  deriving (Eq, Ord, Show, Generic)
+
+instance IsString HostName where
+  fromString = HostName . T.pack
+
+instance FromJSON HostName where
+  parseJSON v = HostName <$> parseJSON v
+
+instance ToJSON HostName where
+  toJSON (HostName t) = toJSON t
+
 data NodeId = NodeId
-  { nodeHost :: Text
+  { nodeHost :: HostName
   , nodePort :: Int
   } deriving (Eq, Ord, Show, Generic)
 
@@ -54,7 +67,7 @@ data SQLThreadState = SQLRunning | SQLStopped
   deriving (Eq, Show, Generic)
 
 data ReplicaStatus = ReplicaStatus
-  { rsSourceHost          :: Text
+  { rsSourceHost          :: HostName
   , rsSourcePort          :: Int
   , rsReplicaIORunning    :: IORunning
   , rsReplicaSQLRunning   :: SQLThreadState
@@ -81,7 +94,7 @@ data NodeRole = Source | Replica
 isSource :: NodeState -> Bool
 isSource ns = nsRole ns == Source
 
-findNodeByHost :: Text -> Map NodeId NodeState -> Maybe NodeState
+findNodeByHost :: HostName -> Map NodeId NodeState -> Maybe NodeState
 findNodeByHost h nodes =
   case filter (\ns -> nodeHost (nsNodeId ns) == h) (Map.elems nodes) of
     (x:_) -> Just x
@@ -137,7 +150,7 @@ data DaemonState = DaemonState
 data ClusterStatus = ClusterStatus
   { csClusterName :: ClusterName
   , csHealth      :: NodeHealth
-  , csSourceHost  :: Maybe Text
+  , csSourceHost  :: Maybe HostName
   , csNodeCount   :: Int
   , csRecoveryBlockedUntil :: Maybe UTCTime
   , csPaused    :: Bool
@@ -149,7 +162,7 @@ data ClusterTopologyView = ClusterTopologyView
   } deriving (Show, Eq, Generic)
 
 data NodeStateView = NodeStateView
-  { nsvHost         :: Text
+  { nsvHost         :: HostName
   , nsvPort         :: Int
   , nsvIsSource     :: Bool
   , nsvHealth       :: NodeHealth

--- a/test/Fixtures.hs
+++ b/test/Fixtures.hs
@@ -28,11 +28,11 @@ fixedTime :: UTCTime
 fixedTime = UTCTime (fromGregorian 2024 1 1) 0
 
 mkNodeId :: Text -> Int -> NodeId
-mkNodeId h p = NodeId h p
+mkNodeId h p = NodeId (HostName h) p
 
 mkReplicaStatus :: Text -> Int -> IORunning -> Text -> ReplicaStatus
 mkReplicaStatus srcHost srcPort ioRunning execGtid = ReplicaStatus
-  { rsSourceHost          = srcHost
+  { rsSourceHost          = HostName srcHost
   , rsSourcePort          = srcPort
   , rsReplicaIORunning    = ioRunning
   , rsReplicaSQLRunning   = SQLRunning
@@ -110,7 +110,7 @@ unreachableNode nid = NodeState
   }
 
 unreachableReplica :: NodeState
-unreachableReplica = unreachableNode (NodeId "db5" 3306)
+unreachableReplica = unreachableNode (NodeId (HostName "db5") 3306)
 
 -- | Cluster where source is unreachable, replicas show IO=No
 clusterWithDeadSource :: Map NodeId NodeState


### PR DESCRIPTION
## Summary
- Introduce `newtype HostName` (with `IsString`, `FromJSON`, `ToJSON`) following the established `ClusterName` pattern
- Replace bare `Text` with `HostName` in domain types: `NodeId.nodeHost`, `ReplicaStatus.rsSourceHost`, `ClusterStatus.csSourceHost`, `NodeStateView.nsvHost`
- Update 18 files: function signatures (`runDemote`, `runPauseReplica`, `doUnfence`, `selectCandidate`, `runSwitchover`, `runClone`, etc.), IPC protocol fields, CLI parsers, and test fixtures

Config types (`NodeConfig.ncHost`, `CandidatePriority.cpHost`, `FailoverConfig.fcNeverPromote`) and `HookEnv` fields remain `Text`; conversion happens at well-defined boundary sites.

Closes #112

## Test plan
- [x] `cabal build all` compiles without errors
- [x] `cabal test` passes all 372 tests
- [x] JSON wire format unchanged (verified by existing IPC round-trip tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)