### PR TITLE
docs: improve wording in README philosophy section

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,17 +6,17 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Haskell](https://img.shields.io/badge/language-Haskell-5D4F85)](https://www.haskell.org/)
 
-A simple, pure-Haskell High Availability tool for MySQL 8.4 replication topologies.
+A simple, pure-Haskell High Availability management tool for MySQL 8.4 replication topologies.
 
-Inspired by the design philosophy of Orchestrator, PureMyHA provides topology discovery, failure detection, and automatic failover — with no C library dependencies.
+Inspired by the design of Orchestrator, PureMyHA provides topology discovery, failure detection, and automatic failover — with no C library dependencies.
 
 ## Philosophy
 
 - **Pure Haskell, no C dependencies** — PureMyHA is built entirely on `mysql-haskell`, a pure-Haskell MySQL client. No libmysqlclient, no CGo, no FFI — just a single statically-linked binary that runs anywhere.
-- **Correctness before convenience** — Every failover decision is GTID-aware: errant GTIDs are detected and repaired, relay log apply is awaited before promotion, and split-brain scenarios are identified before acting. A failover that corrupts data is worse than no failover.
+- **Correctness before convenience** — Every failover decision is GTID-aware: errant GTIDs are detected and repaired, relay log application is awaited before promotion, and split-brain scenarios are identified before acting. A failover that corrupts data is worse than no failover.
 - **Simple by deliberate omission** — PureMyHA targets MySQL 8.4+ exclusively and does not support legacy syntax, older authentication plugins, or non-GTID topologies. Saying no to compatibility layers keeps the code small, auditable, and correct.
 - **Do one thing well** — PureMyHA is a focused HA tool, not a topology manager, query router, or schema migration framework. It detects failure, promotes a replica, and gets out of the way.
-- **Delegate what you do not own** — PureMyHA does not implement leader election for itself. Its own high availability is delegated entirely to Pacemaker, which is already purpose-built for that problem.
+- **Delegate what you do not own** — PureMyHA does not implement its own leader election. Its own high availability is delegated entirely to Pacemaker, which is already purpose-built for that problem.
 - **Stateless by design** — The daemon holds no durable state. All topology knowledge is derived from MySQL on startup and continuously refreshed at runtime, making recovery from a daemon crash trivially safe.
 - **Transparent operation** — Dry-run mode, config hot-reload, and pause/resume controls give operators full visibility and control without requiring a daemon restart.
 


### PR DESCRIPTION
## Summary

- Add "management" to the opening description for clarity
- Remove "philosophy" from the Orchestrator reference for conciseness
- Fix `relay log apply` → `relay log application` (correct noun form)
- Fix `leader election for itself` → `its own leader election` (more natural phrasing)

## Test plan

- [ ] Verify the rendered README looks correct on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)