### PR TITLE
Use upstream mysql-haskell 1.2.3 and remove forked source-repository-package

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,11 +1,3 @@
 packages: .
 
 optimization: 2
-
--- Use forked mysql-haskell with RSA full-auth support for
--- caching_sha2_password over non-TLS connections.
--- Upstream PR: https://github.com/winterland1989/mysql-haskell/pull/XXX
-source-repository-package
-  type: git
-  location: https://github.com/ikaro1192/mysql-haskell.git
-  tag: 830cf3010ae22759af9745d819f199b6c5811eb3

--- a/puremyha.cabal
+++ b/puremyha.cabal
@@ -66,7 +66,7 @@ library
     PureMyHA.IPC.Client
     PureMyHA.HTTP.Server
   build-depends:
-    mysql-haskell    >= 1.2.0,
+    mysql-haskell    >= 1.2.3,
     io-streams       >= 1.5,
     yaml             >= 0.11,
     optparse-applicative >= 0.16,
@@ -141,7 +141,7 @@ test-suite puremyha-test
     time             >= 1.9,
     wai              >= 3.2,
     http-types       >= 0.12,
-    mysql-haskell    >= 1.2.0,
+    mysql-haskell    >= 1.2.3,
     network          >= 3.1
   build-tool-depends:
     hspec-discover:hspec-discover


### PR DESCRIPTION
## Summary
- Remove `source-repository-package` block for the forked mysql-haskell from `cabal.project`
- Bump minimum mysql-haskell version from `>= 1.2.0` to `>= 1.2.3` in both library and test-suite sections of `puremyha.cabal`
- caching_sha2_password RSA full-auth support is now available upstream in mysql-haskell 1.2.3

## Test plan
- [x] `cabal build all` succeeds with mysql-haskell 1.2.3 from Hackage
- [x] `cabal test` passes (486 examples, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)