### PR TITLE
Release failover lock on exceptions via withFailoverLock

### DIFF
--- a/src/PureMyHA/Failover/Auto.hs
+++ b/src/PureMyHA/Failover/Auto.hs
@@ -11,7 +11,7 @@ import Control.Concurrent.STM
 import Control.Monad (forM_, void)
 import Control.Monad.Except (ExceptT (..), runExceptT)
 import Control.Monad.IO.Class (liftIO)
-import Control.Monad.Reader (asks)
+import Control.Monad.Reader (ask, asks, runReaderT)
 import Control.Monad.Trans.Class (lift)
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as Map
@@ -77,17 +77,17 @@ simulateFailover = do
                 , "All eligible candidates (ranked):"
                 ] ++ candLines
 
--- | Execute automatic failover for a cluster
+-- | Execute automatic failover for a cluster. The failover lock is released
+-- on every exit path from 'doFailover' (including synchronous and asynchronous
+-- exceptions) via 'withFailoverLock'.
 runAutoFailover :: App (Either Text ())
 runAutoFailover = do
-  FailoverLock lock <- asks envLock
-  acquired <- liftIO $ atomically $ tryTakeTMVar lock
-  case acquired of
-    Nothing -> pure (Left "Failover already in progress")
-    Just () -> do
-      result <- doFailover
-      liftIO $ atomically $ putTMVar lock ()
-      pure result
+  env  <- ask
+  lock <- asks envLock
+  mResult <- liftIO $ withFailoverLock lock (runReaderT doFailover env)
+  pure $ case mResult of
+    Nothing -> Left "Failover already in progress"
+    Just r  -> r
 
 -- | Check preconditions for auto failover (pure)
 checkAutoFailoverPreconditions
@@ -256,16 +256,16 @@ reconnectReplica newSourceId ns = do
     startReplica conn
 
 -- | Entry point for auto-fence on SplitBrainSuspected.
--- Reuses envLock to prevent concurrent fence/failover operations.
+-- Reuses envLock to prevent concurrent fence/failover operations. The lock is
+-- released on every exit path from 'doAutoFence' via 'withFailoverLock'.
 runAutoFence :: App ()
 runAutoFence = do
-  FailoverLock lock <- asks envLock
-  acquired <- liftIO $ atomically $ tryTakeTMVar lock
-  case acquired of
+  env  <- ask
+  lock <- asks envLock
+  mResult <- liftIO $ withFailoverLock lock (runReaderT doAutoFence env)
+  case mResult of
     Nothing -> appLogInfo "Auto-fence skipped: failover/fence operation already in progress"
-    Just () -> do
-      doAutoFence
-      liftIO $ atomically $ putTMVar lock ()
+    Just () -> pure ()
 
 -- | Fence all source-role nodes except the one with the highest GTID count.
 doAutoFence :: App ()

--- a/src/PureMyHA/Topology/State.hs
+++ b/src/PureMyHA/Topology/State.hs
@@ -9,9 +9,11 @@ module PureMyHA.Topology.State
   , FailoverLock (..)
   , newFailoverLock
   , acquireFailoverLock
+  , withFailoverLock
   ) where
 
 import Control.Concurrent.STM
+import qualified Control.Exception as E
 import qualified Data.Map.Strict as Map
 import PureMyHA.Types
 
@@ -81,3 +83,19 @@ acquireFailoverLock :: FailoverLock -> STM Bool
 acquireFailoverLock (FailoverLock lock) = do
   mt <- tryTakeTMVar lock
   pure (mt /= Nothing)
+
+-- | Run an action while holding the failover lock. Returns @Nothing@ if the
+-- lock is already held by another thread (the action is not run). Otherwise
+-- runs the action and guarantees the lock is released on every exit path,
+-- including synchronous exceptions from the action and asynchronous
+-- exceptions delivered while the action is running.
+withFailoverLock :: FailoverLock -> IO a -> IO (Maybe a)
+withFailoverLock (FailoverLock lock) action =
+  E.mask $ \restore -> do
+    acquired <- atomically (tryTakeTMVar lock)
+    case acquired of
+      Nothing -> pure Nothing
+      Just () -> do
+        r <- restore action `E.onException` atomically (putTMVar lock ())
+        atomically (putTMVar lock ())
+        pure (Just r)

--- a/test/PureMyHA/AutoSpec.hs
+++ b/test/PureMyHA/AutoSpec.hs
@@ -1,6 +1,7 @@
 module PureMyHA.AutoSpec (spec) where
 
 import Control.Concurrent.STM (atomically)
+import Control.Monad (void)
 import Data.Either (isLeft)
 import qualified Data.Map.Strict as Map
 import qualified Data.Text as T
@@ -13,11 +14,11 @@ import PureMyHA.Config
   , PositiveDuration (..), AtLeastOne (..)
   , AutoFailoverMode (..), FenceMode (..), ObservedHealthyRequirement (..)
   )
-import PureMyHA.Env (runApp)
-import PureMyHA.Failover.Auto (checkAutoFailoverPreconditions, simulateFailover)
+import PureMyHA.Env (ClusterEnv (..), runApp)
+import PureMyHA.Failover.Auto (checkAutoFailoverPreconditions, runAutoFailover, simulateFailover)
 import PureMyHA.Failover.Candidate (selectSurvivor)
 import PureMyHA.Topology.Discovery (buildClusterTopology)
-import PureMyHA.Topology.State (newDaemonState, updateClusterTopology)
+import PureMyHA.Topology.State (acquireFailoverLock, newDaemonState, updateClusterTopology)
 import PureMyHA.Types
 import Data.List.NonEmpty (NonEmpty ((:|)))
 
@@ -158,6 +159,26 @@ spec = do
           msg `shouldSatisfy` T.isInfixOf "Would promote"
           msg `shouldSatisfy` T.isInfixOf "paused"
         Left err -> expectationFailure (show err)
+
+  describe "runAutoFailover lock handling" $ do
+
+    it "releases the failover lock after doFailover returns Left (cluster not found)" $ do
+      tvar <- newDaemonState
+      env  <- mkTestEnv tvar testCC testFC
+      -- doFailover returns Left "Cluster not found" because nothing was seeded
+      result <- runApp env runAutoFailover
+      result `shouldBe` Left "Cluster not found"
+      -- Lock must be free again after the inner action has returned
+      acquiredAfter <- atomically $ acquireFailoverLock (envLock env)
+      acquiredAfter `shouldBe` True
+
+    it "rejects concurrent invocations while the lock is held" $ do
+      tvar <- newDaemonState
+      env  <- mkTestEnv tvar testCC testFC
+      -- Simulate another operation currently holding the lock
+      void $ atomically $ acquireFailoverLock (envLock env)
+      result <- runApp env runAutoFailover
+      result `shouldBe` Left "Failover already in progress"
 
 testCC :: ClusterConfig
 testCC = ClusterConfig

--- a/test/PureMyHA/StateSpec.hs
+++ b/test/PureMyHA/StateSpec.hs
@@ -1,7 +1,9 @@
 module PureMyHA.StateSpec (spec) where
 
 import Control.Concurrent.STM
+import Control.Exception (ErrorCall (..), try, throwIO)
 import Control.Monad (void)
+import Data.IORef (newIORef, readIORef, writeIORef)
 import Data.Maybe (isNothing)
 import qualified Data.Map.Strict as Map
 import Test.Hspec
@@ -114,3 +116,29 @@ spec = do
       void $ atomically $ acquireFailoverLock lock
       result <- atomically $ acquireFailoverLock lock
       result `shouldBe` False
+
+  describe "withFailoverLock" $ do
+    it "returns Just and releases the lock on normal return" $ do
+      lock   <- newFailoverLock
+      result <- withFailoverLock lock (pure ("ok" :: String))
+      result `shouldBe` Just "ok"
+      acquiredAfter <- atomically $ acquireFailoverLock lock
+      acquiredAfter `shouldBe` True
+
+    it "releases the lock even when the inner action throws" $ do
+      lock <- newFailoverLock
+      e <- try (withFailoverLock lock (throwIO (ErrorCall "boom") :: IO Int))
+      case e of
+        Left (ErrorCall msg) -> msg `shouldBe` "boom"
+        Right _              -> expectationFailure "expected exception to propagate"
+      acquiredAfter <- atomically $ acquireFailoverLock lock
+      acquiredAfter `shouldBe` True
+
+    it "returns Nothing and does not run the action when already held" $ do
+      lock <- newFailoverLock
+      void $ atomically $ acquireFailoverLock lock
+      ran  <- newIORef False
+      result <- withFailoverLock lock (writeIORef ran True >> pure ())
+      result `shouldBe` Nothing
+      wasRun <- readIORef ran
+      wasRun `shouldBe` False


### PR DESCRIPTION
## Summary
- Fixes #179: `runAutoFailover` and `runAutoFence` could leave the failover `TMVar` permanently held when `doFailover` / `doAutoFence` threw, silently disabling auto-failover and auto-fence for that cluster until daemon restart.
- Adds `withFailoverLock :: FailoverLock -> IO a -> IO (Maybe a)` in `PureMyHA.Topology.State`, using `mask` + `onException` to guarantee release on every exit path (normal, synchronous exception, async exception). `Nothing` now encodes "already held" in the type instead of a magic string.
- Rewrites both `runAutoFailover` and `runAutoFence` to delegate locking to this helper. The inner `doFailover` / `doAutoFence` logic is unchanged.
- No new dependencies (uses `Control.Exception` from `base`).

## Test plan
- [x] `cabal build all` succeeds (library + both executables).
- [x] `cabal test puremyha-test` passes — 543 examples, 0 failures.
- [x] New unit tests in `test/PureMyHA/StateSpec.hs`:
  - `withFailoverLock` returns `Just` and releases the lock on normal return.
  - `withFailoverLock` releases the lock even when the inner action throws.
  - `withFailoverLock` returns `Nothing` and does not run the action when already held.
- [x] New integration tests in `test/PureMyHA/AutoSpec.hs`:
  - `runAutoFailover` releases the lock after returning `Left "Cluster not found"`.
  - `runAutoFailover` rejects concurrent invocations while the lock is held.
- [ ] Run existing E2E suite (`e2e/tests/02-auto-failover.sh`, `e2e/tests/03-network-partition.sh`) in an environment with Docker to confirm no behavioural regression for the happy path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)