### PR TITLE
ci: add codecov.yml with coverage thresholds

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 70%
+    patch:
+      default:
+        target: 60%


### PR DESCRIPTION
## Summary
- Add `codecov.yml` to configure coverage thresholds
- Patch coverage target: 60%
- Project coverage target: 70%

## Test plan
- [ ] Verify Codecov picks up the config on next PR with coverage upload

🤖 Generated with [Claude Code](https://claude.com/claude-code)