### PR TITLE
fix: prevent SOURCE node from showing ReplicaIOConnecting after failover

### DIFF
--- a/src/PureMyHA/Monitor/Detector.hs
+++ b/src/PureMyHA/Monitor/Detector.hs
@@ -64,12 +64,12 @@ replicaIOStopped ns = case nsProbeResult ns of
   _ -> False
 
 hasIoError :: [NodeState] -> Bool
-hasIoError = any $ \ns -> case nsProbeResult ns of
+hasIoError = any $ \ns -> not (isSource ns) && case nsProbeResult ns of
   ProbeSuccess{prReplicaStatus = Just rs} -> not (T.null (rsLastIOError rs))
   _ -> False
 
 hasIoConnecting :: [NodeState] -> Bool
-hasIoConnecting = any $ \ns -> case nsProbeResult ns of
+hasIoConnecting = any $ \ns -> not (isSource ns) && case nsProbeResult ns of
   ProbeSuccess{prReplicaStatus = Just rs} -> rsReplicaIORunning rs == IOConnecting
   _ -> False
 
@@ -80,8 +80,9 @@ detectNodeHealth mLagThreshold ns = case nsProbeResult ns of
   ProbeSuccess{prReplicaStatus = mrs}
     | not (isEmptyGtidSet (nsErrantGtids ns)) ->
         ErrantGtidDetected (nsErrantGtids ns)
+    | isSource ns -> Healthy  -- Source nodes ignore residual replica status
     | Just rs <- mrs -> detectReplicaHealth mLagThreshold rs
-    | otherwise      -> Healthy  -- source or standalone
+    | otherwise      -> Healthy  -- standalone
 
 detectReplicaHealth :: Maybe Int -> ReplicaStatus -> NodeHealth
 detectReplicaHealth mLagThreshold rs

--- a/src/PureMyHA/Monitor/Event.hs
+++ b/src/PureMyHA/Monitor/Event.hs
@@ -108,10 +108,18 @@ applyEvent fdc fc mc ct (NodeProbed nid probeResult errantGtids probeTime) =
         ProbeSuccess{prReplicaStatus = Just _}  -> Replica
         ProbeFailure{} -> maybe Replica nsRole mOldNs
 
-      -- 4. Build raw node state
+      -- 3.5. Compute final role early (before health detection) so that
+      --      detectNodeHealth sees the correct role. During recovery block,
+      --      the promoted Source must not be treated as a Replica.
+      preserveRole = isJust (ctRecoveryBlockedUntil ct)
+      finalRole = if preserveRole
+                    then maybe inferredRole nsRole mOldNs
+                    else inferredRole
+
+      -- 4. Build raw node state with final role
       rawNs = NodeState
         { nsNodeId              = nid
-        , nsRole                = inferredRole
+        , nsRole                = finalRole
         , nsHealth              = Healthy   -- placeholder, computed below
         , nsProbeResult         = probeResult
         , nsErrantGtids         = errantGtids
@@ -131,14 +139,9 @@ applyEvent fdc fc mc ct (NodeProbed nid probeResult errantGtids probeTime) =
             healthNs { nsHealth = maybe Healthy nsHealth mOldNs }
         | otherwise = healthNs
 
-      -- 7. Preserve nsPaused, nsFenced, and conditionally nsRole
-      --    (replicates updateNodeStatePreserveRole logic)
-      preserveRole = isJust (ctRecoveryBlockedUntil ct)
+      -- 7. Preserve nsPaused and nsFenced from current state
       finalNs = suppressed
-        { nsRole   = if preserveRole
-                       then maybe (nsRole suppressed) nsRole mOldNs
-                       else nsRole suppressed
-        , nsPaused = maybe (nsPaused suppressed) nsPaused mOldNs
+        { nsPaused = maybe (nsPaused suppressed) nsPaused mOldNs
         , nsFenced = maybe (nsFenced suppressed) nsFenced mOldNs
         }
 
@@ -245,8 +248,8 @@ applyEvent _ _ _ ct (FailoverCommitted newSrcId oldSrcIds failoverAt recoveryBlo
   let -- Demote old sources to Replica
       demoteNode nodes srcId = Map.adjust (\ns -> ns { nsRole = Replica }) srcId nodes
       demotedNodes = foldl demoteNode (ctNodes ct) oldSrcIds
-      -- Promote new source
-      promotedNodes = Map.adjust (\ns -> ns { nsRole = Source }) newSrcId demotedNodes
+      -- Promote new source and reset stale health
+      promotedNodes = Map.adjust (\ns -> ns { nsRole = Source, nsHealth = Healthy }) newSrcId demotedNodes
       newCt = ct
         { ctNodes                = promotedNodes
         , ctLastFailoverAt       = Just failoverAt

--- a/test/PureMyHA/DetectorSpec.hs
+++ b/test/PureMyHA/DetectorSpec.hs
@@ -137,6 +137,11 @@ spec = do
     it "returns Healthy for a normal replica" $
       detectNodeHealth Nothing healthyReplica `shouldBe` Healthy
 
+    it "returns Healthy for Source node with residual replica status" $ do
+      let rs = mkReplicaStatus "db1" 3306 IOConnecting ""
+          ns = mkNodeState (NodeId "db2" 3306) Source (Just rs) Healthy
+      detectNodeHealth Nothing ns `shouldBe` Healthy
+
     it "returns Lagging when lag meets threshold" $ do
       let rs = (mkReplicaStatus "db1" 3306 IOYes "") { rsSecondsBehindSource = Just 30 }
           ns = mkNodeState (NodeId "db2" 3306) Replica (Just rs) Healthy

--- a/test/PureMyHA/EventSpec.hs
+++ b/test/PureMyHA/EventSpec.hs
@@ -112,6 +112,18 @@ spec = describe "PureMyHA.Monitor.Event" $ do
           mNs = Map.lookup replicaId (ctNodes newTopo)
       -- Role should be preserved as Source (from current state) during recovery block
       fmap nsRole mNs `shouldBe` Just Source
+      -- Health should be Healthy (Source ignores residual replica status)
+      fmap nsHealth mNs `shouldBe` Just Healthy
+
+    it "Source with residual IOConnecting replica status gets Healthy during recovery block" $ do
+      let promoted = Map.adjust (\ns -> ns { nsRole = Source, nsHealth = ReplicaIOConnecting }) replicaId baseNodes
+          topo = baseTopo { ctNodes = promoted, ctRecoveryBlockedUntil = Just fixedTime2 }
+          -- Probe returns residual replica status with IOConnecting (race with RESET REPLICA ALL)
+          event = NodeProbed replicaId (ProbeSuccess fixedTime (Just (mkReplicaStatus "db1" 3306 IOConnecting "uuid1:1-100")) emptyGtidSet) emptyGtidSet fixedTime
+          (newTopo, _) = applyEvent testFdc testFc testMc topo event
+          mNs = Map.lookup replicaId (ctNodes newTopo)
+      fmap nsRole mNs `shouldBe` Just Source
+      fmap nsHealth mNs `shouldBe` Just Healthy
 
     it "uses probe-inferred role when no recovery block" $ do
       let topo = baseTopo
@@ -152,6 +164,16 @@ spec = describe "PureMyHA.Monitor.Event" $ do
           event = FailoverCommitted replicaId [sourceId] fixedTime recoveryUntil
           (newTopo, _) = applyEvent testFdc testFc testMc topo event
       fmap nsRole (Map.lookup sourceId (ctNodes newTopo)) `shouldBe` Just Replica
+      fmap nsRole (Map.lookup replicaId (ctNodes newTopo)) `shouldBe` Just Source
+
+    it "resets promoted node health to Healthy" $ do
+      let -- Replica had ReplicaIOConnecting before failover (source was dead)
+          withIOConnecting = Map.adjust (\ns -> ns { nsHealth = ReplicaIOConnecting }) replicaId (clusterHealthy)
+          topo = mkTopo withIOConnecting
+          recoveryUntil = addUTCTime 300 fixedTime
+          event = FailoverCommitted replicaId [sourceId] fixedTime recoveryUntil
+          (newTopo, _) = applyEvent testFdc testFc testMc topo event
+      fmap nsHealth (Map.lookup replicaId (ctNodes newTopo)) `shouldBe` Just Healthy
       fmap nsRole (Map.lookup replicaId (ctNodes newTopo)) `shouldBe` Just Source
 
     it "sets ctLastFailoverAt and ctRecoveryBlockedUntil" $ do
@@ -251,6 +273,70 @@ spec = describe "PureMyHA.Monitor.Event" $ do
           (newTopo, _) = applyEvent testFdc testFc testMc topo event
       fmap nsRole (Map.lookup sourceId (ctNodes newTopo)) `shouldBe` Just Replica
       fmap nsRole (Map.lookup replicaId (ctNodes newTopo)) `shouldBe` Just Source
+
+  -- E2E scenario: chain events to simulate full failover lifecycle
+  describe "Failover E2E scenario" $ do
+    it "promoted SOURCE shows Healthy immediately after failover and through recovery" $ do
+      let db1 = NodeId "db1" 3306
+          db2 = NodeId "db2" 3306
+          db3 = NodeId "db3" 3306
+          -- Use threshold=1 so probe failures trigger immediately
+          fdc1 = testFdc { fdcConsecutiveFailuresForDead = AtLeastOne 1 }
+
+          -- Initial state: db1=Source(dead), db2=Replica(IOConnecting), db3=Replica(Healthy)
+          initialNodes = Map.fromList
+            [ (db1, (unreachableNode db1) { nsRole = Source })
+            , (db2, NodeState
+                { nsNodeId              = db2
+                , nsRole                = Replica
+                , nsHealth              = ReplicaIOConnecting
+                , nsProbeResult         = ProbeSuccess fixedTime (Just (mkReplicaStatus "db1" 3306 IOConnecting "uuid1:1-100")) emptyGtidSet
+                , nsErrantGtids         = emptyGtidSet
+                , nsPaused              = False
+                , nsConsecutiveFailures = 0
+                , nsFenced              = False
+                })
+            , (db3, mkNodeState db3 Replica (Just (mkReplicaStatus "db1" 3306 IOYes "uuid1:1-100")) Healthy)
+            ]
+          topo0 = (mkTopo initialNodes) { ctHealth = DeadSource }
+
+          -- Step 1: FailoverCommitted (promote db2, demote db1)
+          recoveryUntil = addUTCTime 300 fixedTime
+          foEvent = FailoverCommitted db2 [db1] fixedTime recoveryUntil
+          (topo1, _) = applyEvent fdc1 testFc testMc topo0 foEvent
+
+      -- Immediately after FO: db2 is Source with Healthy (stale health cleared)
+      fmap nsRole (Map.lookup db2 (ctNodes topo1)) `shouldBe` Just Source
+      fmap nsHealth (Map.lookup db2 (ctNodes topo1)) `shouldBe` Just Healthy
+      ctRecoveryBlockedUntil topo1 `shouldBe` Just recoveryUntil
+
+      let -- Step 2: NodeProbed db2 with residual IOConnecting (race with RESET REPLICA ALL)
+          probe2 = NodeProbed db2
+            (ProbeSuccess fixedTime (Just (mkReplicaStatus "db1" 3306 IOConnecting "uuid1:1-100")) emptyGtidSet)
+            emptyGtidSet fixedTime
+          (topo2, _) = applyEvent fdc1 testFc testMc topo1 probe2
+
+      -- Role preserved as Source, health is Healthy (Source ignores replica status)
+      fmap nsRole (Map.lookup db2 (ctNodes topo2)) `shouldBe` Just Source
+      fmap nsHealth (Map.lookup db2 (ctNodes topo2)) `shouldBe` Just Healthy
+      -- Cluster health should NOT be NeedsAttention due to Source's residual IO status
+      ctHealth topo2 `shouldNotBe` NeedsAttention "Replica IO thread not connected"
+
+      let -- Step 3: NodeProbed db2 with no replica status (RESET REPLICA ALL completed)
+          probe3 = NodeProbed db2 (ProbeSuccess fixedTime Nothing emptyGtidSet) emptyGtidSet fixedTime
+          (topo3, _) = applyEvent fdc1 testFc testMc topo2 probe3
+
+      fmap nsRole (Map.lookup db2 (ctNodes topo3)) `shouldBe` Just Source
+      fmap nsHealth (Map.lookup db2 (ctNodes topo3)) `shouldBe` Just Healthy
+
+      let -- Step 4: NodeProbed db3 reconnected to db2 (IOYes, source=db2)
+          probe4 = NodeProbed db3
+            (ProbeSuccess fixedTime (Just (mkReplicaStatus "db2" 3306 IOYes "uuid1:1-100")) emptyGtidSet)
+            emptyGtidSet fixedTime
+          (topo4, _) = applyEvent fdc1 testFc testMc topo3 probe4
+
+      fmap nsRole (Map.lookup db3 (ctNodes topo4)) `shouldBe` Just Replica
+      fmap nsHealth (Map.lookup db3 (ctNodes topo4)) `shouldBe` Just Healthy
 
 isLagExceeded :: HookEvent -> Bool
 isLagExceeded (OnLagThresholdExceeded _) = True


### PR DESCRIPTION
## Summary
- Fix stale `ReplicaIOConnecting` health persisting on SOURCE node after failover
- Reset promoted node's health to `Healthy` in `FailoverCommitted` handler
- Add Source-role guard in `detectNodeHealth` to ignore residual replica status
- Move role preservation before health detection in `NodeProbed` so recovery block works correctly
- Filter Source nodes from `hasIoConnecting`/`hasIoError` cluster health checks

## Test plan
- [x] `cabal build all` compiles without errors
- [x] `cabal test` — all 478 tests pass (0 failures)
- [x] New unit tests: Source with residual replica status returns Healthy
- [x] New unit test: FailoverCommitted resets promoted node health
- [x] New E2E scenario test: chains FailoverCommitted → NodeProbed with residual IOConnecting → NodeProbed after RESET REPLICA ALL → replica reconnect, verifying SOURCE stays Healthy throughout

🤖 Generated with [Claude Code](https://claude.com/claude-code)