### PR TITLE
feat: refine NodeHealth with structured failure constructors (ISSUE #126)

### DIFF
--- a/docs/failover.md
+++ b/docs/failover.md
@@ -21,7 +21,13 @@ When `DeadSource` is detected, the daemon automatically:
 | `UnreachableSource` | Source unreachable from PureMyHA, but replicas can still reach it (possible network partition) |
 | `DeadSourceAndAllReplicas` | Source and all replicas are unresponsive |
 | `SplitBrainSuspected` | Multiple nodes appear to be acting as source |
-| `NeedsAttention` | Other anomaly (errant GTIDs, stale replication, etc.) |
+| `NodeUnreachable` | Probe connect failure (node is not responding) |
+| `ReplicaIOStopped` | Replica IO thread stopped (with or without error) |
+| `ReplicaIOConnecting` | Replica IO thread in Connecting state (transient) |
+| `ReplicaSQLStopped` | Replica SQL thread stopped |
+| `ErrantGtidDetected` | Errant GTIDs detected on the node |
+| `NoSourceDetected` | No node has the source role in the cluster |
+| `NeedsAttention` | Other unclassified anomaly (escape hatch) |
 
 ## Anti-Flap Protection
 

--- a/e2e/tests/21-probe-timeout-failover.sh
+++ b/e2e/tests/21-probe-timeout-failover.sh
@@ -34,8 +34,8 @@ docker pause e2e-source
 #   probe 1 timeout:  6s  → failCount=1 (suppressed below threshold=3)
 #   probe 2 timeout: +7s  → failCount=2 (still suppressed)
 #   replica IO detects no heartbeat: ~10s (replica_net_timeout=10)
-#   probe 3 timeout: +7s  → failCount=3 → NeedsAttention fires
-#   detectClusterHealth: source=NeedsAttention + replicas IO=No → DeadSource
+#   probe 3 timeout: +7s  → failCount=3 → NodeUnreachable fires
+#   detectClusterHealth: source=NodeUnreachable + replicas IO=No → DeadSource
 #   auto-failover executes (wait_for_relay_log_apply_timeout=10s) → ~10s
 #   total: ~40s; wait up to 90s for safety
 #

--- a/e2e/tests/23-structured-health-states.sh
+++ b/e2e/tests/23-structured-health-states.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# Test: Structured NodeHealth states via topology endpoint
+# Verifies that the new structured health constructors (ReplicaIOStopped,
+# ReplicaSQLStopped, ErrantGtidDetected) are correctly exposed through
+# the CLI topology and HTTP topology endpoints.
+set -euo pipefail
+source "$(dirname "$0")/../lib/helpers.sh"
+echo "=== Test 23: Structured health states ==="
+
+wait_for_health "Healthy" 60
+
+# Pause auto-failover to prevent failover during health state manipulation
+cli_pause_failover >/dev/null 2>&1
+
+# ---------------------------------------------------------------------------
+# Step 1: ReplicaIOStopped — stop replica IO thread on mysql-replica1
+# ---------------------------------------------------------------------------
+echo "  Stopping IO thread on mysql-replica1..."
+mysql_exec mysql-replica1 "STOP REPLICA IO_THREAD;"
+
+echo "  Waiting for mysql-replica1 health to show ReplicaIOStopped..."
+replica1_health=""
+for i in $(seq 1 30); do
+  topo_json=$(cli_topology 2>/dev/null || echo "[]")
+  replica1_health=$(echo "$topo_json" | jq -r '.[0].nodes[] | select(.host=="mysql-replica1") | .health' 2>/dev/null || echo "")
+  if echo "$replica1_health" | grep -q "ReplicaIOStopped"; then
+    echo "  mysql-replica1 health is ReplicaIOStopped (${i}s)"
+    break
+  fi
+  sleep 1
+done
+assert_contains "mysql-replica1 shows ReplicaIOStopped" "ReplicaIOStopped" "$replica1_health"
+
+# Verify via HTTP topology endpoint as well
+http_topo=$(http_get_body "/cluster/e2e/topology")
+http_replica1_health=$(echo "$http_topo" | jq -r '.nodes[] | select(.host=="mysql-replica1") | .health' 2>/dev/null || echo "")
+assert_contains "HTTP topology shows ReplicaIOStopped" "ReplicaIOStopped" "$http_replica1_health"
+
+# Restore IO thread
+echo "  Restarting IO thread on mysql-replica1..."
+mysql_exec mysql-replica1 "START REPLICA IO_THREAD;"
+
+# Wait for recovery
+echo "  Waiting for mysql-replica1 to recover..."
+for i in $(seq 1 30); do
+  topo_json=$(cli_topology 2>/dev/null || echo "[]")
+  replica1_health=$(echo "$topo_json" | jq -r '.[0].nodes[] | select(.host=="mysql-replica1") | .health' 2>/dev/null || echo "")
+  if [ "$replica1_health" = "Healthy" ]; then
+    echo "  mysql-replica1 recovered to Healthy (${i}s)"
+    break
+  fi
+  sleep 1
+done
+assert_eq "mysql-replica1 recovers to Healthy after IO restart" "Healthy" "$replica1_health"
+
+# ---------------------------------------------------------------------------
+# Step 2: ReplicaSQLStopped — stop replica SQL thread on mysql-replica2
+# ---------------------------------------------------------------------------
+echo "  Stopping SQL thread on mysql-replica2..."
+mysql_exec mysql-replica2 "STOP REPLICA SQL_THREAD;"
+
+echo "  Waiting for mysql-replica2 health to show ReplicaSQLStopped..."
+replica2_health=""
+for i in $(seq 1 30); do
+  topo_json=$(cli_topology 2>/dev/null || echo "[]")
+  replica2_health=$(echo "$topo_json" | jq -r '.[0].nodes[] | select(.host=="mysql-replica2") | .health' 2>/dev/null || echo "")
+  if echo "$replica2_health" | grep -q "ReplicaSQLStopped"; then
+    echo "  mysql-replica2 health is ReplicaSQLStopped (${i}s)"
+    break
+  fi
+  sleep 1
+done
+assert_contains "mysql-replica2 shows ReplicaSQLStopped" "ReplicaSQLStopped" "$replica2_health"
+
+# Restore SQL thread
+echo "  Restarting SQL thread on mysql-replica2..."
+mysql_exec mysql-replica2 "START REPLICA SQL_THREAD;"
+
+echo "  Waiting for mysql-replica2 to recover..."
+for i in $(seq 1 30); do
+  topo_json=$(cli_topology 2>/dev/null || echo "[]")
+  replica2_health=$(echo "$topo_json" | jq -r '.[0].nodes[] | select(.host=="mysql-replica2") | .health' 2>/dev/null || echo "")
+  if [ "$replica2_health" = "Healthy" ]; then
+    echo "  mysql-replica2 recovered to Healthy (${i}s)"
+    break
+  fi
+  sleep 1
+done
+assert_eq "mysql-replica2 recovers to Healthy after SQL restart" "Healthy" "$replica2_health"
+
+# ---------------------------------------------------------------------------
+# Step 3: ErrantGtidDetected — inject errant GTID on mysql-replica1
+# ---------------------------------------------------------------------------
+echo "  Injecting errant GTID on mysql-replica1..."
+mysql_exec mysql-replica1 "
+  SET GLOBAL read_only = OFF;
+  SET GTID_NEXT = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb:1';
+  BEGIN; COMMIT;
+  SET GTID_NEXT = 'AUTOMATIC';
+  SET GLOBAL read_only = ON;
+"
+
+echo "  Waiting for mysql-replica1 health to show ErrantGtidDetected..."
+replica1_health=""
+for i in $(seq 1 30); do
+  topo_json=$(cli_topology 2>/dev/null || echo "[]")
+  replica1_health=$(echo "$topo_json" | jq -r '.[0].nodes[] | select(.host=="mysql-replica1") | .health' 2>/dev/null || echo "")
+  if echo "$replica1_health" | grep -q "ErrantGtidDetected"; then
+    echo "  mysql-replica1 health is ErrantGtidDetected (${i}s)"
+    break
+  fi
+  sleep 1
+done
+assert_contains "mysql-replica1 shows ErrantGtidDetected" "ErrantGtidDetected" "$replica1_health"
+
+# Fix errant GTIDs so cleanup succeeds
+echo "  Fixing errant GTIDs..."
+cli_fix_errant_gtid >/dev/null 2>&1 || true
+
+echo "  Waiting for errant GTIDs to clear..."
+for i in $(seq 1 30); do
+  topo_json=$(cli_topology 2>/dev/null || echo "[]")
+  replica1_health=$(echo "$topo_json" | jq -r '.[0].nodes[] | select(.host=="mysql-replica1") | .health' 2>/dev/null || echo "")
+  if [ "$replica1_health" = "Healthy" ]; then
+    echo "  mysql-replica1 recovered to Healthy (${i}s)"
+    break
+  fi
+  sleep 1
+done
+assert_eq "mysql-replica1 recovers after errant GTID fix" "Healthy" "$replica1_health"
+
+# Resume failover for cleanup
+cli_resume_failover >/dev/null 2>&1
+
+# Verify overall cluster health
+wait_for_health "Healthy" 30
+
+test_summary
+echo "=== Test 23 PASSED ==="

--- a/src/PureMyHA/IPC/Client.hs
+++ b/src/PureMyHA/IPC/Client.hs
@@ -122,6 +122,12 @@ showHealth DeadSource               = "DeadSource"
 showHealth UnreachableSource        = "UnreachableSource"
 showHealth DeadSourceAndAllReplicas = "DeadSourceAndAllReplicas"
 showHealth SplitBrainSuspected      = "SplitBrainSuspected"
+showHealth (NodeUnreachable msg)    = "NodeUnreachable: " <> T.unpack msg
+showHealth (ReplicaIOStopped msg)   = "ReplicaIOStopped" <> if T.null msg then "" else ": " <> T.unpack msg
+showHealth ReplicaIOConnecting      = "ReplicaIOConnecting"
+showHealth (ReplicaSQLStopped msg)  = "ReplicaSQLStopped: " <> T.unpack msg
+showHealth (ErrantGtidDetected g)   = "ErrantGtidDetected: " <> T.unpack g
+showHealth NoSourceDetected         = "NoSourceDetected"
 showHealth (NeedsAttention msg)     = "NeedsAttention: " <> T.unpack msg
 showHealth (Lagging n)              = "Lagging: " <> show n <> "s"
 

--- a/src/PureMyHA/IPC/Protocol.hs
+++ b/src/PureMyHA/IPC/Protocol.hs
@@ -42,6 +42,12 @@ instance ToJSON NodeHealth where
   toJSON UnreachableSource          = String "UnreachableSource"
   toJSON DeadSourceAndAllReplicas   = String "DeadSourceAndAllReplicas"
   toJSON SplitBrainSuspected        = String "SplitBrainSuspected"
+  toJSON (NodeUnreachable msg)      = object ["NodeUnreachable" .= msg]
+  toJSON (ReplicaIOStopped msg)     = object ["ReplicaIOStopped" .= msg]
+  toJSON ReplicaIOConnecting        = String "ReplicaIOConnecting"
+  toJSON (ReplicaSQLStopped msg)    = object ["ReplicaSQLStopped" .= msg]
+  toJSON (ErrantGtidDetected g)     = object ["ErrantGtidDetected" .= g]
+  toJSON NoSourceDetected           = String "NoSourceDetected"
   toJSON (NeedsAttention msg)       = object ["NeedsAttention" .= msg]
   toJSON (Lagging s)                = object ["Lagging" .= s]
 
@@ -51,7 +57,13 @@ instance FromJSON NodeHealth where
   parseJSON (String "UnreachableSource")        = pure UnreachableSource
   parseJSON (String "DeadSourceAndAllReplicas") = pure DeadSourceAndAllReplicas
   parseJSON (String "SplitBrainSuspected")      = pure SplitBrainSuspected
+  parseJSON (String "ReplicaIOConnecting")      = pure ReplicaIOConnecting
+  parseJSON (String "NoSourceDetected")         = pure NoSourceDetected
   parseJSON (Object o)                          = (Lagging <$> o .: "Lagging")
+                                              <|> (NodeUnreachable <$> o .: "NodeUnreachable")
+                                              <|> (ReplicaIOStopped <$> o .: "ReplicaIOStopped")
+                                              <|> (ReplicaSQLStopped <$> o .: "ReplicaSQLStopped")
+                                              <|> (ErrantGtidDetected <$> o .: "ErrantGtidDetected")
                                               <|> (NeedsAttention <$> o .: "NeedsAttention")
   parseJSON _                                   = fail "Invalid NodeHealth"
 

--- a/src/PureMyHA/Monitor/Detector.hs
+++ b/src/PureMyHA/Monitor/Detector.hs
@@ -29,7 +29,7 @@ detectNoSource :: [NodeState] -> [NodeState] -> NodeHealth
 detectNoSource nodeList reachableNodes
   | null reachableNodes = DeadSourceAndAllReplicas
   | null nodeList       = NeedsAttention "No nodes configured"
-  | otherwise           = NeedsAttention "No source node detected"
+  | otherwise           = NoSourceDetected
 
 detectSingleSource :: [NodeState] -> [NodeState] -> NodeState -> NodeHealth
 detectSingleSource nodeList reachableNodes src
@@ -68,23 +68,23 @@ hasIoConnecting = any $ \ns -> case nsProbeResult ns of
 -- | Detect health for a single node
 detectNodeHealth :: Maybe Int -> NodeState -> NodeHealth
 detectNodeHealth mLagThreshold ns = case nsProbeResult ns of
-  ProbeFailure{prConnectError = e} -> NeedsAttention e
+  ProbeFailure{prConnectError = e} -> NodeUnreachable e
   ProbeSuccess{prReplicaStatus = mrs}
     | not (T.null (nsErrantGtids ns)) ->
-        NeedsAttention ("Errant GTIDs: " <> nsErrantGtids ns)
+        ErrantGtidDetected (nsErrantGtids ns)
     | Just rs <- mrs -> detectReplicaHealth mLagThreshold rs
     | otherwise      -> Healthy  -- source or standalone
 
 detectReplicaHealth :: Maybe Int -> ReplicaStatus -> NodeHealth
 detectReplicaHealth mLagThreshold rs
   | rsReplicaIORunning rs == IONo && not (T.null (rsLastIOError rs)) =
-      NeedsAttention ("IO error: " <> rsLastIOError rs)
+      ReplicaIOStopped (rsLastIOError rs)
   | rsReplicaIORunning rs == IONo =
-      NeedsAttention "Replica IO not running"
+      ReplicaIOStopped ""
   | rsReplicaIORunning rs == IOConnecting =
-      NeedsAttention "Replica IO thread not connected (Connecting)"
+      ReplicaIOConnecting
   | rsReplicaSQLRunning rs == SQLStopped =
-      NeedsAttention ("SQL error: " <> rsLastSQLError rs)
+      ReplicaSQLStopped (rsLastSQLError rs)
   | Just lag <- rsSecondsBehindSource rs
   , Just threshold <- mLagThreshold
   , lag >= threshold =

--- a/src/PureMyHA/Monitor/Worker.hs
+++ b/src/PureMyHA/Monitor/Worker.hs
@@ -186,7 +186,7 @@ probeTimeoutMicros :: NominalDiffTime -> Int -> Int
 probeTimeoutMicros cap retries =
   round (realToFrac cap * fromIntegral (2 * retries + 1) * 1_000_000 :: Double)
 
--- | Suppress NeedsAttention health state when consecutive failure count is below
+-- | Suppress unhealthy health state when consecutive failure count is below
 -- the configured threshold. Falls back to previous health (or Healthy if no prior state).
 suppressBelowThreshold :: Int -> Int -> Maybe NodeState -> NodeState -> NodeState
 suppressBelowThreshold threshold failCount mOldNs ns
@@ -297,7 +297,7 @@ monitorNode nid = do
           NodeState
             { nsNodeId              = nid
             , nsRole                = maybe Replica nsRole mOldNs  -- preserve existing role on error
-            , nsHealth              = NeedsAttention err
+            , nsHealth              = NodeUnreachable err
             , nsProbeResult         = ProbeFailure err
             , nsErrantGtids         = ""
             , nsPaused              = False    -- actual value read atomically at write time
@@ -319,7 +319,7 @@ monitorNode nid = do
   ns' <- enrichErrantGtids ns
   let lagThreshold = Just (round (realToFrac (mcReplicationLagCritical mc) :: Double) :: Int)
       ns''  = ns' { nsHealth = detectNodeHealth lagThreshold ns' }
-  -- Apply consecutive failure threshold: suppress NeedsAttention until N consecutive failures
+  -- Apply consecutive failure threshold: suppress unhealthy state until N consecutive failures
   let ns''' = suppressBelowThreshold threshold newFailures mOldNs ns''
   -- Log below-threshold failures for observability
   liftIO $ when (newFailures > 0 && newFailures < threshold) $ do
@@ -359,11 +359,11 @@ logHealthChange nid mOld new = do
   if nsPaused new
     then pure ()
     else case (fmap nsHealth mOld, nsHealth new) of
-      (Just Healthy, NeedsAttention err) ->
+      (Just Healthy, newH) | Just err <- healthErrorMessage newH ->
         liftIO $ logWarn logger $ "[" <> unClusterName clusterName <> "] Node " <> host <> " unreachable: " <> err
-      (Just (NeedsAttention _), Healthy) ->
+      (Just oldH, Healthy) | isUnhealthy oldH ->
         liftIO $ logInfo logger $ "[" <> unClusterName clusterName <> "] Node " <> host <> " recovered"
-      (Nothing, NeedsAttention err) ->
+      (Nothing, newH) | Just err <- healthErrorMessage newH ->
         liftIO $ logWarn logger $ "[" <> unClusterName clusterName <> "] Node " <> host <> " initial connect failed: " <> err
       _ -> pure ()
   where

--- a/src/PureMyHA/Topology/Discovery.hs
+++ b/src/PureMyHA/Topology/Discovery.hs
@@ -152,7 +152,7 @@ buildNodeStateFromProbe
 buildNodeStateFromProbe nid _ (Left err) = NodeState
   { nsNodeId              = nid
   , nsRole                = Replica
-  , nsHealth              = NeedsAttention err
+  , nsHealth              = NodeUnreachable err
   , nsProbeResult         = ProbeFailure err
   , nsErrantGtids         = ""
   , nsPaused              = False

--- a/src/PureMyHA/Types.hs
+++ b/src/PureMyHA/Types.hs
@@ -12,6 +12,8 @@ module PureMyHA.Types
   , SQLThreadState (..)
   , ReplicaStatus (..)
   , NodeHealth (..)
+  , healthErrorMessage
+  , isUnhealthy
   , NodeRole (..)
   , isSource
   , findNodeByHost
@@ -134,9 +136,38 @@ data NodeHealth
   | UnreachableSource
   | DeadSourceAndAllReplicas
   | SplitBrainSuspected
-  | NeedsAttention Text
+  | NodeUnreachable Text         -- ^ Probe connect failure (Text = error message)
+  | ReplicaIOStopped Text        -- ^ IO thread = No (Text = last IO error, may be empty)
+  | ReplicaIOConnecting          -- ^ IO thread = Connecting (not yet established)
+  | ReplicaSQLStopped Text       -- ^ SQL thread stopped (Text = last SQL error)
+  | ErrantGtidDetected Text      -- ^ Errant GTIDs present (Text = GTID set)
+  | NoSourceDetected             -- ^ Cluster-level: no node has source role
+  | NeedsAttention Text          -- ^ Escape hatch for truly unexpected/unclassified conditions
   | Lagging Int
   deriving (Eq, Show, Generic)
+
+-- | Extract a human-readable error message from an unhealthy state, if any.
+healthErrorMessage :: NodeHealth -> Maybe Text
+healthErrorMessage (NodeUnreachable msg)   = Just msg
+healthErrorMessage (ReplicaIOStopped msg)
+  | T.null msg = Just "Replica IO not running"
+  | otherwise  = Just ("IO error: " <> msg)
+healthErrorMessage ReplicaIOConnecting     = Just "Replica IO connecting"
+healthErrorMessage (ReplicaSQLStopped msg) = Just ("SQL error: " <> msg)
+healthErrorMessage (ErrantGtidDetected g)  = Just ("Errant GTIDs: " <> g)
+healthErrorMessage NoSourceDetected        = Just "No source detected"
+healthErrorMessage (NeedsAttention msg)    = Just msg
+healthErrorMessage (Lagging n)             = Just ("Lagging " <> T.pack (show n) <> "s")
+healthErrorMessage DeadSource              = Just "Dead source"
+healthErrorMessage UnreachableSource       = Just "Unreachable source"
+healthErrorMessage DeadSourceAndAllReplicas = Just "Dead source and all replicas"
+healthErrorMessage SplitBrainSuspected     = Just "Split brain suspected"
+healthErrorMessage Healthy                 = Nothing
+
+-- | Is this health state considered unhealthy?
+isUnhealthy :: NodeHealth -> Bool
+isUnhealthy Healthy = False
+isUnhealthy _       = True
 
 data NodeRole = Source | Replica
   deriving (Eq, Show, Generic)

--- a/test/Fixtures.hs
+++ b/test/Fixtures.hs
@@ -88,20 +88,20 @@ healthyReplica = mkNodeState (mkNodeId "db2" 3306) Replica
 replicaWithErrantGtid :: NodeState
 replicaWithErrantGtid = (mkNodeState (mkNodeId "db3" 3306) Replica
   (Just (mkReplicaStatus "db1" 3306 IOYes "uuid1:1-100"))
-  (NeedsAttention "Errant GTIDs: uuid3:1"))
+  (ErrantGtidDetected "uuid3:1"))
   { nsErrantGtids = "uuid3:1" }
 
 replicaWithIOError :: NodeState
 replicaWithIOError = mkNodeState (mkNodeId "db4" 3306) Replica
   (Just (mkReplicaStatus "db1" 3306 IONo "uuid1:1-50")
     { rsLastIOError = "Access denied" })
-  (NeedsAttention "IO error: Access denied")
+  (ReplicaIOStopped "Access denied")
 
 unreachableNode :: NodeId -> NodeState
 unreachableNode nid = NodeState
   { nsNodeId              = nid
   , nsRole                = Replica
-  , nsHealth              = NeedsAttention "Connection refused"
+  , nsHealth              = NodeUnreachable "Connection refused"
   , nsProbeResult         = ProbeFailure "Connection refused"
   , nsErrantGtids         = ""
   , nsPaused              = False

--- a/test/PureMyHA/DetectorSpec.hs
+++ b/test/PureMyHA/DetectorSpec.hs
@@ -64,38 +64,38 @@ spec = do
             ]
       detectClusterHealth cluster `shouldBe` UnreachableSource
 
-    it "returns NeedsAttention 'No source node detected' when no node is marked as source" $ do
+    it "returns NoSourceDetected when no node is marked as source" $ do
       let cluster = Map.fromList
             [ (NodeId "db1" 3306, healthySource { nsRole = Replica })
             ]
-      detectClusterHealth cluster `shouldBe` NeedsAttention "No source node detected"
+      detectClusterHealth cluster `shouldBe` NoSourceDetected
 
   describe "detectNodeHealth" $ do
-    it "returns NeedsAttention when connect error is present" $ do
+    it "returns NodeUnreachable when connect error is present" $ do
       let ns = healthySource { nsProbeResult = ProbeFailure "refused" }
-      detectNodeHealth Nothing ns `shouldBe` NeedsAttention "refused"
+      detectNodeHealth Nothing ns `shouldBe` NodeUnreachable "refused"
 
-    it "returns NeedsAttention when errant GTIDs are present" $ do
+    it "returns ErrantGtidDetected when errant GTIDs are present" $ do
       let ns = healthySource { nsErrantGtids = "uuid3:1" }
-      detectNodeHealth Nothing ns `shouldBe` NeedsAttention "Errant GTIDs: uuid3:1"
+      detectNodeHealth Nothing ns `shouldBe` ErrantGtidDetected "uuid3:1"
 
     it "returns Healthy for a source node with no errors" $
       detectNodeHealth Nothing healthySource `shouldBe` Healthy
 
-    it "returns NeedsAttention IO error when replica IO=No with error message" $ do
+    it "returns ReplicaIOStopped when replica IO=No with error message" $ do
       let rs = (mkReplicaStatus "db1" 3306 IONo "") { rsLastIOError = "Access denied" }
           ns = mkNodeState (NodeId "db2" 3306) Replica (Just rs) Healthy
-      detectNodeHealth Nothing ns `shouldBe` NeedsAttention "IO error: Access denied"
+      detectNodeHealth Nothing ns `shouldBe` ReplicaIOStopped "Access denied"
 
-    it "returns NeedsAttention 'Replica IO not running' when IO=No with no error" $ do
+    it "returns ReplicaIOStopped with empty text when IO=No with no error" $ do
       let rs = mkReplicaStatus "db1" 3306 IONo ""
           ns = mkNodeState (NodeId "db2" 3306) Replica (Just rs) Healthy
-      detectNodeHealth Nothing ns `shouldBe` NeedsAttention "Replica IO not running"
+      detectNodeHealth Nothing ns `shouldBe` ReplicaIOStopped ""
 
-    it "returns NeedsAttention SQL error when SQL thread is stopped" $ do
+    it "returns ReplicaSQLStopped when SQL thread is stopped" $ do
       let rs = (mkReplicaStatus "db1" 3306 IOYes "") { rsReplicaSQLRunning = SQLStopped, rsLastSQLError = "err" }
           ns = mkNodeState (NodeId "db2" 3306) Replica (Just rs) Healthy
-      detectNodeHealth Nothing ns `shouldBe` NeedsAttention "SQL error: err"
+      detectNodeHealth Nothing ns `shouldBe` ReplicaSQLStopped "err"
 
     it "returns Healthy for a normal replica" $
       detectNodeHealth Nothing healthyReplica `shouldBe` Healthy
@@ -145,7 +145,7 @@ spec = do
 
     it "IO error takes precedence over lag threshold" $ do
       let rs = (mkReplicaStatus "db1" 3306 IONo "") { rsLastIOError = "err", rsSecondsBehindSource = Just 100 }
-      detectReplicaHealth (Just 30) rs `shouldBe` NeedsAttention "IO error: err"
+      detectReplicaHealth (Just 30) rs `shouldBe` ReplicaIOStopped "err"
 
   describe "identifySource" $ do
     it "identifies the source node" $

--- a/test/PureMyHA/DiscoverySpec.hs
+++ b/test/PureMyHA/DiscoverySpec.hs
@@ -43,9 +43,9 @@ spec = do
 
   describe "buildNodeStateFromProbe" $ do
 
-    it "connection failure sets NeedsAttention health and ProbeFailure" $ do
+    it "connection failure sets NodeUnreachable health and ProbeFailure" $ do
       let ns = buildNodeStateFromProbe testNid now (Left "Connection refused")
-      nsHealth ns `shouldBe` NeedsAttention "Connection refused"
+      nsHealth ns `shouldBe` NodeUnreachable "Connection refused"
       nsProbeResult ns `shouldBe` ProbeFailure "Connection refused"
 
     it "success with replica status sets role=Replica" $ do

--- a/test/PureMyHA/IPCSpec.hs
+++ b/test/PureMyHA/IPCSpec.hs
@@ -100,6 +100,34 @@ spec = do
       roundTripHealth (NeedsAttention "test msg")
         `shouldBe` Just (NeedsAttention "test msg")
 
+    it "round-trips NodeUnreachable" $
+      roundTripHealth (NodeUnreachable "conn refused")
+        `shouldBe` Just (NodeUnreachable "conn refused")
+
+    it "round-trips ReplicaIOStopped with error" $
+      roundTripHealth (ReplicaIOStopped "Access denied")
+        `shouldBe` Just (ReplicaIOStopped "Access denied")
+
+    it "round-trips ReplicaIOStopped with empty text" $
+      roundTripHealth (ReplicaIOStopped "")
+        `shouldBe` Just (ReplicaIOStopped "")
+
+    it "round-trips ReplicaIOConnecting" $
+      roundTripHealth ReplicaIOConnecting
+        `shouldBe` Just ReplicaIOConnecting
+
+    it "round-trips ReplicaSQLStopped" $
+      roundTripHealth (ReplicaSQLStopped "duplicate key")
+        `shouldBe` Just (ReplicaSQLStopped "duplicate key")
+
+    it "round-trips ErrantGtidDetected" $
+      roundTripHealth (ErrantGtidDetected "uuid3:1")
+        `shouldBe` Just (ErrantGtidDetected "uuid3:1")
+
+    it "round-trips NoSourceDetected" $
+      roundTripHealth NoSourceDetected
+        `shouldBe` Just NoSourceDetected
+
     it "round-trips Lagging" $
       roundTripHealth (Lagging 42) `shouldBe` Just (Lagging 42)
 

--- a/test/PureMyHA/StateSpec.hs
+++ b/test/PureMyHA/StateSpec.hs
@@ -96,14 +96,14 @@ spec = do
       tvar <- newDaemonState
       seedCluster tvar emptyTopo
       atomically $ updateNodeState tvar "test" healthySource
-      let updated = healthySource { nsHealth = NeedsAttention "err" }
+      let updated = healthySource { nsHealth = NodeUnreachable "err" }
       atomically $ updateNodeState tvar "test" updated
       mct <- getClusterTopology tvar "test"
       case mct of
         Nothing -> expectationFailure "cluster not found"
         Just ct -> case Map.lookup (NodeId "db1" 3306) (ctNodes ct) of
           Nothing -> expectationFailure "node not found"
-          Just ns -> nsHealth ns `shouldBe` NeedsAttention "err"
+          Just ns -> nsHealth ns `shouldBe` NodeUnreachable "err"
 
     it "does nothing for unknown cluster" $ do
       tvar <- newDaemonState

--- a/test/PureMyHA/WorkerSpec.hs
+++ b/test/PureMyHA/WorkerSpec.hs
@@ -93,7 +93,7 @@ spec = do
   describe "suppressBelowThreshold" $ do
     let threshold = 3
         errNs     = healthySource
-                      { nsHealth              = NeedsAttention "refused"
+                      { nsHealth              = NodeUnreachable "refused"
                       , nsProbeResult         = ProbeFailure "refused"
                       , nsConsecutiveFailures = 1
                       }
@@ -102,13 +102,13 @@ spec = do
       suppressBelowThreshold threshold 1 (Just healthySource) errNs
         `shouldBe` errNs { nsHealth = Healthy }
 
-    it "applies NeedsAttention when failCount equals threshold" $
+    it "applies unhealthy state when failCount equals threshold" $
       suppressBelowThreshold threshold 3 (Just healthySource) errNs
-        `shouldBe` errNs { nsHealth = NeedsAttention "refused" }
+        `shouldBe` errNs { nsHealth = NodeUnreachable "refused" }
 
-    it "applies NeedsAttention when failCount exceeds threshold" $
+    it "applies unhealthy state when failCount exceeds threshold" $
       suppressBelowThreshold threshold 5 (Just healthySource) errNs
-        `shouldBe` errNs { nsHealth = NeedsAttention "refused" }
+        `shouldBe` errNs { nsHealth = NodeUnreachable "refused" }
 
     it "uses Healthy as fallback when no previous state (first probe)" $
       suppressBelowThreshold threshold 1 Nothing errNs
@@ -118,15 +118,15 @@ spec = do
       suppressBelowThreshold threshold 0 (Just healthySource) healthySource
         `shouldBe` healthySource
 
-    it "resets to Healthy on success after previous NeedsAttention" $ do
-      let prev = healthySource { nsHealth = NeedsAttention "err", nsConsecutiveFailures = 2 }
+    it "resets to Healthy on success after previous unhealthy state" $ do
+      let prev = healthySource { nsHealth = NodeUnreachable "err", nsConsecutiveFailures = 2 }
           curr = healthySource { nsConsecutiveFailures = 0 }
       suppressBelowThreshold threshold 0 (Just prev) curr `shouldBe` curr
 
-    it "preserves NeedsAttention from previous state when below threshold" $ do
-      let prev = healthySource { nsHealth = NeedsAttention "prior err", nsConsecutiveFailures = 2 }
+    it "preserves previous unhealthy state when below threshold" $ do
+      let prev = healthySource { nsHealth = NodeUnreachable "prior err", nsConsecutiveFailures = 2 }
       suppressBelowThreshold threshold 2 (Just prev) errNs
-        `shouldBe` errNs { nsHealth = NeedsAttention "prior err" }
+        `shouldBe` errNs { nsHealth = NodeUnreachable "prior err" }
 
   describe "computeStaleNodes" $ do
     let db1 = NodeId "db1" 3306


### PR DESCRIPTION
## Summary

- Replace `NeedsAttention Text` catch-all with 6 structured constructors: `NodeUnreachable`, `ReplicaIOStopped`, `ReplicaIOConnecting`, `ReplicaSQLStopped`, `ErrantGtidDetected`, `NoSourceDetected`
- Add `healthErrorMessage` and `isUnhealthy` helper functions to `Types.hs`
- Extend JSON serialization, CLI display, and logging to handle new constructors
- Retain `NeedsAttention Text` as escape hatch for unclassified conditions

Closes #126

## Changed files

| Area | Files |
|------|-------|
| Core types | `src/PureMyHA/Types.hs` |
| Detection | `src/PureMyHA/Monitor/Detector.hs` |
| Serialization | `src/PureMyHA/IPC/Protocol.hs`, `src/PureMyHA/IPC/Client.hs` |
| Monitoring | `src/PureMyHA/Monitor/Worker.hs` |
| Discovery | `src/PureMyHA/Topology/Discovery.hs` |
| Unit tests | `test/Fixtures.hs`, `test/PureMyHA/{DetectorSpec,WorkerSpec,IPCSpec,DiscoverySpec,StateSpec}.hs` |
| E2E tests | `e2e/tests/23-structured-health-states.sh` (new), `e2e/tests/21-probe-timeout-failover.sh` (comment fix) |
| Docs | `docs/failover.md` |

## Test plan

- [x] `cabal build all` passes
- [x] `cabal test` — 399 tests pass (7 new IPC round-trip tests for new constructors)
- [ ] E2E test 23: verifies `ReplicaIOStopped`, `ReplicaSQLStopped`, `ErrantGtidDetected` via CLI topology and HTTP topology endpoints
- [ ] Full E2E suite (`./e2e/run-all.sh`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)