### PR TITLE
fix: re-trigger emergency replica check while UnreachableSource persists

### DIFF
--- a/src/PureMyHA/Monitor/Event.hs
+++ b/src/PureMyHA/Monitor/Event.hs
@@ -5,13 +5,14 @@ module PureMyHA.Monitor.Event
   , applyEvent
   , decideClusterActions
   , decideLagActions
+  , emergencyCheckDue
   ) where
 
 import Data.Maybe (isJust)
 import qualified Data.Map.Strict as Map
 import qualified Data.Text as T
-import Data.Time (UTCTime)
-import PureMyHA.Config (FailureDetectionConfig (..), FailoverConfig (..), MonitoringConfig (..), AtLeastOne (..))
+import Data.Time (UTCTime, NominalDiffTime, diffUTCTime)
+import PureMyHA.Config (FailureDetectionConfig (..), FailoverConfig (..), MonitoringConfig (..), AtLeastOne (..), PositiveDuration (..))
 import PureMyHA.Monitor.Detector (detectClusterHealth, detectNodeHealth, identifySource)
 import PureMyHA.MySQL.GTID (GtidSet)
 import PureMyHA.Types
@@ -24,6 +25,7 @@ data MonitorEvent
       { neNodeId      :: NodeId
       , neProbeResult :: ProbeResult     -- ^ Raw probe outcome
       , neErrantGtids :: GtidSet         -- ^ Errant GTIDs from enrichment
+      , neProbeTime   :: UTCTime         -- ^ Wall-clock time of the probe
       }
   | TopologyRefreshed
       { neMergedTopology :: ClusterTopology
@@ -90,7 +92,7 @@ applyEvent
 -- NodeProbed: the most complex case. Integrates failure counting,
 -- health detection, role/pause/fence preservation, cluster health
 -- recomputation, and hook/action decisions.
-applyEvent fdc fc mc ct (NodeProbed nid probeResult errantGtids) =
+applyEvent fdc fc mc ct (NodeProbed nid probeResult errantGtids probeTime) =
   let -- 1. Read current node state
       mOldNs = Map.lookup nid (ctNodes ct)
 
@@ -188,7 +190,8 @@ applyEvent fdc fc mc ct (NodeProbed nid probeResult errantGtids) =
         | otherwise = []
 
       -- 14. Cluster-level action decisions
-      clusterActions = decideClusterActions fc ct newClusterHealth
+      checkInterval = unPositiveDuration (mcInterval mc)
+      clusterActions = decideClusterActions fc ct newClusterHealth (Just probeTime) checkInterval
       clusterEffects =
         [FireHookEffect e Nothing | FireHook e <- clusterActions]
         ++ [TriggerActionEffect a | a <- clusterActions, isNotHook a]
@@ -199,6 +202,10 @@ applyEvent fdc fc mc ct (NodeProbed nid probeResult errantGtids) =
         , ctHealth          = newClusterHealth
         , ctSourceNodeId    = newSrcId
         , ctObservedHealthy = observedHealthy
+        , ctLastEmergencyCheckAt =
+            if TriggerEmergencyReplicaCheck `elem` clusterActions
+              then Just probeTime
+              else ctLastEmergencyCheckAt ct
         }
 
       allEffects = belowThresholdLog ++ nodeHealthLog ++ lagEffects
@@ -216,6 +223,7 @@ applyEvent _ _ _ ct (TopologyRefreshed newTopo) =
         , ctHealth               = ctHealth ct
         , ctSourceNodeId         = ctSourceNodeId ct
         , ctLastFailoverAt       = ctLastFailoverAt ct
+        , ctLastEmergencyCheckAt = ctLastEmergencyCheckAt ct
         }
   in (merged, [])
 
@@ -243,6 +251,7 @@ applyEvent _ _ _ ct (FailoverCommitted newSrcId oldSrcIds failoverAt recoveryBlo
         { ctNodes                = promotedNodes
         , ctLastFailoverAt       = Just failoverAt
         , ctRecoveryBlockedUntil = Just recoveryBlockUntil
+        , ctLastEmergencyCheckAt = Nothing
         }
   in (newCt, [])
 
@@ -302,8 +311,8 @@ decideLagActions oldHealth newHealth = case (oldHealth, newHealth) of
   (Just (Lagging _), _)        -> [FireHook OnLagThresholdRecovered]
   _                             -> []
 
-decideClusterActions :: FailoverConfig -> ClusterTopology -> NodeHealth -> [ClusterAction]
-decideClusterActions fc topo newHealth =
+decideClusterActions :: FailoverConfig -> ClusterTopology -> NodeHealth -> Maybe UTCTime -> NominalDiffTime -> [ClusterAction]
+decideClusterActions fc topo newHealth mNow checkInterval =
   let transitioned    = ctHealth topo /= newHealth
       observedHealthy = fcFailoverWithoutObservedHealthy fc || ctObservedHealthy topo || newHealth == Healthy
       hookActions
@@ -321,8 +330,17 @@ decideClusterActions fc topo newHealth =
         | transitioned, newHealth == SplitBrainSuspected, fcAutoFence fc, observedHealthy ]
       replicaCheckActions =
         [ TriggerEmergencyReplicaCheck
-        | transitioned, newHealth == UnreachableSource ]
+        | newHealth == UnreachableSource
+        , emergencyCheckDue mNow (ctLastEmergencyCheckAt topo) checkInterval ]
   in hookActions ++ failoverActions ++ fenceActions ++ replicaCheckActions
+
+-- | Determine whether an emergency replica check is due.
+-- Fires immediately on first detection (no prior check), then rate-limited
+-- to at most once per monitoring interval.
+emergencyCheckDue :: Maybe UTCTime -> Maybe UTCTime -> NominalDiffTime -> Bool
+emergencyCheckDue Nothing    _           _        = False  -- no probe timestamp available
+emergencyCheckDue _          Nothing     _        = True   -- first check: fire immediately
+emergencyCheckDue (Just now) (Just last') interval = diffUTCTime now last' >= interval
 
 isNotHook :: ClusterAction -> Bool
 isNotHook (FireHook _) = False

--- a/src/PureMyHA/Monitor/Worker.hs
+++ b/src/PureMyHA/Monitor/Worker.hs
@@ -292,7 +292,7 @@ monitorNode nid = do
   enriched <- enrichErrantGtids dummyNs
   -- Emit the raw fact — all derived state computation happens in applyEvent
   liftIO $ atomically $ writeTBQueue (envEventQueue env) $
-    NodeProbed nid probeResult (nsErrantGtids enriched)
+    NodeProbed nid probeResult (nsErrantGtids enriched) now
 
 
 enrichErrantGtids :: NodeState -> App NodeState

--- a/src/PureMyHA/Topology/Discovery.hs
+++ b/src/PureMyHA/Topology/Discovery.hs
@@ -94,6 +94,7 @@ buildClusterTopology minReplicas name nodeStates =
        , ctLastFailoverAt       = Nothing
        , ctPaused               = False
        , ctTopologyDrift        = False
+       , ctLastEmergencyCheckAt = Nothing
        }
 
 -- | Recursively discover nodes
@@ -253,4 +254,5 @@ buildInitialTopology cc = ClusterTopology
   , ctLastFailoverAt       = Nothing
   , ctPaused               = False
   , ctTopologyDrift        = False
+  , ctLastEmergencyCheckAt = Nothing
   }

--- a/src/PureMyHA/Topology/State.hs
+++ b/src/PureMyHA/Topology/State.hs
@@ -45,6 +45,7 @@ updateClusterTopology tvar ct = do
          , ctHealth               = ctHealth prevCt
          , ctSourceNodeId         = ctSourceNodeId prevCt
          , ctLastFailoverAt       = ctLastFailoverAt prevCt
+         , ctLastEmergencyCheckAt = ctLastEmergencyCheckAt prevCt
          }
 
 getClusterTopology :: TVarDaemonState -> ClusterName -> IO (Maybe ClusterTopology)

--- a/src/PureMyHA/Types.hs
+++ b/src/PureMyHA/Types.hs
@@ -229,6 +229,7 @@ data ClusterTopology = ClusterTopology
   , ctLastFailoverAt        :: Maybe UTCTime
   , ctPaused                :: Bool
   , ctTopologyDrift         :: Bool             -- True if topology drift is currently detected
+  , ctLastEmergencyCheckAt :: Maybe UTCTime    -- Last emergency replica check timestamp
   } deriving (Show, Generic)
 
 data DaemonState = DaemonState

--- a/test/PureMyHA/AutoSpec.hs
+++ b/test/PureMyHA/AutoSpec.hs
@@ -33,6 +33,7 @@ deadSourceTopo = ClusterTopology
   , ctLastFailoverAt       = Nothing
   , ctPaused               = False
   , ctTopologyDrift        = False
+  , ctLastEmergencyCheckAt = Nothing
   }
 
 healthyTopo :: ClusterTopology

--- a/test/PureMyHA/EventSpec.hs
+++ b/test/PureMyHA/EventSpec.hs
@@ -33,6 +33,7 @@ mkTopo nodes = ClusterTopology
   , ctLastFailoverAt        = Nothing
   , ctPaused                = False
   , ctTopologyDrift         = False
+  , ctLastEmergencyCheckAt  = Nothing
   }
 
 sourceId :: NodeId
@@ -51,7 +52,7 @@ spec = describe "PureMyHA.Monitor.Event" $ do
     it "resets nsConsecutiveFailures to 0 on ProbeSuccess" $ do
       let withFailures = Map.adjust (\ns -> ns { nsConsecutiveFailures = 5 }) replicaId baseNodes
           topo = baseTopo { ctNodes = withFailures }
-          event = NodeProbed replicaId (ProbeSuccess fixedTime (Just (mkReplicaStatus "db1" 3306 IOYes "uuid1:1-100")) emptyGtidSet) emptyGtidSet
+          event = NodeProbed replicaId (ProbeSuccess fixedTime (Just (mkReplicaStatus "db1" 3306 IOYes "uuid1:1-100")) emptyGtidSet) emptyGtidSet fixedTime
           (newTopo, _) = applyEvent testFdc testFc testMc topo event
           mNs = Map.lookup replicaId (ctNodes newTopo)
       fmap nsConsecutiveFailures mNs `shouldBe` Just 0
@@ -59,7 +60,7 @@ spec = describe "PureMyHA.Monitor.Event" $ do
     it "increments nsConsecutiveFailures on ProbeFailure" $ do
       let withFailures = Map.adjust (\ns -> ns { nsConsecutiveFailures = 2 }) replicaId baseNodes
           topo = baseTopo { ctNodes = withFailures }
-          event = NodeProbed replicaId (ProbeFailure "Connection refused") emptyGtidSet
+          event = NodeProbed replicaId (ProbeFailure "Connection refused") emptyGtidSet fixedTime
           (newTopo, _) = applyEvent testFdc testFc testMc topo event
           mNs = Map.lookup replicaId (ctNodes newTopo)
       fmap nsConsecutiveFailures mNs `shouldBe` Just 3
@@ -68,7 +69,7 @@ spec = describe "PureMyHA.Monitor.Event" $ do
       let -- Node has 1 consecutive failure, threshold is 3
           withFailures = Map.adjust (\ns -> ns { nsConsecutiveFailures = 1, nsHealth = Healthy }) replicaId baseNodes
           topo = baseTopo { ctNodes = withFailures }
-          event = NodeProbed replicaId (ProbeFailure "timeout") emptyGtidSet
+          event = NodeProbed replicaId (ProbeFailure "timeout") emptyGtidSet fixedTime
           (newTopo, _) = applyEvent testFdc testFc testMc topo event
           mNs = Map.lookup replicaId (ctNodes newTopo)
       -- 2nd failure, still below threshold of 3 -> health preserved as Healthy
@@ -78,7 +79,7 @@ spec = describe "PureMyHA.Monitor.Event" $ do
     it "applies unhealthy state when at threshold" $ do
       let withFailures = Map.adjust (\ns -> ns { nsConsecutiveFailures = 2, nsHealth = Healthy }) replicaId baseNodes
           topo = baseTopo { ctNodes = withFailures }
-          event = NodeProbed replicaId (ProbeFailure "timeout") emptyGtidSet
+          event = NodeProbed replicaId (ProbeFailure "timeout") emptyGtidSet fixedTime
           (newTopo, _) = applyEvent testFdc testFc testMc topo event
           mNs = Map.lookup replicaId (ctNodes newTopo)
       -- 3rd failure = threshold -> health NOT suppressed
@@ -88,7 +89,7 @@ spec = describe "PureMyHA.Monitor.Event" $ do
     it "preserves nsPaused from current state" $ do
       let paused = Map.adjust (\ns -> ns { nsPaused = True }) replicaId baseNodes
           topo = baseTopo { ctNodes = paused }
-          event = NodeProbed replicaId (ProbeSuccess fixedTime (Just (mkReplicaStatus "db1" 3306 IOYes "uuid1:1-100")) emptyGtidSet) emptyGtidSet
+          event = NodeProbed replicaId (ProbeSuccess fixedTime (Just (mkReplicaStatus "db1" 3306 IOYes "uuid1:1-100")) emptyGtidSet) emptyGtidSet fixedTime
           (newTopo, _) = applyEvent testFdc testFc testMc topo event
           mNs = Map.lookup replicaId (ctNodes newTopo)
       fmap nsPaused mNs `shouldBe` Just True
@@ -96,7 +97,7 @@ spec = describe "PureMyHA.Monitor.Event" $ do
     it "preserves nsFenced from current state" $ do
       let fenced = Map.adjust (\ns -> ns { nsFenced = True }) replicaId baseNodes
           topo = baseTopo { ctNodes = fenced }
-          event = NodeProbed replicaId (ProbeSuccess fixedTime (Just (mkReplicaStatus "db1" 3306 IOYes "uuid1:1-100")) emptyGtidSet) emptyGtidSet
+          event = NodeProbed replicaId (ProbeSuccess fixedTime (Just (mkReplicaStatus "db1" 3306 IOYes "uuid1:1-100")) emptyGtidSet) emptyGtidSet fixedTime
           (newTopo, _) = applyEvent testFdc testFc testMc topo event
           mNs = Map.lookup replicaId (ctNodes newTopo)
       fmap nsFenced mNs `shouldBe` Just True
@@ -106,7 +107,7 @@ spec = describe "PureMyHA.Monitor.Event" $ do
           promoted = Map.adjust (\ns -> ns { nsRole = Source }) replicaId baseNodes
           topo = baseTopo { ctNodes = promoted, ctRecoveryBlockedUntil = Just fixedTime2 }
           -- Probe sees the node as a Replica (prReplicaStatus = Just ...)
-          event = NodeProbed replicaId (ProbeSuccess fixedTime (Just (mkReplicaStatus "db1" 3306 IOYes "uuid1:1-100")) emptyGtidSet) emptyGtidSet
+          event = NodeProbed replicaId (ProbeSuccess fixedTime (Just (mkReplicaStatus "db1" 3306 IOYes "uuid1:1-100")) emptyGtidSet) emptyGtidSet fixedTime
           (newTopo, _) = applyEvent testFdc testFc testMc topo event
           mNs = Map.lookup replicaId (ctNodes newTopo)
       -- Role should be preserved as Source (from current state) during recovery block
@@ -115,14 +116,14 @@ spec = describe "PureMyHA.Monitor.Event" $ do
     it "uses probe-inferred role when no recovery block" $ do
       let topo = baseTopo
           -- Probe sees the node as a Source (prReplicaStatus = Nothing)
-          event = NodeProbed replicaId (ProbeSuccess fixedTime Nothing emptyGtidSet) emptyGtidSet
+          event = NodeProbed replicaId (ProbeSuccess fixedTime Nothing emptyGtidSet) emptyGtidSet fixedTime
           (newTopo, _) = applyEvent testFdc testFc testMc topo event
           mNs = Map.lookup replicaId (ctNodes newTopo)
       fmap nsRole mNs `shouldBe` Just Source
 
     it "infers Source role from prReplicaStatus = Nothing" $ do
       let topo = baseTopo
-          event = NodeProbed sourceId (ProbeSuccess fixedTime Nothing emptyGtidSet) emptyGtidSet
+          event = NodeProbed sourceId (ProbeSuccess fixedTime Nothing emptyGtidSet) emptyGtidSet fixedTime
           (newTopo, _) = applyEvent testFdc testFc testMc topo event
           mNs = Map.lookup sourceId (ctNodes newTopo)
       fmap nsRole mNs `shouldBe` Just Source
@@ -130,7 +131,7 @@ spec = describe "PureMyHA.Monitor.Event" $ do
     it "emits lag hook on Lagging transition" $ do
       let rs = (mkReplicaStatus "db1" 3306 IOYes "uuid1:1-100") { rsSecondsBehindSource = Just 120 }
           topo = baseTopo
-          event = NodeProbed replicaId (ProbeSuccess fixedTime (Just rs) emptyGtidSet) emptyGtidSet
+          event = NodeProbed replicaId (ProbeSuccess fixedTime (Just rs) emptyGtidSet) emptyGtidSet fixedTime
           (_, effects) = applyEvent testFdc testFc testMc topo event
           lagEffects = [e | FireHookEffect e _ <- effects, isLagExceeded e]
       lagEffects `shouldSatisfy` (not . null)
@@ -139,7 +140,7 @@ spec = describe "PureMyHA.Monitor.Event" $ do
       let deadNodes = clusterWithDeadSource
           topo = (mkTopo deadNodes) { ctHealth = Healthy }
           -- Probe the replica: it sees IO=No
-          event = NodeProbed (nsNodeId healthySource) (ProbeFailure "Connection refused") emptyGtidSet
+          event = NodeProbed (nsNodeId healthySource) (ProbeFailure "Connection refused") emptyGtidSet fixedTime
           fdc3 = testFdc { fdcConsecutiveFailuresForDead = AtLeastOne 1 }
           (newTopo, _) = applyEvent fdc3 testFc testMc topo event
       ctHealth newTopo `shouldNotBe` Healthy

--- a/test/PureMyHA/HTTPSpec.hs
+++ b/test/PureMyHA/HTTPSpec.hs
@@ -39,6 +39,7 @@ spec = do
                 , ctLastFailoverAt       = Nothing
                 , ctPaused               = False
                 , ctTopologyDrift        = False
+                , ctLastEmergencyCheckAt = Nothing
                 }
         ds     = DaemonState (Map.singleton "test" ct)
         output = BSL8.unpack (renderMetrics ds)
@@ -115,7 +116,8 @@ spec = do
                 , ctSourceNodeId = Nothing, ctHealth = DeadSource
                 , ctObservedHealthy = False, ctRecoveryBlockedUntil = Nothing
                 , ctLastFailoverAt = Nothing, ctPaused = False
-                , ctTopologyDrift = False }
+                , ctTopologyDrift = False
+                , ctLastEmergencyCheckAt = Nothing }
       atomically $ updateClusterTopology tvar ct
       let req = defaultRequest { requestMethod = methodGet, pathInfo = ["health"] }
       resp <- runApp (httpApp tvar) req
@@ -128,7 +130,8 @@ spec = do
                 , ctSourceNodeId = Just (NodeId "db1" 3306), ctHealth = Healthy
                 , ctObservedHealthy = True, ctRecoveryBlockedUntil = Nothing
                 , ctLastFailoverAt = Nothing, ctPaused = False
-                , ctTopologyDrift = False }
+                , ctTopologyDrift = False
+                , ctLastEmergencyCheckAt = Nothing }
       atomically $ updateClusterTopology tvar ct
       let req = defaultRequest { requestMethod = methodGet, pathInfo = ["cluster", "test", "status"] }
       resp <- runApp (httpApp tvar) req
@@ -147,7 +150,8 @@ spec = do
                 , ctSourceNodeId = Just (NodeId "db1" 3306), ctHealth = Healthy
                 , ctObservedHealthy = True, ctRecoveryBlockedUntil = Nothing
                 , ctLastFailoverAt = Nothing, ctPaused = False
-                , ctTopologyDrift = False }
+                , ctTopologyDrift = False
+                , ctLastEmergencyCheckAt = Nothing }
       atomically $ updateClusterTopology tvar ct
       let req = defaultRequest { requestMethod = methodGet, pathInfo = ["cluster", "test", "topology"] }
       resp <- runApp (httpApp tvar) req
@@ -178,7 +182,8 @@ spec = do
                 , ctRecoveryBlockedUntil = Nothing
                 , ctLastFailoverAt = Nothing
                 , ctPaused = False
-                , ctTopologyDrift = False }
+                , ctTopologyDrift = False
+                , ctLastEmergencyCheckAt = Nothing }
           ds = DaemonState (Map.singleton "test" ct)
           out = BSL8.unpack (renderMetrics ds)
       out `shouldContain` "puremyha_node_replication_lag_seconds{cluster=\"test\",host=\"db2\",port=\"3306\"} -1"

--- a/test/PureMyHA/StateSpec.hs
+++ b/test/PureMyHA/StateSpec.hs
@@ -21,6 +21,7 @@ emptyTopo = ClusterTopology
   , ctLastFailoverAt       = Nothing
   , ctPaused               = False
   , ctTopologyDrift        = False
+  , ctLastEmergencyCheckAt = Nothing
   }
 
 healthyTopo :: ClusterTopology

--- a/test/PureMyHA/WorkerSpec.hs
+++ b/test/PureMyHA/WorkerSpec.hs
@@ -6,6 +6,7 @@ import Control.Concurrent.STM (atomically, newTVarIO, readTVarIO)
 import Control.Exception (SomeException, try, fromException)
 import qualified Data.Map.Strict as Map
 import Test.Hspec
+import Data.Time (addUTCTime)
 import Fixtures
 import Data.List.NonEmpty (NonEmpty ((:|)))
 import PureMyHA.Config (ClusterConfig (..), NodeConfig (..), Credentials (..), FailoverConfig (..), MonitoringConfig (..), FailureDetectionConfig (..), Port (..), PositiveDuration (..), AtLeastOne (..))
@@ -329,69 +330,77 @@ spec = do
           , ctLastFailoverAt       = Nothing
           , ctPaused               = False
           , ctTopologyDrift        = False
+          , ctLastEmergencyCheckAt = Nothing
           }
         fcWithFence = testFC { fcAutoFence = True }
 
     -- FireHook tests (transition only)
     it "fires OnFailureDetection hook on transition to DeadSource" $
-      decideClusterActions testFC (mkTopo Healthy True) DeadSource
+      decideClusterActions testFC (mkTopo Healthy True) DeadSource (Just fixedTime) 3
         `shouldContain` [FireHook (OnFailureDetection "DeadSource")]
 
     it "fires OnFailureDetection hook on transition to InsufficientQuorum" $
-      decideClusterActions testFC (mkTopo Healthy True) InsufficientQuorum
+      decideClusterActions testFC (mkTopo Healthy True) InsufficientQuorum (Just fixedTime) 3
         `shouldContain` [FireHook (OnFailureDetection "InsufficientQuorum")]
 
     it "fires OnFailureDetection hook on transition to DeadSourceAndAllReplicas" $
-      decideClusterActions testFC (mkTopo Healthy True) DeadSourceAndAllReplicas
+      decideClusterActions testFC (mkTopo Healthy True) DeadSourceAndAllReplicas (Just fixedTime) 3
         `shouldContain` [FireHook (OnFailureDetection "DeadSourceAndAllReplicas")]
 
     it "does not fire hook when health has not transitioned" $
-      filter isFireHook (decideClusterActions testFC (mkTopo DeadSource True) DeadSource)
+      filter isFireHook (decideClusterActions testFC (mkTopo DeadSource True) DeadSource (Just fixedTime) 3)
         `shouldBe` []
 
     -- TriggerAutoFailover tests
     it "triggers auto-failover on transition to DeadSource when enabled and observed healthy" $
-      decideClusterActions testFC (mkTopo Healthy True) DeadSource
+      decideClusterActions testFC (mkTopo Healthy True) DeadSource (Just fixedTime) 3
         `shouldContain` [TriggerAutoFailover]
 
     it "triggers auto-failover even without transition (resume-failover)" $
-      decideClusterActions testFC (mkTopo DeadSource True) DeadSource
+      decideClusterActions testFC (mkTopo DeadSource True) DeadSource (Just fixedTime) 3
         `shouldContain` [TriggerAutoFailover]
 
     it "does not trigger auto-failover when disabled" $
-      decideClusterActions (testFC { fcAutoFailover = False }) (mkTopo Healthy True) DeadSource
+      decideClusterActions (testFC { fcAutoFailover = False }) (mkTopo Healthy True) DeadSource (Just fixedTime) 3
         `shouldNotContain` [TriggerAutoFailover]
 
     it "does not trigger auto-failover when not observed healthy" $
-      decideClusterActions testFC (mkTopo (NodeUnreachable "err") False) DeadSource
+      decideClusterActions testFC (mkTopo (NodeUnreachable "err") False) DeadSource (Just fixedTime) 3
         `shouldNotContain` [TriggerAutoFailover]
 
     it "triggers auto-failover without observed healthy when failover_without_observed_healthy is true" $
       decideClusterActions (testFC { fcFailoverWithoutObservedHealthy = True })
-        (mkTopo (NodeUnreachable "err") False) DeadSource
+        (mkTopo (NodeUnreachable "err") False) DeadSource (Just fixedTime) 3
         `shouldContain` [TriggerAutoFailover]
 
     -- TriggerAutoFence tests
     it "triggers auto-fence on transition to SplitBrainSuspected when enabled and observed healthy" $
-      decideClusterActions fcWithFence (mkTopo Healthy True) SplitBrainSuspected
+      decideClusterActions fcWithFence (mkTopo Healthy True) SplitBrainSuspected (Just fixedTime) 3
         `shouldContain` [TriggerAutoFence]
 
     it "does not trigger auto-fence without transition" $
-      decideClusterActions fcWithFence (mkTopo SplitBrainSuspected True) SplitBrainSuspected
+      decideClusterActions fcWithFence (mkTopo SplitBrainSuspected True) SplitBrainSuspected (Just fixedTime) 3
         `shouldNotContain` [TriggerAutoFence]
 
     -- TriggerEmergencyReplicaCheck tests
-    it "triggers emergency replica check on transition to UnreachableSource" $
-      decideClusterActions testFC (mkTopo Healthy True) UnreachableSource
+    it "triggers emergency replica check on first detection (no prior check)" $
+      decideClusterActions testFC (mkTopo Healthy True) UnreachableSource (Just fixedTime) 3
         `shouldContain` [TriggerEmergencyReplicaCheck]
 
-    it "does not trigger emergency replica check without transition" $
-      decideClusterActions testFC (mkTopo UnreachableSource True) UnreachableSource
+    it "does not trigger emergency replica check when cooldown has not elapsed" $ do
+      let topo = (mkTopo UnreachableSource True) { ctLastEmergencyCheckAt = Just fixedTime }
+      decideClusterActions testFC topo UnreachableSource (Just fixedTime) 3
         `shouldNotContain` [TriggerEmergencyReplicaCheck]
+
+    it "triggers emergency replica check when cooldown has elapsed" $ do
+      let topo = (mkTopo UnreachableSource True) { ctLastEmergencyCheckAt = Just fixedTime }
+          laterTime = addUTCTime 5 fixedTime  -- 5s > 3s interval
+      decideClusterActions testFC topo UnreachableSource (Just laterTime) 3
+        `shouldContain` [TriggerEmergencyReplicaCheck]
 
     -- Empty actions
     it "returns empty list when health stays Healthy" $
-      decideClusterActions testFC (mkTopo Healthy True) Healthy
+      decideClusterActions testFC (mkTopo Healthy True) Healthy (Just fixedTime) 3
         `shouldBe` []
 
   describe "mergeTopology" $ do
@@ -405,6 +414,7 @@ spec = do
           , ctLastFailoverAt       = Nothing
           , ctPaused               = False
           , ctTopologyDrift        = False
+          , ctLastEmergencyCheckAt = Nothing
           }
 
     it "returns newTopo unchanged when mOldTopo is Nothing" $ do
@@ -458,6 +468,7 @@ spec = do
           , ctLastFailoverAt       = Nothing
           , ctPaused               = False
           , ctTopologyDrift        = False
+          , ctLastEmergencyCheckAt = Nothing
           }
         ccWith nodes fc = testCC { ccNodes = nodes, ccFailover = fc }
 


### PR DESCRIPTION
## Summary
- When source MySQL is stopped, the emergency replica check fired only once on transition to `UnreachableSource`. If replicas hadn't yet detected the source failure (MySQL's `replica_net_timeout` ~60s), failover never triggered.
- Replace the one-shot `transitioned` guard with a rate-limited approach: track `ctLastEmergencyCheckAt` in `ClusterTopology` and re-fire the check every monitoring interval while `UnreachableSource` persists.
- Add `neProbeTime` to `NodeProbed` events so the reducer has wall-clock time for rate-limiting decisions.

## Test plan
- [x] `cabal build all` passes
- [x] `cabal test` passes (474 tests, including 3 updated emergency check tests)
- [ ] Deploy and verify: stop source MySQL via `systemctl stop`, confirm failover triggers within ~70s (3×probe_interval + replica_net_timeout + 2×probe_interval)

🤖 Generated with [Claude Code](https://claude.com/claude-code)