### PR TITLE
refactor: extract decideClusterActions as pure function (ISSUE #137)

### DIFF
--- a/src/PureMyHA/Monitor/Worker.hs
+++ b/src/PureMyHA/Monitor/Worker.hs
@@ -14,6 +14,7 @@ module PureMyHA.Monitor.Worker
   , mergeNodeState
   , DriftCondition (..)
   , detectTopologyDrift
+  , decideClusterActions
   ) where
 
 import Control.Concurrent (threadDelay)
@@ -406,6 +407,31 @@ enrichErrantGtids ns = do
                     Just (Right (Left _))         -> pure ns
                     Just (Right (Right errant))   -> pure ns { nsErrantGtids = errant }
 
+-- | Pure decision function: given the current config, previous topology snapshot,
+-- and the newly computed cluster health, return the list of actions to execute.
+-- This separates "what to do" (pure) from "how to do it" (IO).
+decideClusterActions :: FailoverConfig -> ClusterTopology -> NodeHealth -> [ClusterAction]
+decideClusterActions fc topo newHealth =
+  let transitioned    = ctHealth topo /= newHealth
+      observedHealthy = ctObservedHealthy topo || newHealth == Healthy
+      hookActions
+        | transitioned = case newHealth of
+            DeadSource               -> [FireHook (OnFailureDetection "DeadSource")]
+            InsufficientQuorum       -> [FireHook (OnFailureDetection "InsufficientQuorum")]
+            DeadSourceAndAllReplicas -> [FireHook (OnFailureDetection "DeadSourceAndAllReplicas")]
+            _                        -> []
+        | otherwise = []
+      failoverActions =
+        [ TriggerAutoFailover
+        | newHealth == DeadSource, fcAutoFailover fc, observedHealthy ]
+      fenceActions =
+        [ TriggerAutoFence
+        | transitioned, newHealth == SplitBrainSuspected, fcAutoFence fc, observedHealthy ]
+      replicaCheckActions =
+        [ TriggerEmergencyReplicaCheck
+        | transitioned, newHealth == UnreachableSource ]
+  in hookActions ++ failoverActions ++ fenceActions ++ replicaCheckActions
+
 recomputeClusterHealth :: App ()
 recomputeClusterHealth = do
   tvar <- asks envDaemonState
@@ -417,76 +443,38 @@ recomputeClusterHealth = do
     Nothing -> pure ()
     Just topo -> do
       let minReplicas = fcMinReplicasForFailover fc
-          newHealth = detectClusterHealth minReplicas (ctNodes topo)
-          newSrcId  = identifySource (Map.elems (ctNodes topo))
-      let transitioned     = ctHealth topo /= newHealth
-          observedHealthy  = ctObservedHealthy topo || newHealth == Healthy
-      -- Fire on_failure_detection hook on transition to a dead state
-      liftIO $ when transitioned $
-        case newHealth of
-          DeadSource -> do
-            mHooks <- readTVarIO (envHooks env)
-            ts <- getCurrentTimestamp
-            let hookEnv = HookEnv { hookClusterName  = ccName cc
-                                   , hookNewSource    = Nothing
-                                   , hookOldSource    = Nothing
-                                   , hookFailureType  = Just "DeadSource"
-                                   , hookTimestamp    = ts
-                                   , hookLagSeconds   = Nothing
-                                   , hookNode         = Nothing
-                                   , hookDriftType    = Nothing
-                                   , hookDriftDetails = Nothing
-                                   }
-            runHookFireForget mHooks hcOnFailureDetection hookEnv
-          InsufficientQuorum -> do
-            mHooks <- readTVarIO (envHooks env)
-            ts <- getCurrentTimestamp
-            let hookEnv = HookEnv { hookClusterName  = ccName cc
-                                   , hookNewSource    = Nothing
-                                   , hookOldSource    = Nothing
-                                   , hookFailureType  = Just "InsufficientQuorum"
-                                   , hookTimestamp    = ts
-                                   , hookLagSeconds   = Nothing
-                                   , hookNode         = Nothing
-                                   , hookDriftType    = Nothing
-                                   , hookDriftDetails = Nothing
-                                   }
-            runHookFireForget mHooks hcOnFailureDetection hookEnv
-          DeadSourceAndAllReplicas -> do
-            mHooks <- readTVarIO (envHooks env)
-            ts <- getCurrentTimestamp
-            let hookEnv = HookEnv { hookClusterName  = ccName cc
-                                   , hookNewSource    = Nothing
-                                   , hookOldSource    = Nothing
-                                   , hookFailureType  = Just "DeadSourceAndAllReplicas"
-                                   , hookTimestamp    = ts
-                                   , hookLagSeconds   = Nothing
-                                   , hookNode         = Nothing
-                                   , hookDriftType    = Nothing
-                                   , hookDriftDetails = Nothing
-                                   }
-            runHookFireForget mHooks hcOnFailureDetection hookEnv
-          _ -> pure ()
+          newHealth   = detectClusterHealth minReplicas (ctNodes topo)
+          newSrcId    = identifySource (Map.elems (ctNodes topo))
+          actions     = decideClusterActions fc topo newHealth
+      let transitioned    = ctHealth topo /= newHealth
+          observedHealthy = ctObservedHealthy topo || newHealth == Healthy
+      -- Fire on_failure_detection hooks (decided by decideClusterActions)
+      liftIO $ forM_ [ft | FireHook (OnFailureDetection ft) <- actions] $ \ft -> do
+        mHooks <- readTVarIO (envHooks env)
+        ts <- getCurrentTimestamp
+        let hookEnv = HookEnv { hookClusterName  = ccName cc
+                               , hookNewSource    = Nothing
+                               , hookOldSource    = Nothing
+                               , hookFailureType  = Just ft
+                               , hookTimestamp    = ts
+                               , hookLagSeconds   = Nothing
+                               , hookNode         = Nothing
+                               , hookDriftType    = Nothing
+                               , hookDriftDetails = Nothing
+                               }
+        runHookFireForget mHooks hcOnFailureDetection hookEnv
       -- Log all health transitions for observability
       when transitioned $ liftIO $ do
         logger <- readTVarIO (envLogger env)
         logInfo logger $ "[" <> unClusterName (ccName cc) <> "] Cluster health: "
           <> T.pack (show (ctHealth topo)) <> " \x2192 " <> T.pack (show newHealth)
       liftIO $ atomically $ updateClusterHealthFields tvar (ccName cc) newHealth newSrcId observedHealthy
-      -- Trigger auto-failover when DeadSource (not just on transition, so resume-failover works)
-      -- The failover lock prevents concurrent execution; anti-flap block prevents repeated failovers
-      liftIO $ when (newHealth == DeadSource && fcAutoFailover fc && observedHealthy) $ do
-        _ <- async (runApp env runAutoFailover)
-        pure ()
-      -- Trigger auto-fence on first transition to SplitBrainSuspected only.
-      -- Firing only on transition prevents re-fencing after the operator runs `unfence`.
-      liftIO $ when (transitioned && newHealth == SplitBrainSuspected && fcAutoFence fc && observedHealthy) $ do
-        _ <- async (runApp env runAutoFence)
-        pure ()
-      -- Emergency re-check on first transition to UnreachableSource
-      liftIO $ when (transitioned && newHealth == UnreachableSource) $ do
-        _ <- async (runApp env emergencyReplicaCheck)
-        pure ()
+      -- Execute triggered actions (decided by decideClusterActions)
+      liftIO $ forM_ actions $ \action -> case action of
+        TriggerAutoFailover          -> do { _ <- async (runApp env runAutoFailover); pure () }
+        TriggerAutoFence             -> do { _ <- async (runApp env runAutoFence); pure () }
+        TriggerEmergencyReplicaCheck -> do { _ <- async (runApp env emergencyReplicaCheck); pure () }
+        FireHook _                   -> pure ()  -- already handled above
 
 -- | When UnreachableSource is first detected, immediately re-probe IOYes replicas
 -- to confirm whether they can actually reach the source (Orchestrator-style).

--- a/src/PureMyHA/Types.hs
+++ b/src/PureMyHA/Types.hs
@@ -27,6 +27,8 @@ module PureMyHA.Types
   , NodeStateView (..)
   , OperationResult (..)
   , ErrantGtidInfo (..)
+  , HookEvent (..)
+  , ClusterAction (..)
   ) where
 
 import Data.Aeson (FromJSON (..), ToJSON (..))
@@ -262,6 +264,17 @@ data OperationResult
   = OperationSuccess Text
   | OperationFailure Text
   deriving (Show, Eq, Generic)
+
+data HookEvent
+  = OnFailureDetection Text   -- ^ hookFailureType string ("DeadSource" etc.)
+  deriving (Eq, Show)
+
+data ClusterAction
+  = TriggerAutoFailover
+  | TriggerAutoFence
+  | TriggerEmergencyReplicaCheck
+  | FireHook HookEvent
+  deriving (Eq, Show)
 
 data ErrantGtidInfo = ErrantGtidInfo
   { egiNodeId     :: NodeId

--- a/test/PureMyHA/WorkerSpec.hs
+++ b/test/PureMyHA/WorkerSpec.hs
@@ -11,7 +11,7 @@ import Data.List.NonEmpty (NonEmpty ((:|)))
 import PureMyHA.Config (ClusterConfig (..), NodeConfig (..), Credentials (..), FailoverConfig (..), MonitoringConfig (..), FailureDetectionConfig (..), Port (..), PositiveDuration (..), AtLeastOne (..))
 import PureMyHA.Env (runApp)
 import qualified Data.Set as Set
-import PureMyHA.Monitor.Worker (suppressBelowThreshold, enrichErrantGtids, computeStaleNodes, pruneStaleWorkers, detectAndPruneStaleWorkers, probeTimeoutMicros, buildLagHookEnv, mergeNodeState, detectTopologyDrift, DriftCondition (..))
+import PureMyHA.Monitor.Worker (suppressBelowThreshold, enrichErrantGtids, computeStaleNodes, pruneStaleWorkers, detectAndPruneStaleWorkers, probeTimeoutMicros, buildLagHookEnv, mergeNodeState, detectTopologyDrift, DriftCondition (..), decideClusterActions)
 import PureMyHA.Hook (HookEnv (..))
 import PureMyHA.Topology.Discovery (buildClusterTopology)
 import PureMyHA.Topology.State (newDaemonState, updateClusterTopology)
@@ -314,3 +314,79 @@ spec = do
       let new = healthySource { nsNodeId = nsNodeId healthyReplica, nsRole = Source }
           old = healthyReplica
       nsRole (mergeNodeState new old) `shouldBe` Replica
+
+  describe "decideClusterActions" $ do
+    let mkTopo :: NodeHealth -> Bool -> ClusterTopology
+        mkTopo health obs = ClusterTopology
+          { ctClusterName          = "test"
+          , ctNodes                = Map.empty
+          , ctSourceNodeId         = Nothing
+          , ctHealth               = health
+          , ctObservedHealthy      = obs
+          , ctRecoveryBlockedUntil = Nothing
+          , ctLastFailoverAt       = Nothing
+          , ctPaused               = False
+          , ctTopologyDrift        = False
+          }
+        fcWithFence = testFC { fcAutoFence = True }
+
+    -- FireHook tests (transition only)
+    it "fires OnFailureDetection hook on transition to DeadSource" $
+      decideClusterActions testFC (mkTopo Healthy True) DeadSource
+        `shouldContain` [FireHook (OnFailureDetection "DeadSource")]
+
+    it "fires OnFailureDetection hook on transition to InsufficientQuorum" $
+      decideClusterActions testFC (mkTopo Healthy True) InsufficientQuorum
+        `shouldContain` [FireHook (OnFailureDetection "InsufficientQuorum")]
+
+    it "fires OnFailureDetection hook on transition to DeadSourceAndAllReplicas" $
+      decideClusterActions testFC (mkTopo Healthy True) DeadSourceAndAllReplicas
+        `shouldContain` [FireHook (OnFailureDetection "DeadSourceAndAllReplicas")]
+
+    it "does not fire hook when health has not transitioned" $
+      filter isFireHook (decideClusterActions testFC (mkTopo DeadSource True) DeadSource)
+        `shouldBe` []
+
+    -- TriggerAutoFailover tests
+    it "triggers auto-failover on transition to DeadSource when enabled and observed healthy" $
+      decideClusterActions testFC (mkTopo Healthy True) DeadSource
+        `shouldContain` [TriggerAutoFailover]
+
+    it "triggers auto-failover even without transition (resume-failover)" $
+      decideClusterActions testFC (mkTopo DeadSource True) DeadSource
+        `shouldContain` [TriggerAutoFailover]
+
+    it "does not trigger auto-failover when disabled" $
+      decideClusterActions (testFC { fcAutoFailover = False }) (mkTopo Healthy True) DeadSource
+        `shouldNotContain` [TriggerAutoFailover]
+
+    it "does not trigger auto-failover when not observed healthy" $
+      decideClusterActions testFC (mkTopo (NodeUnreachable "err") False) DeadSource
+        `shouldNotContain` [TriggerAutoFailover]
+
+    -- TriggerAutoFence tests
+    it "triggers auto-fence on transition to SplitBrainSuspected when enabled and observed healthy" $
+      decideClusterActions fcWithFence (mkTopo Healthy True) SplitBrainSuspected
+        `shouldContain` [TriggerAutoFence]
+
+    it "does not trigger auto-fence without transition" $
+      decideClusterActions fcWithFence (mkTopo SplitBrainSuspected True) SplitBrainSuspected
+        `shouldNotContain` [TriggerAutoFence]
+
+    -- TriggerEmergencyReplicaCheck tests
+    it "triggers emergency replica check on transition to UnreachableSource" $
+      decideClusterActions testFC (mkTopo Healthy True) UnreachableSource
+        `shouldContain` [TriggerEmergencyReplicaCheck]
+
+    it "does not trigger emergency replica check without transition" $
+      decideClusterActions testFC (mkTopo UnreachableSource True) UnreachableSource
+        `shouldNotContain` [TriggerEmergencyReplicaCheck]
+
+    -- Empty actions
+    it "returns empty list when health stays Healthy" $
+      decideClusterActions testFC (mkTopo Healthy True) Healthy
+        `shouldBe` []
+
+isFireHook :: ClusterAction -> Bool
+isFireHook (FireHook _) = True
+isFireHook _            = False


### PR DESCRIPTION
## Summary
- Add `HookEvent` and `ClusterAction` types to `src/PureMyHA/Types.hs`
- Extract `decideClusterActions :: FailoverConfig -> ClusterTopology -> NodeHealth -> [ClusterAction]` as a pure function in `src/PureMyHA/Monitor/Worker.hs`
- Refactor `recomputeClusterHealth` to call `decideClusterActions` and dispatch the returned actions, separating decision logic from IO execution
- Add 13 unit tests for `decideClusterActions` in `test/PureMyHA/WorkerSpec.hs` covering all decision branches (hook firing, auto-failover, auto-fence, emergency replica check)

Closes #137

## Test plan
- [x] `cabal build all` passes
- [x] `cabal test` passes (431 examples, 0 failures)
- [ ] Existing E2E tests cover regression for `recomputeClusterHealth` behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)