### PR TITLE
fix: preserve ctSourceNodeId and ctLastFailoverAt in topology refresh

### DIFF
--- a/src/PureMyHA/Topology/State.hs
+++ b/src/PureMyHA/Topology/State.hs
@@ -91,6 +91,8 @@ updateClusterTopology tvar ct = do
          , ctTopologyDrift        = ctTopologyDrift prevCt
          , ctRecoveryBlockedUntil = ctRecoveryBlockedUntil prevCt
          , ctHealth               = ctHealth prevCt
+         , ctSourceNodeId         = ctSourceNodeId prevCt
+         , ctLastFailoverAt       = ctLastFailoverAt prevCt
          }
 
 getClusterTopology :: TVarDaemonState -> ClusterName -> IO (Maybe ClusterTopology)

--- a/test/PureMyHA/StateSpec.hs
+++ b/test/PureMyHA/StateSpec.hs
@@ -75,6 +75,21 @@ spec = do
       mct <- getClusterTopology tvar "test"
       fmap ctHealth mct `shouldBe` Just DeadSource
 
+    it "preserves ctSourceNodeId from previous topology" $ do
+      tvar <- newDaemonState
+      seedCluster tvar healthyTopo  -- ctSourceNodeId = Just (NodeId "db1" 3306)
+      atomically $ updateClusterTopology tvar emptyTopo  -- ctSourceNodeId = Nothing
+      mct <- getClusterTopology tvar "test"
+      fmap ctSourceNodeId mct `shouldBe` Just (Just (NodeId "db1" 3306))
+
+    it "preserves ctLastFailoverAt from previous topology" $ do
+      tvar <- newDaemonState
+      seedCluster tvar emptyTopo
+      atomically $ recordFailover tvar "test" fixedTime
+      atomically $ updateClusterTopology tvar emptyTopo  -- ctLastFailoverAt = Nothing
+      mct <- getClusterTopology tvar "test"
+      fmap ctLastFailoverAt mct `shouldBe` Just (Just fixedTime)
+
   describe "readDaemonState" $
     it "reads multiple clusters" $ do
       tvar <- newDaemonState


### PR DESCRIPTION
## Summary
- `updateClusterTopology` was not preserving `ctSourceNodeId` or `ctLastFailoverAt` from the previous state, unlike other monitoring-worker-owned fields (`ctHealth`, `ctPaused`, etc.)
- When topology refresh runs while the source is dead, `discoverTopology` produces `ctSourceNodeId = Nothing`, clobbering the correct value set by monitoring workers and causing the API to return `sourceHost: null`
- This created a race condition that caused the E2E `10-pause-resume-failover` test to fail intermittently

## Test plan
- [x] `cabal test` — all 401 unit tests pass, including 2 new tests for the preserved fields
- [ ] E2E test `10-pause-resume-failover.sh` no longer fails with `expected='mysql-source', got=''`

🤖 Generated with [Claude Code](https://claude.com/claude-code)