### PR TITLE
Replace deprecated SHOW PROCESSLIST with performance_schema.processlist

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -15,7 +15,7 @@ CREATE USER 'puremyha'@'%' IDENTIFIED BY '...';
 
 -- Fine-grained privileges (MySQL 8.0+, recommended):
 GRANT REPLICATION CLIENT      ON *.* TO 'puremyha'@'%';  -- SHOW REPLICA STATUS, SHOW REPLICAS
-GRANT PROCESS                 ON *.* TO 'puremyha'@'%';  -- SHOW PROCESSLIST (topology discovery)
+GRANT PROCESS                 ON *.* TO 'puremyha'@'%';  -- performance_schema.processlist (topology discovery)
 GRANT REPLICATION_SLAVE_ADMIN ON *.* TO 'puremyha'@'%';  -- STOP/START REPLICA, RESET REPLICA ALL, CHANGE REPLICATION SOURCE TO
 GRANT SYSTEM_VARIABLES_ADMIN  ON *.* TO 'puremyha'@'%';  -- SET GLOBAL read_only
 GRANT REPLICATION_APPLIER     ON *.* TO 'puremyha'@'%';  -- SET GTID_NEXT (errant GTID repair)

--- a/e2e/tests/20-switchover-drain-timeout.sh
+++ b/e2e/tests/20-switchover-drain-timeout.sh
@@ -44,7 +44,7 @@ $COMPOSE exec -T mysql-source mysql -uroot -prootpass -N \
   -e "SELECT SLEEP(30);" >/dev/null 2>&1 &
 SLEEP_CONN_PID=$!
 
-# Give the connection a moment to appear in SHOW PROCESSLIST
+# Give the connection a moment to appear in performance_schema.processlist
 sleep 1
 
 # Confirm it is visible before starting the switchover

--- a/src/PureMyHA/Failover/Switchover.hs
+++ b/src/PureMyHA/Failover/Switchover.hs
@@ -222,7 +222,7 @@ reconnectToNew newSourceId ns = do
     pure ()
 
 -- | Wait up to timeoutSecs for user connections to close, then KILL remaining ones.
--- Polls SHOW PROCESSLIST every second. If connection to old source is lost, proceeds silently.
+-- Polls performance_schema.processlist every second. If connection to old source is lost, proceeds silently.
 waitThenKill
   :: Maybe TLSConfig
   -> ConnectInfo

--- a/src/PureMyHA/MySQL/Query.hs
+++ b/src/PureMyHA/MySQL/Query.hs
@@ -84,14 +84,14 @@ parseIORunning "Connecting" = IOConnecting
 parseIORunning _            = IONo
 
 -- | Discover connected replicas by combining SHOW REPLICAS (Host column)
--- and SHOW PROCESSLIST (Binlog Dump threads).  Returns discovered NodeIds
--- (deduplicated), the expected replica count from SHOW REPLICAS,
+-- and performance_schema.processlist (Binlog Dump threads).  Returns discovered
+-- NodeIds (deduplicated), the expected replica count from SHOW REPLICAS,
 -- and raw hostnames before resolution (for diagnostics).
 showReplicas :: MySQLConn -> Int -> IO ([NodeId], Int, [Text])
 showReplicas conn defaultPort = do
   -- 1. SHOW REPLICAS — extract Host column where non-empty
   --    Wrapped in try: if the user lacks REPLICATION SLAVE privilege,
-  --    we still fall through to SHOW PROCESSLIST.
+  --    we still fall through to performance_schema.processlist.
   (expectedCount, srHosts) <- do
     result <- try @SomeException $ do
       (srCols, srStream) <- query_ conn "SHOW REPLICAS"
@@ -107,15 +107,15 @@ showReplicas conn defaultPort = do
     pure $ case result of
       Left _       -> (0, [])
       Right (n, h) -> (n, h)
-  -- 2. SHOW PROCESSLIST — Binlog Dump threads
-  (plCols, plStream) <- query_ conn "SHOW PROCESSLIST"
+  -- 2. performance_schema.processlist — Binlog Dump threads
+  (plCols, plStream) <- query_ conn "SELECT COMMAND, HOST FROM performance_schema.processlist WHERE COMMAND IN ('Binlog Dump', 'Binlog Dump GTID') AND HOST != ''"
   plRows <- consumeRows plStream
   let plColNames = map (TE.decodeUtf8 . columnName) plCols
       plHosts = [ T.takeWhile (/= ':') h
                 | row <- plRows
                 , let kvs = zip plColNames row
-                      cmd = textVal (maybe MySQLNull id (lookup "Command" kvs))
-                      h   = textVal (maybe MySQLNull id (lookup "Host"    kvs))
+                      cmd = textVal (maybe MySQLNull id (lookup "COMMAND" kvs))
+                      h   = textVal (maybe MySQLNull id (lookup "HOST"    kvs))
                 , (cmd == "Binlog Dump GTID" || cmd == "Binlog Dump") && h /= ""
                 ]
   -- 3. Merge and deduplicate
@@ -353,26 +353,26 @@ cloneInstanceFrom conn donorHost donorPort DbCredentials{..} = do
         Just _  -> throwIO e
         Nothing -> pure ()
 
--- | A row from SHOW PROCESSLIST
+-- | A row from performance_schema.processlist
 data ProcessInfo = ProcessInfo
   { piId      :: Int
   , piUser    :: Text
   , piCommand :: Text
   } deriving (Show, Eq)
 
--- | Parse SHOW PROCESSLIST and return all entries
+-- | Query performance_schema.processlist and return all entries
 showProcessList :: MySQLConn -> IO [ProcessInfo]
 showProcessList conn = do
-  (cols, stream) <- query_ conn "SHOW PROCESSLIST"
+  (cols, stream) <- query_ conn "SELECT ID, USER, COMMAND FROM performance_schema.processlist"
   rows <- consumeRows stream
   let colNames = map (TE.decodeUtf8 . columnName) cols
       mkRow row =
         let kvs  = zip colNames row
             get k = maybe MySQLNull id (lookup k kvs)
         in ProcessInfo
-             (intVal  (get "Id"))
-             (textVal (get "User"))
-             (textVal (get "Command"))
+             (intVal  (get "ID"))
+             (textVal (get "USER"))
+             (textVal (get "COMMAND"))
   pure (map mkRow rows)
 
 -- | True if this is a user (application) connection that should be drained.

--- a/src/PureMyHA/Topology/Discovery.hs
+++ b/src/PureMyHA/Topology/Discovery.hs
@@ -126,7 +126,7 @@ discoverAll queue visited acc
           discoverAll newQueue visited' acc'
 
 -- | Probe a single node and return its NodeState plus any replicas discovered
--- via SHOW PROCESSLIST (only populated when the node is a source).
+-- via performance_schema.processlist (only populated when the node is a source).
 -- Uses async + timeout to bound the probe duration; a stopped node that causes
 -- TCP to hang will be treated as a failed probe after tMicros microseconds.
 probeNode :: NodeId -> ReaderT DiscoveryEnv IO (NodeState, [NodeId])
@@ -156,9 +156,9 @@ runProbe nid = do
           logInfo deLogger $ "[discovery] " <> unHostName (nodeHost nid) <> " is a replica of " <> unHostName (rsSourceHost rs) <> ":" <> T.pack (show (rsSourcePort rs))
           pure []
         Nothing -> do
-          -- source node: discover downstream replicas via SHOW REPLICAS + SHOW PROCESSLIST
+          -- source node: discover downstream replicas via SHOW REPLICAS + performance_schema.processlist
           (discovered, expected, rawHosts) <- showReplicas conn (nodePort nid)
-          logInfo deLogger $ "[" <> unHostName (nodeHost nid) <> "] Raw hosts from SHOW REPLICAS/PROCESSLIST: "
+          logInfo deLogger $ "[" <> unHostName (nodeHost nid) <> "] Raw hosts from SHOW REPLICAS/processlist: "
             <> T.pack (show rawHosts)
           logInfo deLogger $ "[" <> unHostName (nodeHost nid) <> "] Resolved replica NodeIds: "
             <> T.pack (show (map (\n -> unHostName (nodeHost n) <> ":" <> T.pack (show (nodePort n))) discovered))


### PR DESCRIPTION
## Summary
- Replace `SHOW PROCESSLIST` with `SELECT ... FROM performance_schema.processlist` in `showReplicas` and `showProcessList` (Query.hs)
- Update column lookup keys from mixed case (`Id`, `User`, `Command`, `Host`) to uppercase (`ID`, `USER`, `COMMAND`, `HOST`) to match `performance_schema` column names
- Update comments and documentation across Switchover.hs, Discovery.hs, configuration.md, and E2E tests

Closes #152

## Test plan
- [x] `cabal build all` passes
- [x] `cabal test` passes (474/474 tests)
- [ ] E2E tests pass (topology discovery correctly finds replicas via processlist)
- [ ] E2E test 20 (switchover drain timeout) passes with new SQL

🤖 Generated with [Claude Code](https://claude.com/claude-code)