### PR TITLE
Redact DbCredentials password in Show instance (#181)

### DIFF
--- a/src/PureMyHA/Config.hs
+++ b/src/PureMyHA/Config.hs
@@ -166,12 +166,22 @@ data RawClusterConfig = RawClusterConfig
 data DbCredentials = DbCredentials
   { dbUser     :: Text
   , dbPassword :: Text
-  } deriving (Show)
+  }
+
+-- | Hand-written 'Show' instance that redacts 'dbPassword'. Prevents
+-- accidental leakage of cleartext DB passwords via logs or exception messages.
+instance Show DbCredentials where
+  show c = "DbCredentials {dbUser = " ++ show (dbUser c)
+        ++ ", dbPassword = <redacted>}"
 
 data ClusterPasswords = ClusterPasswords
   { cpMonCredentials  :: DbCredentials  -- ^ monitoring/management credentials
   , cpReplCredentials :: DbCredentials  -- ^ replication credentials
-  } deriving (Show)
+  }
+
+instance Show ClusterPasswords where
+  show cp = "ClusterPasswords {cpMonCredentials = " ++ show (cpMonCredentials cp)
+         ++ ", cpReplCredentials = " ++ show (cpReplCredentials cp) ++ "}"
 
 data NodeConfig = NodeConfig
   { ncHost :: Text

--- a/test/PureMyHA/ConfigSpec.hs
+++ b/test/PureMyHA/ConfigSpec.hs
@@ -19,6 +19,7 @@ import PureMyHA.Config
   , defaultLoggingConfig, defaultHttpConfig
   , TLSMode (..), TLSMinVersion (..), TLSConfig (..)
   , NodeConfig (..), Credentials (..)
+  , DbCredentials (..), ClusterPasswords (..)
   , Port (..), PositiveDuration (..), AtLeastOne (..)
   , AutoFailoverMode (..), FenceMode (..), ObservedHealthyRequirement (..)
   )
@@ -962,6 +963,26 @@ spec = do
     it "returns Left for a non-existent file" $ do
       result <- loadConfig "/nonexistent/path/puremyha-test.yaml"
       result `shouldSatisfy` isLeft
+
+  describe "DbCredentials Show instance (no password leak)" $ do
+    let creds = DbCredentials "alice" "s3cret!"
+    it "does not include the plaintext password" $
+      show creds `shouldNotContain` "s3cret!"
+    it "displays the user name" $
+      show creds `shouldContain` "alice"
+    it "includes a redaction marker" $
+      show creds `shouldContain` "<redacted>"
+
+  describe "ClusterPasswords Show instance (no password leak)" $ do
+    let cp = ClusterPasswords
+              (DbCredentials "mon"  "monPass123")
+              (DbCredentials "repl" "replPass456")
+    it "does not leak monitoring password" $
+      show cp `shouldNotContain` "monPass123"
+    it "does not leak replication password" $
+      show cp `shouldNotContain` "replPass456"
+    it "still shows structure for debugging" $
+      show cp `shouldContain` "ClusterPasswords"
 
 -- | A minimal valid ClusterConfig for direct validateConfig testing
 minimalCluster :: ClusterConfig


### PR DESCRIPTION
## Summary
- Replace derived `Show` on `DbCredentials` and `ClusterPasswords` with hand-written instances that mask `dbPassword` as `<redacted>`
- Prevents cleartext DB passwords from leaking through exception messages, debug logs, or future `show` calls
- Adds 6 unit tests in `ConfigSpec` verifying the redaction and that non-sensitive fields (user name, record structure) remain visible

## Test plan
- [x] `cabal build all` passes with `-Werror`
- [x] `cabal test` passes (544/544, including 6 new redaction tests)
- [x] TDD verified: new tests failed against the old derived `Show`, pass with the hand-written instances

Closes #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)