### PR TITLE
Prioritize highest GTID score over candidate_priority in failover

### DIFF
--- a/puremyha.cabal
+++ b/puremyha.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               puremyha
-version:            0.7.0.2
+version:            0.7.1.0
 synopsis:           MySQL 8.4 HA Manager tool in Haskell
 description:        PureMyHA is a simple HA Manager tool for MySQL 8.4 replication topologies.
 license:            MIT

--- a/src/PureMyHA/Failover/Candidate.hs
+++ b/src/PureMyHA/Failover/Candidate.hs
@@ -73,7 +73,7 @@ rankCandidates :: [HostInfo] -> Maybe Int -> [NodeState] -> [CandidatePriority] 
 rankCandidates neverPromote mMaxLag nodes priorities =
   let eligible = filter (isEligibleCandidate neverPromote mMaxLag) nodes
       infos    = map (toCandidateInfo priorities) eligible
-      ranked   = sortBy (comparing ciPriorityRank <> comparing (Down . gtidScore)) infos
+      ranked   = sortBy (comparing (Down . gtidScore) <> comparing ciPriorityRank) infos
   in nonEmpty ranked
 
 isEligibleCandidate :: [HostInfo] -> Maybe Int -> NodeState -> Bool

--- a/test/PureMyHA/CandidateSpec.hs
+++ b/test/PureMyHA/CandidateSpec.hs
@@ -175,15 +175,24 @@ spec = do
       let result = rankCandidates [] Nothing [healthyReplica, replicaLongGtid] []
       fmap (ciNodeId . NE.head) result `shouldBe` Just (unsafeNodeId "db3" 3306)
 
-    it "priority order takes precedence over GTID score" $ do
+    it "GTID score takes precedence over candidate_priority" $ do
       let replicaLongGtid = healthyReplica
             { nsNodeId = unsafeNodeId "db3" 3306
             , nsProbeResult = ProbeSuccess fixedTime (Just (mkReplicaStatus "db1" 3306 IOYes "uuid1:1-1,uuid2:1-200,uuid3:1-50")) emptyGtidSet
             }
-          -- db2 has lower GTID but appears first in priority
+          -- db2 appears first in priority but db3 has higher GTID score
           priorities = [CandidatePriority "db2"]
       let result = rankCandidates [] Nothing [healthyReplica, replicaLongGtid] priorities
-      fmap (ciNodeId . NE.head) result `shouldBe` Just (unsafeNodeId "db2" 3306)
+      fmap (ciNodeId . NE.head) result `shouldBe` Just (unsafeNodeId "db3" 3306)
+
+    it "candidate_priority breaks ties when GTID scores are equal" $ do
+      let replica3 = healthyReplica
+            { nsNodeId = unsafeNodeId "db3" 3306
+            }
+          -- db3 and db2 have same GTID score, db3 is prioritized
+          priorities = [CandidatePriority "db3"]
+      let result = rankCandidates [] Nothing [healthyReplica, replica3] priorities
+      fmap (ciNodeId . NE.head) result `shouldBe` Just (unsafeNodeId "db3" 3306)
 
     it "excludes Lagging nodes from candidates" $ do
       let laggingReplica = healthyReplica


### PR DESCRIPTION
## Summary
- Change `rankCandidates` sort order so GTID score is the primary key and `candidate_priority` is a tiebreaker
- Prevents promoting a replica with older data when a more up-to-date replica is available
- Update existing test to verify GTID score precedence, add new test for tiebreaker behavior

Closes #168

## Test plan
- [x] `cabal test` — all 486 tests pass
- [x] Verify failover selects the replica with highest `Executed_Gtid_Set` even when another replica has higher `candidate_priority`
- [x] Verify `candidate_priority` still determines selection when GTID scores are equal

🤖 Generated with [Claude Code](https://claude.com/claude-code)