### PR TITLE
Reject pause/resume on cluster source with stale nsRole

### DIFF
--- a/src/PureMyHA/Failover/PauseReplica.hs
+++ b/src/PureMyHA/Failover/PauseReplica.hs
@@ -68,7 +68,8 @@ withTargetNodeNoMySQL actionName targetHost mkEvent = do
       case findNodeByHost targetHost (ctNodes topo) of
         Nothing -> pure (Left $ "Node not found: " <> unHostName targetHost)
         Just targetNs
-          | isSource targetNs -> pure (Left $ sourceRejectionMsg actionName targetHost)
+          | isClusterSource topo targetNs ->
+              pure (Left $ sourceRejectionMsg actionName targetHost)
           | otherwise -> do
               liftIO $ atomically $ writeTBQueue queue (mkEvent (nsNodeId targetNs))
               appLogInfo $ "[" <> unClusterName (ccName cc) <> "] " <> actionName <> " replica " <> unHostName targetHost
@@ -94,7 +95,8 @@ withTargetNode actionName targetHost mysqlAction mkEvent = do
       case findNodeByHost targetHost (ctNodes topo) of
         Nothing -> pure (Left $ "Node not found: " <> unHostName targetHost)
         Just targetNs
-          | isSource targetNs -> pure (Left $ sourceRejectionMsg actionName targetHost)
+          | isClusterSource topo targetNs ->
+              pure (Left $ sourceRejectionMsg actionName targetHost)
           | otherwise -> do
               let ci = makeConnectInfo (nsNodeId targetNs) creds
               appLogInfo $ "[" <> unClusterName (ccName cc) <> "] " <> actionName <> " replication on " <> unHostName targetHost
@@ -112,6 +114,18 @@ withTargetNode actionName targetHost mysqlAction mkEvent = do
       "Stopping" -> "stopped"
       "Starting" -> "started"
       other      -> other
+
+-- | Cluster-source check that reconciles per-node and cluster-level views.
+-- Treats a node as source if either its own nsRole is Source or the
+-- cluster-level ctSourceNodeId points at it. During the window after a
+-- failover + cluster reset, identifySource's fallback can restore
+-- ctSourceNodeId to the pre-failover source before that node's own
+-- NodeProbed event refreshes its nsRole from stale Replica to Source.
+-- Checking ctSourceNodeId in addition to nsRole makes pause/resume
+-- rejection agree with what CLI status reports as sourceHost.
+isClusterSource :: ClusterTopology -> NodeState -> Bool
+isClusterSource topo ns =
+  isSource ns || ctSourceNodeId topo == Just (nsNodeId ns)
 
 -- | Build a rejection message for source nodes.
 sourceRejectionMsg :: Text -> HostName -> Text

--- a/test/PureMyHA/PauseReplicaSpec.hs
+++ b/test/PureMyHA/PauseReplicaSpec.hs
@@ -1,6 +1,7 @@
 module PureMyHA.PauseReplicaSpec (spec) where
 
 import Control.Concurrent.STM (atomically)
+import qualified Data.Map.Strict as Map
 import qualified Data.Text as T
 import Test.Hspec
 import Fixtures
@@ -17,6 +18,7 @@ import PureMyHA.Failover.PauseReplica
   )
 import PureMyHA.Topology.Discovery (buildClusterTopology)
 import PureMyHA.Topology.State (newDaemonState, updateClusterTopology)
+import PureMyHA.Types (ClusterTopology (..), NodeState (..), NodeRole (..), nsNodeId)
 import Data.List.NonEmpty (NonEmpty ((:|)))
 
 spec :: Spec
@@ -60,6 +62,33 @@ spec = do
       result <- runApp env $ runStartReplication "db1"
       result `shouldSatisfy` isSourceRejection
 
+  -- Race scenario: ctSourceNodeId has already been restored to point at db1
+  -- (via identifySource's fallback, which scans replicas' source refs) but
+  -- db1's own nsRole is still stale Replica from a prior failover demote.
+  -- CLI status reports sourceHost=db1, so wait_for_source succeeds — yet a
+  -- check based solely on nsRole would erroneously accept pause/resume on
+  -- the cluster source.
+  describe "cluster-source rejection when nsRole is stale but ctSourceNodeId matches" $ do
+    it "runPauseReplica rejects" $ do
+      env <- setupRaceEnv
+      result <- runApp env $ runPauseReplica "db1"
+      result `shouldSatisfy` isSourceRejection
+
+    it "runResumeReplica rejects" $ do
+      env <- setupRaceEnv
+      result <- runApp env $ runResumeReplica "db1"
+      result `shouldSatisfy` isSourceRejection
+
+    it "runStopReplication rejects" $ do
+      env <- setupRaceEnv
+      result <- runApp env $ runStopReplication "db1"
+      result `shouldSatisfy` isSourceRejection
+
+    it "runStartReplication rejects" $ do
+      env <- setupRaceEnv
+      result <- runApp env $ runStartReplication "db1"
+      result `shouldSatisfy` isSourceRejection
+
 -- | Check that the result is a Left containing source rejection message
 isSourceRejection :: Either T.Text () -> Bool
 isSourceRejection (Left msg) = "source" `T.isInfixOf` T.toLower msg
@@ -69,6 +98,20 @@ setupEnv :: IO ClusterEnv
 setupEnv = do
   tvar <- newDaemonState
   let topo = buildClusterTopology 1 "main" clusterHealthy
+  atomically $ updateClusterTopology tvar topo
+  mkTestEnv tvar testCC testFC
+
+-- | Build a topology that reproduces the race: ctSourceNodeId points at db1
+-- (as identifySource's fallback would restore after a reset), but db1's own
+-- nsRole is stale Replica because its NodeProbed event has not yet been
+-- applied.
+setupRaceEnv :: IO ClusterEnv
+setupRaceEnv = do
+  tvar <- newDaemonState
+  let base   = buildClusterTopology 1 "main" clusterHealthy
+      db1Id  = nsNodeId healthySource
+      topo   = base
+        { ctNodes = Map.adjust (\ns -> ns { nsRole = Replica }) db1Id (ctNodes base) }
   atomically $ updateClusterTopology tvar topo
   mkTestEnv tvar testCC testFC
 


### PR DESCRIPTION
## Summary
- Fix a race in `runPauseReplica` / `runResumeReplica` / `runStopReplication` / `runStartReplication` where the cluster source could be accepted by these operations for a brief window after a failover + cluster reset
- After failover the demoted source's `nsRole` is `Replica`. When `reset_cluster` re-points replicas at the original source and those replicas are re-probed first, `identifySource`'s fallback path restores `ctSourceNodeId` to the pre-failover source while `nsRole` stays stale until that node's own `NodeProbed` event fires
- During that window CLI status reports `sourceHost=db1` (so `wait_for_source` passes) but `isSource` alone read the stale `nsRole=Replica` and let pause/resume succeed on the cluster source
- Introduce `isClusterSource topo ns = isSource ns || ctSourceNodeId topo == Just (nsNodeId ns)`, so rejection matches the `sourceHost` CLI status exposes. Apply to both the no-MySQL (pause/resume) and with-MySQL (start/stop-replication) code paths
- Explains the x86_64-only flake in `e2e/tests/08-pause-resume-replica.sh` ("FAIL: pause-replica on source returns error (was empty)")

## Test plan
- [x] `cabal build all` passes with `-Werror`
- [x] `cabal test` passes (547/547, including 4 new race-scenario tests)
- [x] TDD verified: new tests failed before the fix, pass after
- [ ] CI on x86_64 runs `08-pause-resume-replica.sh` to confirm the flake is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)