### PR TITLE
Escape and validate values interpolated into MySQL DDL (#178)

### DIFF
--- a/e2e/tests/08-pause-resume-replica.sh
+++ b/e2e/tests/08-pause-resume-replica.sh
@@ -7,6 +7,10 @@ source "$(dirname "$0")/../lib/helpers.sh"
 echo "=== Test 08: Pause / Resume Replica ==="
 
 wait_for_health "Healthy" 60
+# Health alone can be satisfied by a stale cached value; wait until the
+# daemon has actually classified mysql-source as Source before asserting
+# that pause/resume-replica reject it.
+wait_for_source "mysql-source" 60
 
 # --- Reject pause-replica on source node ---
 echo "  Verifying pause-replica rejects source node..."

--- a/puremyha.cabal
+++ b/puremyha.cabal
@@ -47,6 +47,7 @@ library
     PureMyHA.MySQL.Connection
     PureMyHA.MySQL.Query
     PureMyHA.MySQL.GTID
+    PureMyHA.MySQL.SqlEscape
     PureMyHA.MySQL.TLS
     PureMyHA.Topology.Discovery
     PureMyHA.Topology.State
@@ -124,6 +125,7 @@ test-suite puremyha-test
     PureMyHA.HTTPSpec
     PureMyHA.StateSpec
     PureMyHA.QuerySpec
+    PureMyHA.SqlEscapeSpec
     PureMyHA.CloneSpec
     PureMyHA.DemoteSpec
     PureMyHA.PauseReplicaSpec

--- a/src/PureMyHA/MySQL/Query.hs
+++ b/src/PureMyHA/MySQL/Query.hs
@@ -23,6 +23,13 @@ module PureMyHA.MySQL.Query
   , isUserProcess
   , killConnection
   , resolveHostInfo
+    -- * Pure SQL builders (exported for testing)
+  , buildChangeReplicationSourceSql
+  , buildCloneInstanceSql
+  , buildSetCloneValidDonorListSql
+  , buildGtidSubtractSql
+  , buildGtidSubsetSql
+  , buildSetGtidNextSql
   ) where
 
 import Data.Text (Text)
@@ -42,6 +49,11 @@ import Database.MySQL.Protocol.Packet (ERR (..))
 import qualified System.IO.Streams as S
 import PureMyHA.Config (DbCredentials (..), TLSConfig (..), TLSMode (..))
 import PureMyHA.MySQL.GTID (GtidSet, GtidEntry, emptyGtidSet, isEmptyGtidSet, parseGtidSet, renderGtidSet, renderGtidEntry)
+import PureMyHA.MySQL.SqlEscape
+  ( quoteSqlString
+  , validateIdentifierLike
+  , validateGtidRendering
+  )
 import PureMyHA.Types
 
 -- | Convert a lazy ByteString SQL to a Query
@@ -148,20 +160,31 @@ needsPublicKeyRetrieval :: Maybe TLSConfig -> Bool
 needsPublicKeyRetrieval Nothing   = True
 needsPublicKeyRetrieval (Just tc) = tlsMode tc == TLSDisabled
 
+-- | Pure builder for @CHANGE REPLICATION SOURCE TO@ SQL.
+-- Host and user name are whitelist-validated; the password is escaped so any
+-- single quotes inside it are doubled.
+buildChangeReplicationSourceSql
+  :: Text -> Int -> DbCredentials -> Bool -> Either Text Text
+buildChangeReplicationSourceSql host port DbCredentials{..} wantPubKey = do
+  validHost <- validateIdentifierLike host
+  validUser <- validateIdentifierLike dbUser
+  let pubKeyOpt = if wantPubKey then ", GET_SOURCE_PUBLIC_KEY=1" else ""
+  pure $
+    "CHANGE REPLICATION SOURCE TO SOURCE_HOST=" <> quoteSqlString validHost
+      <> ", SOURCE_PORT=" <> T.pack (show port)
+      <> ", SOURCE_USER=" <> quoteSqlString validUser
+      <> ", SOURCE_PASSWORD=" <> quoteSqlString dbPassword
+      <> ", SOURCE_AUTO_POSITION=1"
+      <> pubKeyOpt
+
 -- | CHANGE REPLICATION SOURCE TO ... SOURCE_AUTO_POSITION=1
 changeReplicationSourceTo :: MySQLConn -> Text -> Int -> DbCredentials -> Maybe TLSConfig -> IO ()
-changeReplicationSourceTo conn host port DbCredentials{..} mTls = do
-  let pubKeyOpt = if needsPublicKeyRetrieval mTls
-                    then ", GET_SOURCE_PUBLIC_KEY=1"
-                    else ""
-      sql = "CHANGE REPLICATION SOURCE TO SOURCE_HOST='" <> host
-            <> "', SOURCE_PORT=" <> T.pack (show port)
-            <> ", SOURCE_USER='" <> dbUser <> "'"
-            <> ", SOURCE_PASSWORD='" <> dbPassword <> "'"
-            <> ", SOURCE_AUTO_POSITION=1"
-            <> pubKeyOpt
-  _ <- execute_ conn (toQuery (BL.fromStrict (TE.encodeUtf8 sql)))
-  pure ()
+changeReplicationSourceTo conn host port creds mTls =
+  case buildChangeReplicationSourceSql host port creds (needsPublicKeyRetrieval mTls) of
+    Left err  -> throwIO (userError (T.unpack err))
+    Right sql -> do
+      _ <- execute_ conn (toQuery (BL.fromStrict (TE.encodeUtf8 sql)))
+      pure ()
 
 -- | START REPLICA
 startReplica :: MySQLConn -> IO ()
@@ -210,37 +233,65 @@ clearSuperReadOnly conn = do
   _ <- execute_ conn "SET GLOBAL read_only = OFF"
   pure ()
 
+-- | Pure builder for the @GTID_SUBTRACT@ probe.
+-- Defence-in-depth: the rendering is validated against the GTID character set
+-- even though 'renderGtidSet' already produces only safe characters.
+buildGtidSubtractSql :: GtidSet -> Either Text Text
+buildGtidSubtractSql replicaGtid = do
+  rendered <- validateGtidRendering (renderGtidSet replicaGtid)
+  pure ("SELECT GTID_SUBTRACT(" <> quoteSqlString rendered <> ", @@GLOBAL.gtid_executed)")
+
 -- | Use MySQL GTID_SUBTRACT to find errant GTIDs.
 -- The source side uses @@GLOBAL.gtid_executed queried live from the source
 -- connection, so the result is always fresh regardless of the cached topology.
 gtidSubtract :: MySQLConn -> GtidSet -> IO GtidSet
-gtidSubtract conn replicaGtid = do
-  let sql = "SELECT GTID_SUBTRACT('" <> renderGtidSet replicaGtid <> "', @@GLOBAL.gtid_executed)"
-  (_, stream) <- query_ conn (toQuery (BL.fromStrict (TE.encodeUtf8 sql)))
-  rows <- consumeRows stream
-  case rows of
-    [[v]] -> pure (parseGtidOrEmpty (textVal v))
-    _     -> pure emptyGtidSet
+gtidSubtract conn replicaGtid =
+  case buildGtidSubtractSql replicaGtid of
+    Left err  -> throwIO (userError (T.unpack err))
+    Right sql -> do
+      (_, stream) <- query_ conn (toQuery (BL.fromStrict (TE.encodeUtf8 sql)))
+      rows <- consumeRows stream
+      case rows of
+        [[v]] -> pure (parseGtidOrEmpty (textVal v))
+        _     -> pure emptyGtidSet
 
+
+-- | Pure builder for the @GTID_SUBSET@ probe.
+buildGtidSubsetSql :: GtidSet -> GtidSet -> Either Text Text
+buildGtidSubsetSql replicaGtid sourceGtid = do
+  rReplica <- validateGtidRendering (renderGtidSet replicaGtid)
+  rSource  <- validateGtidRendering (renderGtidSet sourceGtid)
+  pure ("SELECT GTID_SUBSET(" <> quoteSqlString rReplica <> ", " <> quoteSqlString rSource <> ")")
 
 -- | Use MySQL GTID_SUBSET to check if replicaGtid is a subset of sourceGtid
 gtidSubset :: MySQLConn -> GtidSet -> GtidSet -> IO Bool
-gtidSubset conn replicaGtid sourceGtid = do
-  let sql = "SELECT GTID_SUBSET('" <> renderGtidSet replicaGtid <> "', '" <> renderGtidSet sourceGtid <> "')"
-  (_, stream) <- query_ conn (toQuery (BL.fromStrict (TE.encodeUtf8 sql)))
-  rows <- consumeRows stream
-  case rows of
-    [[v]] -> pure (intVal v == 1)
-    _     -> pure False
+gtidSubset conn replicaGtid sourceGtid =
+  case buildGtidSubsetSql replicaGtid sourceGtid of
+    Left err  -> throwIO (userError (T.unpack err))
+    Right sql -> do
+      (_, stream) <- query_ conn (toQuery (BL.fromStrict (TE.encodeUtf8 sql)))
+      rows <- consumeRows stream
+      case rows of
+        [[v]] -> pure (intVal v == 1)
+        _     -> pure False
+
+-- | Pure builder for @SET GTID_NEXT=\'<gtid>\'@.
+buildSetGtidNextSql :: GtidEntry -> Either Text Text
+buildSetGtidNextSql gtid = do
+  rendered <- validateGtidRendering (renderGtidEntry gtid)
+  pure ("SET GTID_NEXT=" <> quoteSqlString rendered)
 
 -- | Inject an empty transaction for a given GTID (for errant GTID repair)
 injectEmptyTransaction :: MySQLConn -> GtidEntry -> IO ()
-injectEmptyTransaction conn gtid = do
-  _ <- execute_ conn (toQuery (BL.fromStrict (TE.encodeUtf8 ("SET GTID_NEXT='" <> renderGtidEntry gtid <> "'"))))
-  _ <- execute_ conn "BEGIN"
-  _ <- execute_ conn "COMMIT"
-  _ <- execute_ conn "SET GTID_NEXT='AUTOMATIC'"
-  pure ()
+injectEmptyTransaction conn gtid =
+  case buildSetGtidNextSql gtid of
+    Left err  -> throwIO (userError (T.unpack err))
+    Right sql -> do
+      _ <- execute_ conn (toQuery (BL.fromStrict (TE.encodeUtf8 sql)))
+      _ <- execute_ conn "BEGIN"
+      _ <- execute_ conn "COMMIT"
+      _ <- execute_ conn "SET GTID_NEXT='AUTOMATIC'"
+      pure ()
 
 -- | Wait until all GTIDs in Retrieved_Gtid_Set are applied (appear in Executed_Gtid_Set).
 -- Polls SHOW REPLICA STATUS at 1-second intervals.
@@ -323,35 +374,55 @@ checkClonePlugin conn = do
   rows <- consumeRows stream
   pure (not (null rows))
 
+-- | Pure builder for @SET GLOBAL clone_valid_donor_list = \'host:port\'@.
+buildSetCloneValidDonorListSql :: Text -> Int -> Either Text Text
+buildSetCloneValidDonorListSql donorHost donorPort = do
+  validHost <- validateIdentifierLike donorHost
+  let donor = validHost <> ":" <> T.pack (show donorPort)
+  pure ("SET GLOBAL clone_valid_donor_list = " <> quoteSqlString donor)
+
 -- | Set the clone_valid_donor_list system variable on the recipient.
 -- MySQL requires the donor host:port to be in this list before CLONE will proceed.
 setCloneValidDonorList :: MySQLConn -> Text -> Int -> IO ()
-setCloneValidDonorList conn donorHost donorPort = do
-  let sql = "SET GLOBAL clone_valid_donor_list = '"
-            <> donorHost <> ":" <> T.pack (show donorPort) <> "'"
-  _ <- execute_ conn (toQuery (BL.fromStrict (TE.encodeUtf8 sql)))
-  pure ()
+setCloneValidDonorList conn donorHost donorPort =
+  case buildSetCloneValidDonorListSql donorHost donorPort of
+    Left err  -> throwIO (userError (T.unpack err))
+    Right sql -> do
+      _ <- execute_ conn (toQuery (BL.fromStrict (TE.encodeUtf8 sql)))
+      pure ()
+
+-- | Pure builder for @CLONE INSTANCE FROM \'user\'@\'host\':port IDENTIFIED BY \'password\'@.
+buildCloneInstanceSql :: Text -> Int -> DbCredentials -> Either Text Text
+buildCloneInstanceSql donorHost donorPort DbCredentials{..} = do
+  validHost <- validateIdentifierLike donorHost
+  validUser <- validateIdentifierLike dbUser
+  pure $
+    "CLONE INSTANCE FROM " <> quoteSqlString validUser
+      <> "@" <> quoteSqlString validHost
+      <> ":" <> T.pack (show donorPort)
+      <> " IDENTIFIED BY " <> quoteSqlString dbPassword
 
 -- | Execute CLONE INSTANCE FROM on a recipient node connection.
 -- The recipient MySQL instance clones data from the specified donor.
 -- NOTE: The MySQL process restarts after cloning; the connection will be dropped.
 cloneInstanceFrom :: MySQLConn -> Text -> Int -> DbCredentials -> IO ()
-cloneInstanceFrom conn donorHost donorPort DbCredentials{..} = do
-  let sql = "CLONE INSTANCE FROM '" <> dbUser <> "'@'" <> donorHost <> "':"
-            <> T.pack (show donorPort) <> " IDENTIFIED BY '" <> dbPassword <> "'"
-  -- After a successful CLONE, MySQL restarts and closes the TCP connection.
-  -- mysql-haskell throws NetworkException (not IOException) on EOF (io-streams
-  -- returns Nothing). MySQL may also send ER_SERVER_SHUTDOWN (code 1053) as an
-  -- ERRException before restarting. Both indicate success. Re-throw any other
-  -- ERRException (wrong credentials, donor unreachable, etc.).
-  result <- try @SomeException $ execute_ conn (toQuery (BL.fromStrict (TE.encodeUtf8 sql)))
-  case result of
-    Right _ -> pure ()
-    Left e  ->
-      case fromException @ERRException e of
-        Just (ERRException err) | errCode err `elem` [1053, 3707] -> pure ()
-        Just _  -> throwIO e
-        Nothing -> pure ()
+cloneInstanceFrom conn donorHost donorPort creds =
+  case buildCloneInstanceSql donorHost donorPort creds of
+    Left err  -> throwIO (userError (T.unpack err))
+    Right sql -> do
+      -- After a successful CLONE, MySQL restarts and closes the TCP connection.
+      -- mysql-haskell throws NetworkException (not IOException) on EOF (io-streams
+      -- returns Nothing). MySQL may also send ER_SERVER_SHUTDOWN (code 1053) as an
+      -- ERRException before restarting. Both indicate success. Re-throw any other
+      -- ERRException (wrong credentials, donor unreachable, etc.).
+      result <- try @SomeException $ execute_ conn (toQuery (BL.fromStrict (TE.encodeUtf8 sql)))
+      case result of
+        Right _ -> pure ()
+        Left e  ->
+          case fromException @ERRException e of
+            Just (ERRException err) | errCode err `elem` [1053, 3707] -> pure ()
+            Just _  -> throwIO e
+            Nothing -> pure ()
 
 -- | A row from performance_schema.processlist
 data ProcessInfo = ProcessInfo

--- a/src/PureMyHA/MySQL/SqlEscape.hs
+++ b/src/PureMyHA/MySQL/SqlEscape.hs
@@ -1,0 +1,58 @@
+-- | Pure SQL literal escaping and whitelist validation helpers.
+--
+-- MySQL's 'CHANGE REPLICATION SOURCE TO' and 'CLONE INSTANCE FROM' statements
+-- do not support prepared statements, so any text embedded in those queries
+-- must be escaped at the application layer.
+module PureMyHA.MySQL.SqlEscape
+  ( escapeSqlString
+  , quoteSqlString
+  , validateIdentifierLike
+  , validateGtidRendering
+  ) where
+
+import Data.Char (isAlphaNum)
+import Data.Text (Text)
+import qualified Data.Text as T
+
+-- | Escape a 'Text' value for safe embedding inside a single-quoted SQL
+-- string literal. Doubles both @'@ and @\\@ so the result is safe regardless
+-- of whether @NO_BACKSLASH_ESCAPES@ is set on the server.
+escapeSqlString :: Text -> Text
+escapeSqlString = T.concatMap escapeChar
+  where
+    escapeChar '\'' = "''"
+    escapeChar '\\' = "\\\\"
+    escapeChar c    = T.singleton c
+
+-- | Wrap a value in single quotes with its contents escaped.
+-- E.g. @quoteSqlString "can't" == "'can''t'"@.
+quoteSqlString :: Text -> Text
+quoteSqlString t = "'" <> escapeSqlString t <> "'"
+
+-- | Whitelist validation for hostname- or username-shaped identifiers.
+--
+-- Accepts non-empty strings containing only @[A-Za-z0-9]@, @-@, @.@, or @_@.
+-- This covers DNS hostnames (RFC 1123 labels), IPv4 dotted-decimal literals,
+-- and typical MySQL account names. Any other character is rejected so that
+-- identifiers can be interpolated into DDL that does not support prepared
+-- statements without risk of SQL injection.
+validateIdentifierLike :: Text -> Either Text Text
+validateIdentifierLike t
+  | T.null t = Left "identifier must not be empty"
+  | T.all isAllowed t = Right t
+  | otherwise = Left ("identifier contains disallowed characters: " <> t)
+  where
+    isAllowed c = isAlphaNum c || c == '-' || c == '.' || c == '_'
+
+-- | Defence-in-depth validation for GTID-set renderings.
+--
+-- 'PureMyHA.MySQL.GTID.renderGtidSet' and 'renderGtidEntry' emit only
+-- alphanumeric characters plus @-@, @:@, @,@, and @_@ (the last for tagged
+-- GTIDs). This helper enforces that invariant at the embedding site so a
+-- future change to the renderer cannot silently introduce injection.
+validateGtidRendering :: Text -> Either Text Text
+validateGtidRendering t
+  | T.all isAllowed t = Right t
+  | otherwise = Left ("GTID rendering contains disallowed characters: " <> t)
+  where
+    isAllowed c = isAlphaNum c || c == '-' || c == ':' || c == ',' || c == '_'

--- a/test/PureMyHA/QuerySpec.hs
+++ b/test/PureMyHA/QuerySpec.hs
@@ -1,8 +1,33 @@
 module PureMyHA.QuerySpec (spec) where
 
+import Data.Either (isLeft)
+import qualified Data.Text as T
 import Test.Hspec
-import PureMyHA.Config (TLSConfig (..), TLSMode (..))
-import PureMyHA.MySQL.Query (needsPublicKeyRetrieval, ProcessInfo (..), isUserProcess)
+
+import PureMyHA.Config
+  ( DbCredentials (..)
+  , TLSConfig (..)
+  , TLSMode (..)
+  )
+import PureMyHA.MySQL.GTID
+  ( GtidEntry (..)
+  , GtidInterval (..)
+  , GtidUUID (..)
+  , TransactionId (..)
+  , unsafeGtidSet
+  )
+import PureMyHA.MySQL.Query
+  ( ProcessInfo (..)
+  , buildChangeReplicationSourceSql
+  , buildCloneInstanceSql
+  , buildGtidSubsetSql
+  , buildGtidSubtractSql
+  , buildSetCloneValidDonorListSql
+  , buildSetGtidNextSql
+  , isUserProcess
+  , needsPublicKeyRetrieval
+  , piId
+  )
 
 spec :: Spec
 spec = do
@@ -44,5 +69,93 @@ spec = do
     it "returns False when TLS mode is VerifyFull" $
       needsPublicKeyRetrieval (Just tls { tlsMode = TLSVerifyFull }) `shouldBe` False
 
+  describe "buildChangeReplicationSourceSql" $ do
+    it "builds the expected SQL for safe inputs without public-key option" $
+      buildChangeReplicationSourceSql "db1.example.com" 3306 (DbCredentials "repl" "secret") False
+        `shouldBe` Right
+          "CHANGE REPLICATION SOURCE TO SOURCE_HOST='db1.example.com'\
+          \, SOURCE_PORT=3306\
+          \, SOURCE_USER='repl'\
+          \, SOURCE_PASSWORD='secret'\
+          \, SOURCE_AUTO_POSITION=1"
+
+    it "appends GET_SOURCE_PUBLIC_KEY=1 when requested" $
+      case buildChangeReplicationSourceSql "db1" 3306 (DbCredentials "repl" "secret") True of
+        Right sql -> T.isSuffixOf ", GET_SOURCE_PUBLIC_KEY=1" sql `shouldBe` True
+        Left err  -> expectationFailure (T.unpack err)
+
+    it "escapes a single quote inside the password" $
+      case buildChangeReplicationSourceSql "db1" 3306 (DbCredentials "repl" "p'ass") False of
+        Right sql -> T.isInfixOf "SOURCE_PASSWORD='p''ass'" sql `shouldBe` True
+        Left err  -> expectationFailure (T.unpack err)
+
+    it "rejects a host containing a single quote" $
+      buildChangeReplicationSourceSql "db'; DROP USER 'x" 3306 (DbCredentials "repl" "p") False
+        `shouldSatisfy` isLeft
+
+    it "rejects a user containing whitespace" $
+      buildChangeReplicationSourceSql "db1" 3306 (DbCredentials "re pl" "p") False
+        `shouldSatisfy` isLeft
+
+  describe "buildCloneInstanceSql" $ do
+    it "builds the expected SQL for safe inputs" $
+      buildCloneInstanceSql "donor.example.com" 3306 (DbCredentials "clone_user" "secret")
+        `shouldBe` Right
+          "CLONE INSTANCE FROM 'clone_user'@'donor.example.com':3306 IDENTIFIED BY 'secret'"
+
+    it "escapes a single quote in the password" $
+      case buildCloneInstanceSql "donor" 3306 (DbCredentials "clone_user" "p'w") of
+        Right sql -> T.isSuffixOf "IDENTIFIED BY 'p''w'" sql `shouldBe` True
+        Left err  -> expectationFailure (T.unpack err)
+
+    it "rejects a donor host containing a single quote" $
+      buildCloneInstanceSql "donor'; --" 3306 (DbCredentials "u" "p") `shouldSatisfy` isLeft
+
+    it "rejects a user containing a semicolon" $
+      buildCloneInstanceSql "donor" 3306 (DbCredentials "u;DROP" "p") `shouldSatisfy` isLeft
+
+  describe "buildSetCloneValidDonorListSql" $ do
+    it "builds the expected SQL for a safe donor host" $
+      buildSetCloneValidDonorListSql "donor.example.com" 3306
+        `shouldBe` Right "SET GLOBAL clone_valid_donor_list = 'donor.example.com:3306'"
+
+    it "rejects a donor host containing a single quote" $
+      buildSetCloneValidDonorListSql "donor';--" 3306 `shouldSatisfy` isLeft
+
+  describe "buildGtidSubtractSql" $ do
+    it "builds the expected SQL for a rendered GTID set" $
+      buildGtidSubtractSql (unsafeGtidSet [sampleEntry])
+        `shouldBe` Right "SELECT GTID_SUBTRACT('aaaa-bbbb:1-5', @@GLOBAL.gtid_executed)"
+
+    it "rejects a GTID set whose rendering contains disallowed characters" $
+      buildGtidSubtractSql (unsafeGtidSet [taintedEntry]) `shouldSatisfy` isLeft
+
+  describe "buildGtidSubsetSql" $ do
+    it "builds the expected SQL for safe GTID set renderings" $
+      buildGtidSubsetSql (unsafeGtidSet [sampleEntry]) (unsafeGtidSet [sampleEntry])
+        `shouldBe` Right "SELECT GTID_SUBSET('aaaa-bbbb:1-5', 'aaaa-bbbb:1-5')"
+
+    it "rejects when either argument renders unsafe characters" $
+      buildGtidSubsetSql (unsafeGtidSet [sampleEntry]) (unsafeGtidSet [taintedEntry])
+        `shouldSatisfy` isLeft
+
+  describe "buildSetGtidNextSql" $ do
+    it "builds the expected SQL for a single GTID entry" $
+      buildSetGtidNextSql sampleEntry
+        `shouldBe` Right "SET GTID_NEXT='aaaa-bbbb:1-5'"
+
+    it "rejects an entry whose rendering contains disallowed characters" $
+      buildSetGtidNextSql taintedEntry `shouldSatisfy` isLeft
+
   where
     tls = TLSConfig TLSDisabled Nothing Nothing Nothing Nothing
+
+    sampleEntry =
+      GtidEntry (GtidUUID "aaaa-bbbb") Nothing
+        [GtidInterval (TransactionId 1) (TransactionId 5)]
+
+    -- Hypothetical tainted entry: simulates a renderer defect that emits an
+    -- illegal character. validateGtidRendering must reject it.
+    taintedEntry =
+      GtidEntry (GtidUUID "aaaa' OR '1'='1") Nothing
+        [GtidInterval (TransactionId 1) (TransactionId 1)]

--- a/test/PureMyHA/SqlEscapeSpec.hs
+++ b/test/PureMyHA/SqlEscapeSpec.hs
@@ -1,0 +1,111 @@
+module PureMyHA.SqlEscapeSpec (spec) where
+
+import Data.Either (isLeft, isRight)
+import qualified Data.Text as T
+import Test.Hspec
+import Test.QuickCheck
+
+import PureMyHA.MySQL.SqlEscape
+  ( escapeSqlString
+  , quoteSqlString
+  , validateIdentifierLike
+  , validateGtidRendering
+  )
+
+spec :: Spec
+spec = do
+  describe "escapeSqlString" $ do
+    it "doubles a single quote" $
+      escapeSqlString "can't" `shouldBe` "can''t"
+
+    it "doubles a backslash" $
+      escapeSqlString "a\\b" `shouldBe` "a\\\\b"
+
+    it "leaves safe text untouched" $
+      escapeSqlString "hello world" `shouldBe` "hello world"
+
+    it "escapes multiple quotes" $
+      escapeSqlString "a'b'c" `shouldBe` "a''b''c"
+
+    it "escapes an empty string to an empty string" $
+      escapeSqlString "" `shouldBe` ""
+
+    it "property: every run of quotes has even length" $
+      property $ \s ->
+        let escaped = escapeSqlString (T.pack s)
+            runs = T.split (/= '\'') escaped
+        in all ((== 0) . (`mod` 2) . T.length) runs
+
+    it "property: every run of backslashes has even length" $
+      property $ \s ->
+        let escaped = escapeSqlString (T.pack s)
+            runs = T.split (/= '\\') escaped
+        in all ((== 0) . (`mod` 2) . T.length) runs
+
+  describe "quoteSqlString" $ do
+    it "wraps a plain string in single quotes" $
+      quoteSqlString "repl" `shouldBe` "'repl'"
+
+    it "wraps and escapes a single quote" $
+      quoteSqlString "p'ass" `shouldBe` "'p''ass'"
+
+    it "wraps an empty string as empty quotes" $
+      quoteSqlString "" `shouldBe` "''"
+
+    it "property: starts and ends with a single quote" $
+      property $ \s ->
+        let q = quoteSqlString (T.pack s)
+        in T.head q == '\'' && T.last q == '\''
+
+  describe "validateIdentifierLike" $ do
+    it "accepts a DNS hostname" $
+      validateIdentifierLike "db1.example.com" `shouldSatisfy` isRight
+
+    it "accepts an IPv4 literal" $
+      validateIdentifierLike "10.0.0.1" `shouldSatisfy` isRight
+
+    it "accepts a typical MySQL user name" $
+      validateIdentifierLike "puremyha" `shouldSatisfy` isRight
+
+    it "accepts underscore and hyphen" $
+      validateIdentifierLike "user_1-a" `shouldSatisfy` isRight
+
+    it "rejects empty input" $
+      validateIdentifierLike "" `shouldSatisfy` isLeft
+
+    it "rejects a single quote" $
+      validateIdentifierLike "db'; DROP" `shouldSatisfy` isLeft
+
+    it "rejects whitespace" $
+      validateIdentifierLike "a b" `shouldSatisfy` isLeft
+
+    it "rejects a semicolon" $
+      validateIdentifierLike "a;b" `shouldSatisfy` isLeft
+
+    it "rejects a parenthesis" $
+      validateIdentifierLike "a)b" `shouldSatisfy` isLeft
+
+    it "returns the input unchanged on success" $
+      validateIdentifierLike "db1" `shouldBe` Right "db1"
+
+  describe "validateGtidRendering" $ do
+    it "accepts a well-formed GTID set rendering" $
+      validateGtidRendering "aaaa-bbbb:1-5,cccc:7" `shouldSatisfy` isRight
+
+    it "accepts a tagged GTID rendering" $
+      validateGtidRendering "3e11fa47-71ca-11e1-9e33-c80aa9429562:myTag:1-5" `shouldSatisfy` isRight
+
+    it "accepts the empty rendering" $
+      validateGtidRendering "" `shouldSatisfy` isRight
+
+    it "rejects an input containing a single quote" $
+      validateGtidRendering "abc'; DROP" `shouldSatisfy` isLeft
+
+    it "rejects an input containing whitespace" $
+      validateGtidRendering "abc def" `shouldSatisfy` isLeft
+
+    it "rejects an input containing a semicolon" $
+      validateGtidRendering "abc;def" `shouldSatisfy` isLeft
+
+    it "returns the input unchanged on success" $
+      validateGtidRendering "aaaa:1" `shouldBe` Right "aaaa:1"


### PR DESCRIPTION
## Summary
- Fixes the SQL injection reported in #178: six functions in `src/PureMyHA/MySQL/Query.hs` were concatenating operator-supplied values (hostnames, DB usernames, passwords, GTID renderings) directly into DDL that does not support prepared statements, so a single quote in a password was sufficient to execute arbitrary privileged SQL.
- Adds a pure `PureMyHA.MySQL.SqlEscape` module with `escapeSqlString` / `quoteSqlString` (doubles `'` and `\`), `validateIdentifierLike` (whitelist for hostnames and usernames), and `validateGtidRendering` (defence-in-depth for GTID-set renderings).
- Extracts each affected query to a pure `build*Sql :: ... -> Either Text Text` function and rewrites the IO wrappers to `throwIO` on validation failure. Public IO function signatures are unchanged, so no caller edits were needed.

## Test plan
- [x] `cabal build all` under `-Wall -Werror`
- [x] `cabal test` — 538 examples, 0 failures (prior baseline + new `SqlEscapeSpec` and `build*Sql` unit tests including QuickCheck properties)
- [x] `buildChangeReplicationSourceSql` with a password containing `'` produces `SOURCE_PASSWORD='p''ass'` and with a hostname containing `'`/`;`/space returns `Left`
- [x] `buildCloneInstanceSql` / `buildSetCloneValidDonorListSql` / `buildGtidSubtractSql` / `buildGtidSubsetSql` / `buildSetGtidNextSql` likewise escape or reject injected values
- [ ] Run the full E2E suite (failover / switchover / clone) on a developer MySQL 8.4 cluster to confirm the unchanged IO behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)