### PR TITLE
docs: add Examples section pointing to e2e tests and helpers

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -104,3 +104,12 @@ kill -HUP $(pidof puremyhad)      # direct signal (non-systemd)
 # Graceful stop
 kill -TERM $(pidof puremyhad)
 ```
+
+## Examples
+
+The end-to-end test scripts under `e2e/tests/` serve as worked usage examples for
+every major scenario (failover, switchover, clone, errant-GTID handling, etc.).
+
+To understand which CLI commands are available and how they map to helper functions
+used in tests, see `e2e/lib/helpers.sh` — the CLI wrapper section defines one
+function per `puremyha` subcommand.


### PR DESCRIPTION
## Summary
- Add an `## Examples` section at the bottom of `docs/cli.md`
- Points readers to `e2e/tests/` for worked usage examples covering major scenarios
- Points readers to `e2e/lib/helpers.sh` to discover available CLI commands via the CLI wrapper section

## Test plan
- [ ] Read `docs/cli.md` and confirm the new section renders correctly in Markdown
- [ ] Verify links/paths `e2e/tests/` and `e2e/lib/helpers.sh` exist in the repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)