### PR TITLE
docs: fix stale comment in selectCandidate about GTID ranking

### DIFF
--- a/src/PureMyHA/Failover/Candidate.hs
+++ b/src/PureMyHA/Failover/Candidate.hs
@@ -37,7 +37,7 @@ data CandidateInfo = CandidateInfo
 --   - nodes in the never_promote list
 -- Ranks by:
 --   1. candidate_priority config order (lower index = higher priority)
---   2. Executed_Gtid_Set (we use text length as a rough proxy; real comparison is done by MySQL)
+--   2. Executed_Gtid_Set (ranked by total transaction count via gtidTransactionCount)
 selectCandidate
   :: [HostInfo]             -- ^ hosts permanently excluded from promotion (never_promote list)
   -> Maybe Int              -- ^ max lag in seconds for auto-select candidates (Nothing = no limit)


### PR DESCRIPTION
## Summary
- The comment on `selectCandidate` described GTID ranking as using "text length as a rough proxy", which was accurate at an earlier point in time
- The implementation now uses `gtidTransactionCount` (in `PureMyHA.MySQL.GTID`), which parses the GTID set string and sums all transaction intervals for an accurate transaction count
- This PR updates the comment to reflect the actual behaviour

## Test plan
- [ ] `cabal build` passes with no warnings
- [ ] Comment in `src/PureMyHA/Failover/Candidate.hs` L40 accurately describes `gtidScore` → `gtidTransactionCount` behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)