### PR TITLE
refactor: move Clone module under MySQL/ namespace

### DIFF
--- a/puremyha.cabal
+++ b/puremyha.cabal
@@ -40,7 +40,7 @@ library
     PureMyHA.Logger
     PureMyHA.Env
     PureMyHA.Hook
-    PureMyHA.Clone
+    PureMyHA.MySQL.Clone
     PureMyHA.MySQL.Auth
     PureMyHA.MySQL.Connection
     PureMyHA.MySQL.Query

--- a/src/PureMyHA/IPC/Server.hs
+++ b/src/PureMyHA/IPC/Server.hs
@@ -22,7 +22,7 @@ import qualified Network.Socket.ByteString as NSB
 import PureMyHA.Config
 import PureMyHA.Env (ClusterEnv (..), runApp)
 import PureMyHA.Logger (Logger, setLogLevel)
-import PureMyHA.Clone (runClone)
+import PureMyHA.MySQL.Clone (runClone)
 import PureMyHA.Failover.Auto (doUnfence, simulateFailover)
 import PureMyHA.Failover.Demote (runDemote, dryRunDemote)
 import PureMyHA.Failover.PauseReplica (runPauseReplica, runResumeReplica)

--- a/src/PureMyHA/MySQL/Clone.hs
+++ b/src/PureMyHA/MySQL/Clone.hs
@@ -1,4 +1,4 @@
-module PureMyHA.Clone
+module PureMyHA.MySQL.Clone
   ( runClone
   , selectDonorAuto
   , parseHostPort

--- a/test/PureMyHA/CloneSpec.hs
+++ b/test/PureMyHA/CloneSpec.hs
@@ -4,7 +4,7 @@ import qualified Data.Map.Strict as Map
 import Data.Either (isLeft)
 import Test.Hspec
 import Fixtures
-import PureMyHA.Clone
+import PureMyHA.MySQL.Clone
 import PureMyHA.MySQL.GTID (GtidSet)
 import PureMyHA.Types
 


### PR DESCRIPTION
## Summary
- Move `src/PureMyHA/Clone.hs` to `src/PureMyHA/MySQL/Clone.hs` (module `PureMyHA.MySQL.Clone`)
- Update imports in `IPC/Server.hs` and `CloneSpec.hs`
- Update `puremyha.cabal` exposed module entry

Clone depends entirely on `PureMyHA.MySQL.*` modules and implements MySQL CLONE plugin operations, so it belongs in the MySQL directory alongside Connection, Query, GTID, Auth, and TLS.

Closes #147

## Test plan
- [x] `cabal build all` passes
- [x] `cabal test` passes (451 examples, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)