### PR TITLE
refactor: introduce DiscoveryEnv ReaderT and extract pure helpers

### DIFF
--- a/src/PureMyHA/Topology/Discovery.hs
+++ b/src/PureMyHA/Topology/Discovery.hs
@@ -9,9 +9,10 @@ module PureMyHA.Topology.Discovery
 
 import Control.Concurrent.Async (withAsync, waitCatch)
 import Control.Concurrent.STM (readTVarIO)
+import Control.Exception (SomeException)
 import Control.Monad (when)
 import Control.Monad.IO.Class (liftIO)
-import Control.Monad.Reader (asks)
+import Control.Monad.Reader (ReaderT, ask, asks, runReaderT)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Set (Set)
@@ -30,6 +31,30 @@ import PureMyHA.MySQL.Query (showReplicaStatus, showReplicas, getGtidExecuted, r
 import PureMyHA.Types
 import PureMyHA.Monitor.Detector (identifySource, detectClusterHealth)
 
+-- | Internal environment for discovery, bundling invariant parameters.
+data DiscoveryEnv = DiscoveryEnv
+  { deMTls    :: Maybe TLSConfig
+  , deCreds   :: DbCredentials
+  , deTMicros :: Int
+  , deLogger  :: Logger
+  }
+
+-- | Collapse the triple-nested result from timeout/waitCatch into a simple Either.
+collapseProbeResult
+  :: Maybe (Either SomeException (Either Text a))
+  -> Either Text a
+collapseProbeResult Nothing                    = Left "probe timeout"
+collapseProbeResult (Just (Left e))            = Left (T.pack (show e))
+collapseProbeResult (Just (Right (Left err)))  = Left err
+collapseProbeResult (Just (Right (Right r)))   = Right r
+
+-- | Split a probe result into the probe info and any discovered replica NodeIds.
+splitProbeSuccess
+  :: Either Text (Maybe ReplicaStatus, GtidSet, [NodeId])
+  -> (Either Text (Maybe ReplicaStatus, GtidSet), [NodeId])
+splitProbeSuccess (Left err)                     = (Left err, [])
+splitProbeSuccess (Right (rs, gtid, replicaIds)) = (Right (rs, gtid), replicaIds)
+
 -- | Discover all nodes reachable from the seed nodes
 discoverTopology :: App ClusterTopology
 discoverTopology = do
@@ -39,11 +64,12 @@ discoverTopology = do
   logger <- asks envLogger >>= liftIO . readTVarIO
   mc     <- getMonitoringConfig
   let tMicros = round (realToFrac (unPositiveDuration (mcConnectTimeout mc)) * 1_000_000 :: Double) :: Int
+      denv = DiscoveryEnv mTls creds tMicros logger
   seedNodes <- liftIO $ mapM (\nc -> do
     hi <- resolveHostInfo (HostName (ncHost nc))
     pure (NodeId hi (unPort (ncPort nc)))) (NE.toList (ccNodes cc))
   fc         <- asks envFailover
-  nodeStates <- liftIO $ discoverAll mTls creds tMicros (Set.fromList seedNodes) Set.empty Map.empty logger
+  nodeStates <- liftIO $ runReaderT (discoverAll (Set.fromList seedNodes) Set.empty Map.empty) denv
   pure (buildClusterTopology (fcMinReplicasForFailover fc) (ccName cc) nodeStates)
 
 -- | Build a ClusterTopology from discovered node states (pure)
@@ -72,79 +98,79 @@ buildClusterTopology minReplicas name nodeStates =
 
 -- | Recursively discover nodes
 discoverAll
-  :: Maybe TLSConfig   -- ^ TLS configuration
-  -> DbCredentials     -- ^ credentials
-  -> Int               -- ^ connect timeout in microseconds
-  -> Set NodeId        -- ^ queue
+  :: Set NodeId        -- ^ queue
   -> Set NodeId        -- ^ visited
   -> Map NodeId NodeState
-  -> Logger
-  -> IO (Map NodeId NodeState)
-discoverAll mTls creds tMicros queue visited acc logger
+  -> ReaderT DiscoveryEnv IO (Map NodeId NodeState)
+discoverAll queue visited acc
   | Set.null queue = do
-      logInfo logger $ "[discovery] Queue empty, discovery complete (" <> T.pack (show (Map.size acc)) <> " node(s))"
+      logger <- asks deLogger
+      liftIO $ logInfo logger $ "[discovery] Queue empty, discovery complete (" <> T.pack (show (Map.size acc)) <> " node(s))"
       pure acc
   | otherwise = do
-      logInfo logger $ "[discovery] Queue: " <> T.pack (show (map (\n -> unHostName (nodeHost n) <> ":" <> T.pack (show (nodePort n))) (Set.toList queue)))
+      logger <- asks deLogger
+      liftIO $ logInfo logger $ "[discovery] Queue: " <> T.pack (show (map (\n -> unHostName (nodeHost n) <> ":" <> T.pack (show (nodePort n))) (Set.toList queue)))
       let (nid0, rest) = Set.deleteFindMin queue
       -- Resolve hostname to IP so that queue entries from nextDiscoveryTargets
       -- (which use hostname-as-IP fallback) match already-visited resolved nodes.
-      nid <- resolveQueueEntry nid0
+      nid <- liftIO $ resolveQueueEntry nid0
       if Set.member nid visited
-        then discoverAll mTls creds tMicros rest visited acc logger
+        then discoverAll rest visited acc
         else do
-          (ns, replicaIds) <- probeNode mTls creds tMicros nid logger
+          (ns, replicaIds) <- probeNode nid
           let visited'  = Set.insert nid visited
               acc'      = Map.insert nid ns acc
               fromRs    = nextDiscoveryTargets ns visited' rest
               newQueue  = foldr (\rid q -> if Set.notMember rid visited' then Set.insert rid q else q) fromRs replicaIds
-          discoverAll mTls creds tMicros newQueue visited' acc' logger
+          discoverAll newQueue visited' acc'
 
 -- | Probe a single node and return its NodeState plus any replicas discovered
 -- via SHOW PROCESSLIST (only populated when the node is a source).
 -- Uses async + timeout to bound the probe duration; a stopped node that causes
 -- TCP to hang will be treated as a failed probe after tMicros microseconds.
-probeNode :: Maybe TLSConfig -> DbCredentials -> Int -> NodeId -> Logger -> IO (NodeState, [NodeId])
-probeNode mTls creds tMicros nid logger = do
-  logInfo logger $ "[discovery] Probing " <> unHostName (nodeHost nid) <> ":" <> T.pack (show (nodePort nid))
-  now <- getCurrentTime
-  let ci = makeConnectInfo nid creds
-  mEither <- withAsync (withNodeConn mTls ci $ \conn -> do
-    mReplicaStatus <- showReplicaStatus conn
-    gtidExec       <- getGtidExecuted conn
-    replicaIds <- case mReplicaStatus of
-      Just rs -> do
-        logInfo logger $ "[discovery] " <> unHostName (nodeHost nid) <> " is a replica of " <> unHostName (rsSourceHost rs) <> ":" <> T.pack (show (rsSourcePort rs))
-        pure []
-      Nothing -> do
-        -- source node: discover downstream replicas via SHOW REPLICAS + SHOW PROCESSLIST
-        (discovered, expected, rawHosts) <- showReplicas conn (nodePort nid)
-        logInfo logger $ "[" <> unHostName (nodeHost nid) <> "] Raw hosts from SHOW REPLICAS/PROCESSLIST: "
-          <> T.pack (show rawHosts)
-        logInfo logger $ "[" <> unHostName (nodeHost nid) <> "] Resolved replica NodeIds: "
-          <> T.pack (show (map (\n -> unHostName (nodeHost n) <> ":" <> T.pack (show (nodePort n))) discovered))
-          <> " (SHOW REPLICAS reports " <> T.pack (show expected) <> " replica(s))"
-        when (length discovered < expected) $
-          logInfo logger $ "[" <> unHostName (nodeHost nid) <> "] WARNING: found "
-            <> T.pack (show (length discovered)) <> " of " <> T.pack (show expected)
-            <> " expected replica(s). Ensure the monitoring user has PROCESS privilege "
-            <> "or set report_host on each replica."
-        pure discovered
-    pure (mReplicaStatus, gtidExec, replicaIds)) $ \probeAsync ->
-    timeout tMicros (waitCatch probeAsync)
-  let result = case mEither of
-        Nothing                  -> Left "probe timeout"
-        Just (Left e)            -> Left (T.pack (show e))
-        Just (Right (Left err))  -> Left err
-        Just (Right (Right r))   -> Right r
+probeNode :: NodeId -> ReaderT DiscoveryEnv IO (NodeState, [NodeId])
+probeNode nid = do
+  logger <- asks deLogger
+  liftIO $ logInfo logger $ "[discovery] Probing " <> unHostName (nodeHost nid) <> ":" <> T.pack (show (nodePort nid))
+  now <- liftIO getCurrentTime
+  result <- runProbe nid
   case result of
-    Left err -> logInfo logger $ "[discovery] " <> unHostName (nodeHost nid) <> " probe failed: " <> err
+    Left err -> liftIO $ logInfo logger $ "[discovery] " <> unHostName (nodeHost nid) <> " probe failed: " <> err
     Right _  -> pure ()
-  let (probeResult, discoveredReplicas) = case result of
-        Left err                     -> (Left err, [])
-        Right (rs, gtid, replicaIds) -> (Right (rs, gtid), replicaIds)
+  let (probeResult, discoveredReplicas) = splitProbeSuccess result
       ns = buildNodeStateFromProbe nid now probeResult
   pure (ns, discoveredReplicas)
+
+-- | Execute the actual probe: connect, query, and collapse the nested result.
+runProbe :: NodeId -> ReaderT DiscoveryEnv IO (Either Text (Maybe ReplicaStatus, GtidSet, [NodeId]))
+runProbe nid = do
+  DiscoveryEnv{..} <- ask
+  let ci = makeConnectInfo nid deCreds
+  mEither <- liftIO $
+    withAsync (withNodeConn deMTls ci $ \conn -> do
+      mReplicaStatus <- showReplicaStatus conn
+      gtidExec       <- getGtidExecuted conn
+      replicaIds <- case mReplicaStatus of
+        Just rs -> do
+          logInfo deLogger $ "[discovery] " <> unHostName (nodeHost nid) <> " is a replica of " <> unHostName (rsSourceHost rs) <> ":" <> T.pack (show (rsSourcePort rs))
+          pure []
+        Nothing -> do
+          -- source node: discover downstream replicas via SHOW REPLICAS + SHOW PROCESSLIST
+          (discovered, expected, rawHosts) <- showReplicas conn (nodePort nid)
+          logInfo deLogger $ "[" <> unHostName (nodeHost nid) <> "] Raw hosts from SHOW REPLICAS/PROCESSLIST: "
+            <> T.pack (show rawHosts)
+          logInfo deLogger $ "[" <> unHostName (nodeHost nid) <> "] Resolved replica NodeIds: "
+            <> T.pack (show (map (\n -> unHostName (nodeHost n) <> ":" <> T.pack (show (nodePort n))) discovered))
+            <> " (SHOW REPLICAS reports " <> T.pack (show expected) <> " replica(s))"
+          when (length discovered < expected) $
+            logInfo deLogger $ "[" <> unHostName (nodeHost nid) <> "] WARNING: found "
+              <> T.pack (show (length discovered)) <> " of " <> T.pack (show expected)
+              <> " expected replica(s). Ensure the monitoring user has PROCESS privilege "
+              <> "or set report_host on each replica."
+          pure discovered
+      pure (mReplicaStatus, gtidExec, replicaIds)) $ \probeAsync ->
+      timeout deTMicros (waitCatch probeAsync)
+  pure (collapseProbeResult mEither)
 
 -- | Build a NodeState from a probe result (pure)
 buildNodeStateFromProbe
@@ -201,15 +227,19 @@ resolveQueueEntry nid = do
 -- NodeId than the previously-resolved entry already in the topology.
 deduplicateByHostname :: Map NodeId NodeState -> Map NodeId NodeState
 deduplicateByHostname nodes =
-  Map.fromList . map selectBest . groupByHostPort . Map.toList $ nodes
+    Map.fromList
+  . Map.elems
+  . Map.fromListWith preferResolved
+  . map (\(nid, ns) -> (hostPort nid, (nid, ns)))
+  . Map.toList
+  $ nodes
   where
     hostPort nid   = (nodeHost nid, nodePort nid)
     isResolved nid = unIPAddr (nodeIPAddr nid) /= unHostName (nodeHost nid)
-    groupByHostPort =
-      Map.elems . foldr (\e m -> Map.insertWith (++) (hostPort (fst e)) [e] m) Map.empty
-    selectBest xs  = case filter (isResolved . fst) xs of
-      (best:_) -> best
-      []       -> head xs
+    preferResolved a@(nidA, _) b@(nidB, _)
+      | isResolved nidA = a
+      | isResolved nidB = b
+      | otherwise       = a
 
 -- | Build an initial (empty) topology from config
 buildInitialTopology :: ClusterConfig -> ClusterTopology


### PR DESCRIPTION
## Summary
- Bundle invariant discovery parameters (TLS, credentials, timeout, logger) into a `DiscoveryEnv` record threaded via `ReaderT`, eliminating repetitive parameter passing across `discoverAll`, `probeNode`, and the new `runProbe`
- Extract `collapseProbeResult` and `splitProbeSuccess` as pure, pattern-match-based helper functions
- Simplify `deduplicateByHostname` using `Map.fromListWith` instead of manual grouping and list filtering

## Test plan
- [x] `cabal build all` passes
- [x] `cabal test` passes (461/461 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)