### PR TITLE
Reject pause-replica and related commands on source nodes

### DIFF
--- a/e2e/tests/08-pause-resume-replica.sh
+++ b/e2e/tests/08-pause-resume-replica.sh
@@ -8,6 +8,18 @@ echo "=== Test 08: Pause / Resume Replica ==="
 
 wait_for_health "Healthy" 60
 
+# --- Reject pause-replica on source node ---
+echo "  Verifying pause-replica rejects source node..."
+source_pause=$(cli_pause_replica "mysql-source")
+source_pause_err=$(echo "$source_pause" | jq -r '.failure // empty')
+assert_not_empty "pause-replica on source returns error" "$source_pause_err"
+
+# --- Reject resume-replica on source node ---
+echo "  Verifying resume-replica rejects source node..."
+source_resume=$(cli_resume_replica "mysql-source")
+source_resume_err=$(echo "$source_resume" | jq -r '.failure // empty')
+assert_not_empty "resume-replica on source returns error" "$source_resume_err"
+
 # --- Pause replica (exclude from failover candidates) ---
 echo "  Pausing replica mysql-replica1 (exclude from failover)..."
 pause_result=$(cli_pause_replica "mysql-replica1")

--- a/puremyha.cabal
+++ b/puremyha.cabal
@@ -126,6 +126,7 @@ test-suite puremyha-test
     PureMyHA.QuerySpec
     PureMyHA.CloneSpec
     PureMyHA.DemoteSpec
+    PureMyHA.PauseReplicaSpec
   build-depends:
     puremyha,
     async            >= 2.2,

--- a/src/PureMyHA/Failover/PauseReplica.hs
+++ b/src/PureMyHA/Failover/PauseReplica.hs
@@ -67,10 +67,12 @@ withTargetNodeNoMySQL actionName targetHost mkEvent = do
     Just topo ->
       case findNodeByHost targetHost (ctNodes topo) of
         Nothing -> pure (Left $ "Node not found: " <> unHostName targetHost)
-        Just targetNs -> do
-          liftIO $ atomically $ writeTBQueue queue (mkEvent (nsNodeId targetNs))
-          appLogInfo $ "[" <> unClusterName (ccName cc) <> "] " <> actionName <> " replica " <> unHostName targetHost
-          pure (Right ())
+        Just targetNs
+          | isSource targetNs -> pure (Left $ sourceRejectionMsg actionName targetHost)
+          | otherwise -> do
+              liftIO $ atomically $ writeTBQueue queue (mkEvent (nsNodeId targetNs))
+              appLogInfo $ "[" <> unClusterName (ccName cc) <> "] " <> actionName <> " replica " <> unHostName targetHost
+              pure (Right ())
 
 -- | Common logic for stop/start-replication: find node, connect, run MySQL action, emit event.
 withTargetNode
@@ -91,20 +93,34 @@ withTargetNode actionName targetHost mysqlAction mkEvent = do
     Just topo ->
       case findNodeByHost targetHost (ctNodes topo) of
         Nothing -> pure (Left $ "Node not found: " <> unHostName targetHost)
-        Just targetNs -> do
-          let ci = makeConnectInfo (nsNodeId targetNs) creds
-          appLogInfo $ "[" <> unClusterName (ccName cc) <> "] " <> actionName <> " replication on " <> unHostName targetHost
-          result <- liftIO $ withNodeConn mTls ci $ \conn -> mysqlAction conn
-          case result of
-            Left err -> do
-              appLogError $ "[" <> unClusterName (ccName cc) <> "] " <> actionName <> " failed: " <> err
-              pure (Left err)
-            Right () -> do
-              liftIO $ atomically $ writeTBQueue queue (mkEvent (nsNodeId targetNs))
-              appLogInfo $ "[" <> unClusterName (ccName cc) <> "] Replication " <> actionResult <> " on " <> unHostName targetHost
-              pure (Right ())
+        Just targetNs
+          | isSource targetNs -> pure (Left $ sourceRejectionMsg actionName targetHost)
+          | otherwise -> do
+              let ci = makeConnectInfo (nsNodeId targetNs) creds
+              appLogInfo $ "[" <> unClusterName (ccName cc) <> "] " <> actionName <> " replication on " <> unHostName targetHost
+              result <- liftIO $ withNodeConn mTls ci $ \conn -> mysqlAction conn
+              case result of
+                Left err -> do
+                  appLogError $ "[" <> unClusterName (ccName cc) <> "] " <> actionName <> " failed: " <> err
+                  pure (Left err)
+                Right () -> do
+                  liftIO $ atomically $ writeTBQueue queue (mkEvent (nsNodeId targetNs))
+                  appLogInfo $ "[" <> unClusterName (ccName cc) <> "] Replication " <> actionResult <> " on " <> unHostName targetHost
+                  pure (Right ())
   where
     actionResult = case actionName of
       "Stopping" -> "stopped"
       "Starting" -> "started"
+      other      -> other
+
+-- | Build a rejection message for source nodes.
+sourceRejectionMsg :: Text -> HostName -> Text
+sourceRejectionMsg actionName host =
+  "Cannot " <> verb <> " source node: " <> unHostName host
+  where
+    verb = case actionName of
+      "Pausing"  -> "pause"
+      "Resuming" -> "resume"
+      "Stopping" -> "stop replication on"
+      "Starting" -> "start replication on"
       other      -> other

--- a/test/PureMyHA/PauseReplicaSpec.hs
+++ b/test/PureMyHA/PauseReplicaSpec.hs
@@ -1,0 +1,98 @@
+module PureMyHA.PauseReplicaSpec (spec) where
+
+import Control.Concurrent.STM (atomically)
+import qualified Data.Text as T
+import Test.Hspec
+import Fixtures
+import PureMyHA.Config
+  ( ClusterConfig (..), Credentials (..), FailoverConfig (..)
+  , MonitoringConfig (..), FailureDetectionConfig (..), NodeConfig (..)
+  , Port (..), PositiveDuration (..), AtLeastOne (..)
+  , AutoFailoverMode (..), FenceMode (..), ObservedHealthyRequirement (..)
+  )
+import PureMyHA.Env (runApp, ClusterEnv)
+import PureMyHA.Failover.PauseReplica
+  ( runPauseReplica, runResumeReplica
+  , runStopReplication, runStartReplication
+  )
+import PureMyHA.Topology.Discovery (buildClusterTopology)
+import PureMyHA.Topology.State (newDaemonState, updateClusterTopology)
+import Data.List.NonEmpty (NonEmpty ((:|)))
+
+spec :: Spec
+spec = do
+  describe "runPauseReplica" $ do
+    it "rejects source node" $ do
+      env <- setupEnv
+      result <- runApp env $ runPauseReplica "db1"
+      result `shouldSatisfy` isSourceRejection
+
+    it "accepts replica node" $ do
+      env <- setupEnv
+      result <- runApp env $ runPauseReplica "db2"
+      result `shouldBe` Right ()
+
+    it "returns Left when node not found" $ do
+      env <- setupEnv
+      result <- runApp env $ runPauseReplica "nonexistent"
+      result `shouldBe` Left "Node not found: nonexistent"
+
+  describe "runResumeReplica" $ do
+    it "rejects source node" $ do
+      env <- setupEnv
+      result <- runApp env $ runResumeReplica "db1"
+      result `shouldSatisfy` isSourceRejection
+
+    it "accepts replica node" $ do
+      env <- setupEnv
+      result <- runApp env $ runResumeReplica "db2"
+      result `shouldBe` Right ()
+
+  describe "runStopReplication" $ do
+    it "rejects source node" $ do
+      env <- setupEnv
+      result <- runApp env $ runStopReplication "db1"
+      result `shouldSatisfy` isSourceRejection
+
+  describe "runStartReplication" $ do
+    it "rejects source node" $ do
+      env <- setupEnv
+      result <- runApp env $ runStartReplication "db1"
+      result `shouldSatisfy` isSourceRejection
+
+-- | Check that the result is a Left containing source rejection message
+isSourceRejection :: Either T.Text () -> Bool
+isSourceRejection (Left msg) = "source" `T.isInfixOf` T.toLower msg
+isSourceRejection _          = False
+
+setupEnv :: IO ClusterEnv
+setupEnv = do
+  tvar <- newDaemonState
+  let topo = buildClusterTopology 1 "main" clusterHealthy
+  atomically $ updateClusterTopology tvar topo
+  mkTestEnv tvar testCC testFC
+
+testCC :: ClusterConfig
+testCC = ClusterConfig
+  { ccName                   = "main"
+  , ccNodes                  = NodeConfig "db1" (Port 3306) :| []
+  , ccCredentials            = Credentials "user" "/dev/null"
+  , ccReplicationCredentials = Nothing
+  , ccMonitoring             = MonitoringConfig (PositiveDuration 3) (PositiveDuration 5) 30 60 300 (AtLeastOne 1) 1
+  , ccFailureDetection       = FailureDetectionConfig 3600 (AtLeastOne 3)
+  , ccFailover               = FailoverConfig AutoFailoverOn 1 [] 60 FenceManual Nothing [] AllowUnobserved
+  , ccHooks                  = Nothing
+  , ccTLS                    = Nothing
+  }
+
+testFC :: FailoverConfig
+testFC = FailoverConfig
+  { fcAutoFailover                   = AutoFailoverOn
+  , fcMinReplicasForFailover         = 1
+  , fcCandidatePriority              = []
+  , fcWaitRelayLogTimeout            = 60
+  , fcAutoFence                      = FenceManual
+  , fcMaxReplicaLagForCandidate      = Nothing
+  , fcNeverPromote                   = []
+  , fcFailoverWithoutObservedHealthy = RequireObservedHealthy
+  }


### PR DESCRIPTION
## Summary
- Add `isSource` guard to `withTargetNodeNoMySQL` and `withTargetNode` in `PauseReplica.hs` so that `pause-replica`, `resume-replica`, `stop-replication`, and `start-replication` return a clear error when targeting a source node
- Add unit tests (`PauseReplicaSpec.hs`) covering source rejection, replica acceptance, and node-not-found cases
- Add E2E test cases in `08-pause-resume-replica.sh` verifying source node rejection

Closes #173

## Test plan
- [x] `cabal build all` passes
- [x] `cabal test` passes (493 examples, 0 failures)
- [ ] E2E test `08-pause-resume-replica.sh` passes with source rejection assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)