### PR TITLE
feat: separate pause-replica and stop-replication into distinct commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Inspired by the design of Orchestrator, PureMyHA provides topology discovery, fa
 
 ### Operator Controls
 - **Config Hot-Reload** — Reloads `monitoring` and `hooks` config on SIGHUP without restart
+- **Pause/Resume Replica** — Exclude a replica from failover candidates without stopping MySQL replication
+- **Stop/Start Replication** — Stop or start MySQL replication on a replica (auto-pauses/resumes failover candidacy)
 - **Pause/Resume Auto-Failover** — Temporarily disable automatic failover for maintenance windows
 - **Runtime Log Level** — Change verbosity without restarting via `puremyha set-log-level`
 - **Config Validation** — `puremyha validate-config` validates offline, no daemon required

--- a/app/CLI/Main.hs
+++ b/app/CLI/Main.hs
@@ -33,6 +33,8 @@ data Command
   | CmdDiscovery
   | CmdPauseReplica  HostName
   | CmdResumeReplica HostName
+  | CmdStopReplication  HostName
+  | CmdStartReplication HostName
   | CmdPauseFailover
   | CmdResumeFailover
   | CmdSetLogLevel Text
@@ -76,9 +78,13 @@ cliOptions = CLIOptions
         <> command "discovery"
             (info (pure CmdDiscovery) (progDesc "Trigger manual topology discovery"))
         <> command "pause-replica"
-            (info pauseReplicaCmd (progDesc "Pause replication on a node for maintenance"))
+            (info pauseReplicaCmd (progDesc "Exclude a replica from failover candidates (does not stop MySQL replication)"))
         <> command "resume-replica"
-            (info resumeReplicaCmd (progDesc "Resume replication on a paused node"))
+            (info resumeReplicaCmd (progDesc "Re-include a paused replica in failover candidates (does not start MySQL replication)"))
+        <> command "stop-replication"
+            (info stopReplicationCmd (progDesc "Stop MySQL replication on a replica and exclude from failover"))
+        <> command "start-replication"
+            (info startReplicationCmd (progDesc "Start MySQL replication on a replica and re-include in failover"))
         <> command "pause-failover"
             (info (pure CmdPauseFailover) (progDesc "Pause automatic failover for maintenance"))
         <> command "resume-failover"
@@ -108,6 +114,12 @@ pauseReplicaCmd = CmdPauseReplica <$> (HostName <$> strOption (long "host" <> me
 
 resumeReplicaCmd :: Parser Command
 resumeReplicaCmd = CmdResumeReplica <$> (HostName <$> strOption (long "host" <> metavar "HOST" <> help "Node to resume"))
+
+stopReplicationCmd :: Parser Command
+stopReplicationCmd = CmdStopReplication <$> (HostName <$> strOption (long "host" <> metavar "HOST" <> help "Node to stop replication on"))
+
+startReplicationCmd :: Parser Command
+startReplicationCmd = CmdStartReplication <$> (HostName <$> strOption (long "host" <> metavar "HOST" <> help "Node to start replication on"))
 
 setLogLevelCmd :: Parser Command
 setLogLevelCmd = CmdSetLogLevel
@@ -171,6 +183,8 @@ main = do
             CmdDiscovery          -> ReqDiscovery mCluster
             CmdPauseReplica  host -> ReqPauseReplica  mCluster host
             CmdResumeReplica host -> ReqResumeReplica mCluster host
+            CmdStopReplication  host -> ReqStopReplication  mCluster host
+            CmdStartReplication host -> ReqStartReplication mCluster host
             CmdPauseFailover      -> ReqPauseFailover  mCluster
             CmdResumeFailover     -> ReqResumeFailover mCluster
             CmdSetLogLevel lvl    -> ReqSetLogLevel lvl

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -50,11 +50,17 @@ puremyha simulate-failover [--cluster=<name>]
 # Clear super_read_only on a fenced node (verify data consistency first)
 puremyha unfence --host <host> [--cluster=<name>]
 
-# Pause replication on a replica (STOP REPLICA + stop monitoring)
+# Exclude a replica from failover candidates (does not stop MySQL replication)
 puremyha pause-replica --host db2 [--cluster=<name>]
 
-# Resume replication on a paused replica (START REPLICA + resume monitoring)
+# Re-include a paused replica in failover candidates (does not start MySQL replication)
 puremyha resume-replica --host db2 [--cluster=<name>]
+
+# Stop MySQL replication on a replica and exclude from failover
+puremyha stop-replication --host db2 [--cluster=<name>]
+
+# Start MySQL replication on a replica and re-include in failover
+puremyha start-replication --host db2 [--cluster=<name>]
 
 # Trigger manual topology discovery
 puremyha discovery [--cluster=<name>]

--- a/docs/features.md
+++ b/docs/features.md
@@ -165,6 +165,22 @@ kill -HUP $(pidof puremyhad)
 systemctl reload puremyhad
 ```
 
+### Pause / Resume Replica
+Exclude a replica from failover candidates without stopping MySQL replication. Useful when a replica is under maintenance but replication should continue.
+
+```bash
+puremyha pause-replica --host <host>     # exclude from failover candidates
+puremyha resume-replica --host <host>    # re-include in failover candidates
+```
+
+### Stop / Start Replication
+Stop or start MySQL replication on a replica. `stop-replication` also excludes the node from failover candidates (auto-pause), and `start-replication` re-includes it (auto-resume).
+
+```bash
+puremyha stop-replication --host <host>   # STOP REPLICA + exclude from failover
+puremyha start-replication --host <host>  # START REPLICA + re-include in failover
+```
+
 ### Pause / Resume Auto-Failover
 Temporarily disable automatic failover cluster-wide for planned maintenance windows without stopping the daemon.
 

--- a/e2e/lib/helpers.sh
+++ b/e2e/lib/helpers.sh
@@ -107,6 +107,14 @@ cli_resume_replica() {
   cli_exec resume-replica --host "$1"
 }
 
+cli_stop_replication() {
+  cli_exec stop-replication --host "$1"
+}
+
+cli_start_replication() {
+  cli_exec start-replication --host "$1"
+}
+
 cli_pause_failover() {
   cli_exec pause-failover
 }

--- a/e2e/tests/08-pause-resume-replica.sh
+++ b/e2e/tests/08-pause-resume-replica.sh
@@ -1,14 +1,15 @@
 #!/usr/bin/env bash
 # Test: Pause and Resume Replica
-# Tests pausing and resuming replication on a replica via puremyha CLI.
+# Tests that pause-replica excludes a node from failover candidates
+# WITHOUT stopping MySQL replication (data continues to replicate).
 set -euo pipefail
 source "$(dirname "$0")/../lib/helpers.sh"
 echo "=== Test 08: Pause / Resume Replica ==="
 
 wait_for_health "Healthy" 60
 
-# --- Pause replication on mysql-replica1 ---
-echo "  Pausing replication on mysql-replica1..."
+# --- Pause replica (exclude from failover candidates) ---
+echo "  Pausing replica mysql-replica1 (exclude from failover)..."
 pause_result=$(cli_pause_replica "mysql-replica1")
 echo "  Pause response: $pause_result"
 
@@ -23,45 +24,41 @@ topo=$(cli_topology)
 paused=$(echo "$topo" | jq -r '.[0].nodes[] | select(.host == "mysql-replica1") | .paused')
 assert_eq "mysql-replica1 paused == true" "true" "$paused"
 
-# --- Write data on source, verify it does NOT reach paused replica ---
+# --- Write data on source, verify it STILL reaches paused replica ---
+# pause-replica does NOT stop MySQL replication, only excludes from failover
 echo "  Writing data on source..."
 mysql_exec mysql-source "CREATE DATABASE IF NOT EXISTS e2e_pause_test;"
 mysql_exec mysql-source "CREATE TABLE IF NOT EXISTS e2e_pause_test.t1 (id INT PRIMARY KEY);"
 mysql_exec mysql-source "INSERT INTO e2e_pause_test.t1 VALUES (1);"
 
-# Give a moment for replication (should NOT arrive since paused)
-sleep 3
+# Give time for replication (should still arrive since pause-replica does NOT stop replication)
+sleep 5
 
-# Check that data did NOT replicate to paused replica
+# Check that data DID replicate to paused replica (replication is still running)
 paused_count=$(mysql_exec mysql-replica1 "SELECT COUNT(*) FROM e2e_pause_test.t1;" 2>/dev/null || echo "0")
 paused_count=$(echo "$paused_count" | tr -d '[:space:]')
-assert_eq "Data NOT replicated to paused replica" "0" "$paused_count"
+assert_eq "Data replicated to paused replica (replication still running)" "1" "$paused_count"
 
-# But it should reach the non-paused replica2
+# And it should also reach the non-paused replica2
 running_count=$(mysql_exec mysql-replica2 "SELECT COUNT(*) FROM e2e_pause_test.t1;" 2>/dev/null || echo "0")
 running_count=$(echo "$running_count" | tr -d '[:space:]')
 assert_eq "Data replicated to running replica2" "1" "$running_count"
 
-# --- Resume replication on mysql-replica1 ---
-echo "  Resuming replication on mysql-replica1..."
+# --- Resume replica (re-include in failover candidates) ---
+echo "  Resuming replica mysql-replica1 (re-include in failover)..."
 resume_result=$(cli_resume_replica "mysql-replica1")
 echo "  Resume response: $resume_result"
 
 resume_success=$(echo "$resume_result" | jq -r '.success // empty')
 assert_not_empty "Resume returns success message" "$resume_success"
 
-# Wait for daemon to pick up resumed state and data to catch up
-sleep 5
+# Wait for daemon to pick up resumed state
+sleep 3
 
 # Verify paused flag is now false
 topo=$(cli_topology)
 paused=$(echo "$topo" | jq -r '.[0].nodes[] | select(.host == "mysql-replica1") | .paused')
 assert_eq "mysql-replica1 paused == false" "false" "$paused"
-
-# Verify data caught up on replica1
-caught_up_count=$(mysql_exec mysql-replica1 "SELECT COUNT(*) FROM e2e_pause_test.t1;" 2>/dev/null || echo "0")
-caught_up_count=$(echo "$caught_up_count" | tr -d '[:space:]')
-assert_eq "Data caught up on resumed replica" "1" "$caught_up_count"
 
 # Cleanup test data
 mysql_exec mysql-source "DROP DATABASE IF EXISTS e2e_pause_test;" || true

--- a/e2e/tests/25-stop-start-replication.sh
+++ b/e2e/tests/25-stop-start-replication.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Test: Stop and Start Replication
+# Tests that stop-replication executes STOP REPLICA and auto-pauses,
+# and start-replication executes START REPLICA and auto-resumes.
+set -euo pipefail
+source "$(dirname "$0")/../lib/helpers.sh"
+echo "=== Test 25: Stop / Start Replication ==="
+
+wait_for_health "Healthy" 60
+
+# --- Stop replication on mysql-replica1 ---
+echo "  Stopping replication on mysql-replica1..."
+stop_result=$(cli_stop_replication "mysql-replica1")
+echo "  Stop response: $stop_result"
+
+stop_success=$(echo "$stop_result" | jq -r '.success // empty')
+assert_not_empty "Stop replication returns success message" "$stop_success"
+
+# Wait for daemon to pick up paused state
+sleep 3
+
+# Verify paused flag in topology (auto-pause)
+topo=$(cli_topology)
+paused=$(echo "$topo" | jq -r '.[0].nodes[] | select(.host == "mysql-replica1") | .paused')
+assert_eq "mysql-replica1 paused == true (auto-pause)" "true" "$paused"
+
+# --- Write data on source, verify it does NOT reach stopped replica ---
+echo "  Writing data on source..."
+mysql_exec mysql-source "CREATE DATABASE IF NOT EXISTS e2e_stoprepl_test;"
+mysql_exec mysql-source "CREATE TABLE IF NOT EXISTS e2e_stoprepl_test.t1 (id INT PRIMARY KEY);"
+mysql_exec mysql-source "INSERT INTO e2e_stoprepl_test.t1 VALUES (1);"
+
+# Give a moment for replication (should NOT arrive since STOP REPLICA was executed)
+sleep 3
+
+# Check that data did NOT replicate to stopped replica
+stopped_count=$(mysql_exec mysql-replica1 "SELECT COUNT(*) FROM e2e_stoprepl_test.t1;" 2>/dev/null || echo "0")
+stopped_count=$(echo "$stopped_count" | tr -d '[:space:]')
+assert_eq "Data NOT replicated to stopped replica" "0" "$stopped_count"
+
+# But it should reach the non-stopped replica2
+running_count=$(mysql_exec mysql-replica2 "SELECT COUNT(*) FROM e2e_stoprepl_test.t1;" 2>/dev/null || echo "0")
+running_count=$(echo "$running_count" | tr -d '[:space:]')
+assert_eq "Data replicated to running replica2" "1" "$running_count"
+
+# --- Start replication on mysql-replica1 ---
+echo "  Starting replication on mysql-replica1..."
+start_result=$(cli_start_replication "mysql-replica1")
+echo "  Start response: $start_result"
+
+start_success=$(echo "$start_result" | jq -r '.success // empty')
+assert_not_empty "Start replication returns success message" "$start_success"
+
+# Wait for daemon to pick up resumed state and data to catch up
+sleep 5
+
+# Verify paused flag is now false (auto-resume)
+topo=$(cli_topology)
+paused=$(echo "$topo" | jq -r '.[0].nodes[] | select(.host == "mysql-replica1") | .paused')
+assert_eq "mysql-replica1 paused == false (auto-resume)" "false" "$paused"
+
+# Verify data caught up on replica1
+caught_up_count=$(mysql_exec mysql-replica1 "SELECT COUNT(*) FROM e2e_stoprepl_test.t1;" 2>/dev/null || echo "0")
+caught_up_count=$(echo "$caught_up_count" | tr -d '[:space:]')
+assert_eq "Data caught up on started replica" "1" "$caught_up_count"
+
+# Cleanup test data
+mysql_exec mysql-source "DROP DATABASE IF EXISTS e2e_stoprepl_test;" || true
+
+test_summary

--- a/src/PureMyHA/Failover/Candidate.hs
+++ b/src/PureMyHA/Failover/Candidate.hs
@@ -56,6 +56,7 @@ selectCandidate neverPromote mMaxLag nodes priorities mToHost =
            []  -> Left $ "Host not found as replica: " <> unHostName toHost
            (ns:_)
              | nodeHostInfo (nsNodeId ns) `elem` neverPromote -> Left $ "Cannot promote: host is in never_promote list: " <> unHostName toHost
+             | nsPaused ns -> Left $ "Cannot promote: node is paused: " <> unHostName toHost
              | hasErrantGtid ns -> Left $ "Cannot promote: node has errant GTIDs: " <> unHostName toHost
              | hasConnectError ns -> Left $ "Cannot promote: node unreachable: " <> unHostName toHost
              | otherwise -> Right (nsNodeId ns)
@@ -76,6 +77,7 @@ rankCandidates neverPromote mMaxLag nodes priorities =
 isEligibleCandidate :: [HostInfo] -> Maybe Int -> NodeState -> Bool
 isEligibleCandidate neverPromote mMaxLag ns =
   not (isSource ns)
+  && not (nsPaused ns)
   && not (hasErrantGtid ns)
   && not (hasConnectError ns)
   && not (isLagging ns)

--- a/src/PureMyHA/Failover/PauseReplica.hs
+++ b/src/PureMyHA/Failover/PauseReplica.hs
@@ -1,4 +1,9 @@
-module PureMyHA.Failover.PauseReplica (runPauseReplica, runResumeReplica) where
+module PureMyHA.Failover.PauseReplica
+  ( runPauseReplica
+  , runResumeReplica
+  , runStopReplication
+  , runStartReplication
+  ) where
 
 import Control.Concurrent.STM (atomically, writeTBQueue)
 import Control.Monad.IO.Class (liftIO)
@@ -13,23 +18,63 @@ import PureMyHA.MySQL.Query (stopReplica, startReplica)
 import PureMyHA.Topology.State (getClusterTopology)
 import PureMyHA.Types
 
--- | Pause replication on a replica node for maintenance
+-- | Pause monitoring on a replica node (exclude from failover candidates).
+-- Does NOT execute STOP REPLICA — use 'runStopReplication' for that.
 runPauseReplica
   :: HostName   -- ^ host to pause
   -> App (Either Text ())
 runPauseReplica targetHost =
-  withTargetNode "Pausing" targetHost stopReplica ReplicaPaused
+  withTargetNodeNoMySQL "Pausing" targetHost ReplicaPaused
 
--- | Resume replication on a paused replica node
+-- | Resume monitoring on a paused replica node (re-include in failover candidates).
+-- Does NOT execute START REPLICA — use 'runStartReplication' for that.
 runResumeReplica
   :: HostName   -- ^ host to resume
   -> App (Either Text ())
 runResumeReplica targetHost =
-  withTargetNode "Resuming" targetHost startReplica ReplicaResumed
+  withTargetNodeNoMySQL "Resuming" targetHost ReplicaResumed
 
--- | Common logic for pause/resume: find node, connect, run action, emit event.
+-- | Stop MySQL replication on a replica node.
+-- Executes STOP REPLICA and automatically pauses monitoring (nsPaused=True).
+runStopReplication
+  :: HostName   -- ^ host to stop replication on
+  -> App (Either Text ())
+runStopReplication targetHost =
+  withTargetNode "Stopping" targetHost stopReplica ReplicaPaused
+
+-- | Start MySQL replication on a replica node.
+-- Executes START REPLICA and automatically resumes monitoring (nsPaused=False).
+runStartReplication
+  :: HostName   -- ^ host to start replication on
+  -> App (Either Text ())
+runStartReplication targetHost =
+  withTargetNode "Starting" targetHost startReplica ReplicaResumed
+
+-- | Emit an event for a target node without connecting to MySQL.
+-- Used for pause/resume which only change daemon-side state.
+withTargetNodeNoMySQL
+  :: Text                            -- ^ action name for logging
+  -> HostName                        -- ^ target host
+  -> (NodeId -> MonitorEvent)        -- ^ event constructor on success
+  -> App (Either Text ())
+withTargetNodeNoMySQL actionName targetHost mkEvent = do
+  tvar  <- asks envDaemonState
+  cc    <- asks envCluster
+  queue <- asks envEventQueue
+  mTopo <- liftIO $ getClusterTopology tvar (ccName cc)
+  case mTopo of
+    Nothing -> pure (Left "Cluster not found")
+    Just topo ->
+      case findNodeByHost targetHost (ctNodes topo) of
+        Nothing -> pure (Left $ "Node not found: " <> unHostName targetHost)
+        Just targetNs -> do
+          liftIO $ atomically $ writeTBQueue queue (mkEvent (nsNodeId targetNs))
+          appLogInfo $ "[" <> unClusterName (ccName cc) <> "] " <> actionName <> " replica " <> unHostName targetHost
+          pure (Right ())
+
+-- | Common logic for stop/start-replication: find node, connect, run MySQL action, emit event.
 withTargetNode
-  :: Text                            -- ^ action name for logging (e.g. "Pausing")
+  :: Text                            -- ^ action name for logging (e.g. "Stopping")
   -> HostName                        -- ^ target host
   -> (MySQLConn -> IO ())            -- ^ MySQL action to execute
   -> (NodeId -> MonitorEvent)        -- ^ event constructor on success
@@ -60,6 +105,6 @@ withTargetNode actionName targetHost mysqlAction mkEvent = do
               pure (Right ())
   where
     actionResult = case actionName of
-      "Pausing"  -> "paused"
-      "Resuming" -> "resumed"
+      "Stopping" -> "stopped"
+      "Starting" -> "started"
       other      -> other

--- a/src/PureMyHA/IPC/Protocol.hs
+++ b/src/PureMyHA/IPC/Protocol.hs
@@ -172,6 +172,8 @@ data Request
   | ReqResumeFailover { reqCluster :: Maybe ClusterName }
   | ReqSetLogLevel    { reqLogLevel :: Text }
   | ReqUnfence { reqCluster :: Maybe ClusterName, reqUnfenceHost :: HostName }
+  | ReqStopReplication  { reqCluster :: Maybe ClusterName, reqStopReplHost  :: HostName }
+  | ReqStartReplication { reqCluster :: Maybe ClusterName, reqStartReplHost :: HostName }
   | ReqClone
       { reqCloneCluster   :: Maybe ClusterName
       , reqCloneRecipient :: HostName
@@ -195,6 +197,8 @@ instance ToJSON Request where
   toJSON (ReqResumeFailover mc)  = object ["type" .= ("resume-failover"  :: Text), "cluster" .= mc]
   toJSON (ReqSetLogLevel lvl)    = object ["type" .= ("set-log-level"   :: Text), "level" .= lvl]
   toJSON (ReqUnfence mc h)       = object ["type" .= ("unfence" :: Text), "cluster" .= mc, "host" .= h]
+  toJSON (ReqStopReplication  mc h) = object ["type" .= ("stop-replication"  :: Text), "cluster" .= mc, "host" .= h]
+  toJSON (ReqStartReplication mc h) = object ["type" .= ("start-replication" :: Text), "cluster" .= mc, "host" .= h]
   toJSON (ReqClone mc r md)      = object ["type" .= ("clone" :: Text), "cluster" .= mc, "recipient" .= r, "donor" .= md]
 
 instance FromJSON Request where
@@ -216,6 +220,8 @@ instance FromJSON Request where
       "resume-failover" -> ReqResumeFailover <$> o .:? "cluster"
       "set-log-level"   -> ReqSetLogLevel    <$> o .:  "level"
       "unfence"         -> ReqUnfence        <$> o .:? "cluster" <*> o .: "host"
+      "stop-replication"  -> ReqStopReplication  <$> o .:? "cluster" <*> o .: "host"
+      "start-replication" -> ReqStartReplication <$> o .:? "cluster" <*> o .: "host"
       "clone"           -> ReqClone          <$> o .:? "cluster" <*> o .: "recipient" <*> o .:? "donor"
       _                 -> fail $ "Unknown request type: " <> show t
 

--- a/src/PureMyHA/IPC/Server.hs
+++ b/src/PureMyHA/IPC/Server.hs
@@ -26,7 +26,7 @@ import PureMyHA.Monitor.Event (MonitorEvent (..))
 import PureMyHA.MySQL.Clone (runClone)
 import PureMyHA.Failover.Auto (doUnfence, simulateFailover)
 import PureMyHA.Failover.Demote (runDemote, dryRunDemote)
-import PureMyHA.Failover.PauseReplica (runPauseReplica, runResumeReplica)
+import PureMyHA.Failover.PauseReplica (runPauseReplica, runResumeReplica, runStopReplication, runStartReplication)
 import PureMyHA.Failover.ErrantGtid (runFixErrantGtid, dryRunFixErrantGtid)
 import PureMyHA.Failover.Switchover (runSwitchover, dryRunSwitchover)
 import System.Posix.Files (removeLink)
@@ -171,11 +171,19 @@ handleRequest tvar clusterMap discoveryMap loggerVar req = case req of
 
   ReqPauseReplica mCluster host ->
     runClusterOp mCluster clusterMap
-      (\env -> runApp env $ runPauseReplica host) ("Replication paused on " <> unHostName host)
+      (\env -> runApp env $ runPauseReplica host) ("Replica paused (excluded from failover) on " <> unHostName host)
 
   ReqResumeReplica mCluster host ->
     runClusterOp mCluster clusterMap
-      (\env -> runApp env $ runResumeReplica host) ("Replication resumed on " <> unHostName host)
+      (\env -> runApp env $ runResumeReplica host) ("Replica resumed (included in failover) on " <> unHostName host)
+
+  ReqStopReplication mCluster host ->
+    runClusterOp mCluster clusterMap
+      (\env -> runApp env $ runStopReplication host) ("Replication stopped on " <> unHostName host)
+
+  ReqStartReplication mCluster host ->
+    runClusterOp mCluster clusterMap
+      (\env -> runApp env $ runStartReplication host) ("Replication started on " <> unHostName host)
 
   ReqPauseFailover mCluster ->
     withClusterEnv mCluster clusterMap $ \env -> do

--- a/test/PureMyHA/CandidateSpec.hs
+++ b/test/PureMyHA/CandidateSpec.hs
@@ -121,6 +121,24 @@ spec = do
             ]
       selectCandidate [] (Just 30) nodes [] Nothing `shouldBe` Right (NodeId "db2" 3306)
 
+    it "excludes paused replica from auto-select" $ do
+      let pausedReplica = healthyReplica { nsPaused = True }
+          replica3 = healthyReplica { nsNodeId = NodeId "db3" 3306 }
+          nodes = Map.fromList
+            [ (NodeId "db1" 3306, healthySource)
+            , (NodeId "db2" 3306, pausedReplica)
+            , (NodeId "db3" 3306, replica3)
+            ]
+      selectCandidate [] Nothing nodes [] Nothing `shouldBe` Right (NodeId "db3" 3306)
+
+    it "rejects --to for paused replica" $ do
+      let pausedReplica = healthyReplica { nsPaused = True }
+          nodes = Map.fromList
+            [ (NodeId "db1" 3306, healthySource)
+            , (NodeId "db2" 3306, pausedReplica)
+            ]
+      selectCandidate [] Nothing nodes [] (Just "db2") `shouldBe` Left "Cannot promote: node is paused: db2"
+
     it "returns Left when all replicas exceed maxLag" $ do
       let slowReplica = healthyReplica
             { nsProbeResult = ProbeSuccess fixedTime
@@ -189,6 +207,10 @@ spec = do
     it "returns False for a Lagging replica" $ do
       let lagging = healthyReplica { nsHealth = Lagging 45 }
       isEligibleCandidate [] Nothing lagging `shouldBe` False
+
+    it "returns False for a paused replica" $ do
+      let paused = healthyReplica { nsPaused = True }
+      isEligibleCandidate [] Nothing paused `shouldBe` False
 
     it "returns False when lag exceeds maxLag" $ do
       let slowReplica = healthyReplica

--- a/test/PureMyHA/IPCSpec.hs
+++ b/test/PureMyHA/IPCSpec.hs
@@ -194,6 +194,14 @@ spec = do
       roundTrip (ReqClone Nothing "db3" (Just "db2"))
         `shouldBe` Just (ReqClone Nothing "db3" (Just "db2"))
 
+    it "round-trips ReqStopReplication" $
+      roundTrip (ReqStopReplication (Just "main") "db2")
+        `shouldBe` Just (ReqStopReplication (Just "main") "db2")
+
+    it "round-trips ReqStartReplication" $
+      roundTrip (ReqStartReplication Nothing "db3")
+        `shouldBe` Just (ReqStartReplication Nothing "db3")
+
   describe "Response FromJSON error paths" $ do
     it "rejects unknown response type" $
       (decode (BLC.pack "{\"type\":\"foobar\",\"data\":[]}") :: Maybe Response) `shouldBe` Nothing


### PR DESCRIPTION
## Summary
- **Separate `pause-replica` from `stop-replication`**: `pause-replica` now only excludes a node from failover candidates (sets `nsPaused=True`) without executing `STOP REPLICA`. A new `stop-replication` command executes `STOP REPLICA` and auto-pauses.
- **Separate `resume-replica` from `start-replication`**: `resume-replica` re-includes in failover candidates without `START REPLICA`. A new `start-replication` command executes `START REPLICA` and auto-resumes.
- **Fix candidate exclusion bug**: `isEligibleCandidate` and `selectCandidate --to` now correctly reject paused nodes as failover candidates.

Closes #144

## Test plan
- [x] `cabal build all` passes
- [x] `cabal test` passes (483 tests, 0 failures)
- [ ] E2E: `./run-all.sh 08` — pause-replica excludes from failover but does not stop replication
- [ ] E2E: `./run-all.sh 25` — stop/start-replication stops/starts MySQL replication with auto-pause/resume

🤖 Generated with [Claude Code](https://claude.com/claude-code)