### PR TITLE
Validate hook scripts and bound their runtime

### DIFF
--- a/config/config.yaml.example
+++ b/config/config.yaml.example
@@ -62,6 +62,12 @@ global:
                                                # same AZ and can fail simultaneously (e.g. AZ outage).
                                                # Default: false. See docs/failover.md for tradeoffs.
   hooks:
+    # Each configured hook script must, at invocation time, be an absolute
+    # path, a regular file (not a symlink or directory), owned by root or the
+    # user running puremyhad, and must NOT have the world-writable bit set
+    # (mode & 0o002 == 0). Hooks failing any check are refused; for pre-hooks
+    # this aborts the failover/switchover. Recommended: chown root:root and
+    # chmod 0755 on every hook script.
     pre_failover: /etc/puremyha/hooks/pre_failover.sh
     post_failover: /etc/puremyha/hooks/post_failover.sh
     pre_switchover: /etc/puremyha/hooks/pre_switchover.sh
@@ -77,6 +83,7 @@ global:
     on_topology_drift: /etc/puremyha/hooks/on_topology_drift.sh                    # optional; fired on transition to topology drift state (False→True only)
                                                                                     # Env: PUREMYHA_CLUSTER, PUREMYHA_DRIFT_TYPE (missing_node|unexpected_node|replica_count_below_threshold),
                                                                                     #      PUREMYHA_DRIFT_DETAILS, PUREMYHA_TIMESTAMP
+    hook_timeout: 30s                                                              # max wall-clock time per hook; process group is SIGTERM'd then SIGKILL'd on overrun. Default: 30s
 
 logging:                               # optional logging configuration
   log_file: /var/log/puremyha.log    # default: /var/log/puremyha.log

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -56,6 +56,38 @@ See [`config/config.yaml.example`](../config/config.yaml.example) for the comple
 
 The `logging` section is optional and global (defaults to `/var/log/puremyha.log` and `log_level: info` when omitted).
 
+## Hooks
+
+Shell scripts invoked at key lifecycle events. See [docs/features.md](features.md#hooks) for the full list of hooks.
+
+### Security requirements
+
+`puremyhad` typically runs as root, so every configured hook script is validated each time it is about to be executed. A hook is refused if any of these checks fail:
+
+- **Absolute path** — relative paths are rejected.
+- **Regular file** — symlinks, directories, and device files are rejected. Symlinks are explicitly disallowed to prevent TOCTOU swaps after config load.
+- **Trusted owner** — the file's owner UID must be 0 (root) or the UID running `puremyhad`.
+- **Not world-writable** — `mode & 0o002` must be zero.
+
+The recommended install is `chown root:root` and `chmod 0755` for every hook script, living in a directory that is itself not world-writable.
+
+A rejected `pre_failover` or `pre_switchover` hook aborts the operation (because the operator explicitly opted into a pre-check that cannot be trusted). A rejected fire-and-forget hook is logged and skipped; the surrounding operation continues.
+
+### `hook_timeout`
+
+```yaml
+hooks:
+  hook_timeout: 30s   # default: 30s
+```
+
+Maximum wall-clock time for any single hook invocation. On overrun the daemon:
+
+1. sends `SIGTERM` to the hook's process group (the child is started as a new group leader so any subprocesses it forked are included),
+2. waits up to 2 seconds for the group to exit,
+3. sends `SIGKILL` to the group, reaps the child, and returns an error.
+
+This prevents a stuck pre-hook from indefinitely blocking failover and prevents fire-and-forget hooks from leaking processes.
+
 ## TLS
 
 PureMyHA supports optional TLS for MySQL connections on a per-cluster basis via the `tls:` key.

--- a/docs/features.md
+++ b/docs/features.md
@@ -138,6 +138,15 @@ Shell hooks are called at key lifecycle events. All hooks receive cluster and no
 | `on_lag_threshold_exceeded` | Replica crosses `replication_lag_critical` — provides `PUREMYHA_NODE` (replica hostname) and `PUREMYHA_LAG_SECONDS` |
 | `on_lag_threshold_recovered` | Replica recovers below `replication_lag_critical` — provides `PUREMYHA_NODE` (replica hostname) |
 
+**Security requirements.** Because `puremyhad` typically runs as root, every configured hook script is validated immediately before execution. A hook is refused unless all of the following hold:
+
+- the configured path is absolute,
+- the path resolves to a regular file (symlinks and directories are rejected, to prevent TOCTOU swap),
+- the file is owned by root or by the user running `puremyhad`,
+- the file is not world-writable (`mode & 0o002 == 0`).
+
+A rejected `pre_failover` or `pre_switchover` hook aborts the operation; a rejected fire-and-forget hook is skipped. Every hook invocation is also bounded by `hook_timeout` (default 30s): on overrun the process group is sent `SIGTERM`, and `SIGKILL` after a short grace period, so a stuck hook cannot indefinitely block a failover.
+
 See [docs/configuration.md](configuration.md) for hook configuration syntax.
 
 ### Optional TLS

--- a/e2e/Dockerfile.e2e
+++ b/e2e/Dockerfile.e2e
@@ -34,4 +34,11 @@ RUN apt-get update && \
 COPY --from=selected /staging/puremyhad /usr/sbin/puremyhad
 COPY --from=selected /staging/puremyha  /usr/bin/puremyha
 
+# Hook scripts are baked into the image with root ownership so that the
+# daemon's runtime validator (which rejects files not owned by root or the
+# daemon user) accepts them. Bind-mounting hooks from the host would expose
+# them with the host user's UID, which the validator would reject.
+COPY --chown=root:root e2e/config/hooks /opt/puremyha/hooks
+RUN chmod 0755 /opt/puremyha/hooks/*.sh
+
 CMD ["puremyhad"]

--- a/e2e/config/puremyha-failover-without-observed-healthy.yaml
+++ b/e2e/config/puremyha-failover-without-observed-healthy.yaml
@@ -18,13 +18,13 @@ clusters:
         - host: mysql-replica1
       failover_without_observed_healthy: true
     hooks:
-      pre_failover: /etc/puremyha/hooks/pre_failover.sh
-      post_failover: /etc/puremyha/hooks/post_failover.sh
-      pre_switchover: /etc/puremyha/hooks/pre_switchover.sh
-      post_switchover: /etc/puremyha/hooks/post_switchover.sh
-      on_lag_threshold_exceeded: /etc/puremyha/hooks/on_lag_threshold_exceeded.sh
-      on_lag_threshold_recovered: /etc/puremyha/hooks/on_lag_threshold_recovered.sh
-      on_topology_drift: /etc/puremyha/hooks/on_topology_drift.sh
+      pre_failover: /opt/puremyha/hooks/pre_failover.sh
+      post_failover: /opt/puremyha/hooks/post_failover.sh
+      pre_switchover: /opt/puremyha/hooks/pre_switchover.sh
+      post_switchover: /opt/puremyha/hooks/post_switchover.sh
+      on_lag_threshold_exceeded: /opt/puremyha/hooks/on_lag_threshold_exceeded.sh
+      on_lag_threshold_recovered: /opt/puremyha/hooks/on_lag_threshold_recovered.sh
+      on_topology_drift: /opt/puremyha/hooks/on_topology_drift.sh
 
 http:
   enabled: true

--- a/e2e/config/puremyha-tls-skip-verify.yaml
+++ b/e2e/config/puremyha-tls-skip-verify.yaml
@@ -19,10 +19,10 @@ clusters:
       candidate_priority:
         - host: mysql-replica1
     hooks:
-      pre_failover: /etc/puremyha/hooks/pre_failover.sh
-      post_failover: /etc/puremyha/hooks/post_failover.sh
-      pre_switchover: /etc/puremyha/hooks/pre_switchover.sh
-      post_switchover: /etc/puremyha/hooks/post_switchover.sh
+      pre_failover: /opt/puremyha/hooks/pre_failover.sh
+      post_failover: /opt/puremyha/hooks/post_failover.sh
+      pre_switchover: /opt/puremyha/hooks/pre_switchover.sh
+      post_switchover: /opt/puremyha/hooks/post_switchover.sh
 
 http:
   enabled: true

--- a/e2e/config/puremyha-tls-verify-ca.yaml
+++ b/e2e/config/puremyha-tls-verify-ca.yaml
@@ -20,10 +20,10 @@ clusters:
       candidate_priority:
         - host: mysql-replica1
     hooks:
-      pre_failover: /etc/puremyha/hooks/pre_failover.sh
-      post_failover: /etc/puremyha/hooks/post_failover.sh
-      pre_switchover: /etc/puremyha/hooks/pre_switchover.sh
-      post_switchover: /etc/puremyha/hooks/post_switchover.sh
+      pre_failover: /opt/puremyha/hooks/pre_failover.sh
+      post_failover: /opt/puremyha/hooks/post_failover.sh
+      pre_switchover: /opt/puremyha/hooks/pre_switchover.sh
+      post_switchover: /opt/puremyha/hooks/post_switchover.sh
 
 http:
   enabled: true

--- a/e2e/config/puremyha.yaml
+++ b/e2e/config/puremyha.yaml
@@ -17,13 +17,13 @@ clusters:
       candidate_priority:
         - host: mysql-replica1
     hooks:
-      pre_failover: /etc/puremyha/hooks/pre_failover.sh
-      post_failover: /etc/puremyha/hooks/post_failover.sh
-      pre_switchover: /etc/puremyha/hooks/pre_switchover.sh
-      post_switchover: /etc/puremyha/hooks/post_switchover.sh
-      on_lag_threshold_exceeded: /etc/puremyha/hooks/on_lag_threshold_exceeded.sh
-      on_lag_threshold_recovered: /etc/puremyha/hooks/on_lag_threshold_recovered.sh
-      on_topology_drift: /etc/puremyha/hooks/on_topology_drift.sh
+      pre_failover: /opt/puremyha/hooks/pre_failover.sh
+      post_failover: /opt/puremyha/hooks/post_failover.sh
+      pre_switchover: /opt/puremyha/hooks/pre_switchover.sh
+      post_switchover: /opt/puremyha/hooks/post_switchover.sh
+      on_lag_threshold_exceeded: /opt/puremyha/hooks/on_lag_threshold_exceeded.sh
+      on_lag_threshold_recovered: /opt/puremyha/hooks/on_lag_threshold_recovered.sh
+      on_topology_drift: /opt/puremyha/hooks/on_topology_drift.sh
 
 http:
   enabled: true

--- a/e2e/tests/26-hook-security.sh
+++ b/e2e/tests/26-hook-security.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Test: Hook Security — world-writable rejection
+#
+# Verifies that puremyhad refuses to execute a hook script whose mode has the
+# world-writable bit set, even when the script is at an absolute path and
+# owned by root. A world-writable hook running as root is a trivial local-root
+# privilege escalation if an attacker can get file-write access, so the
+# daemon must refuse to run it and instead abort the failover.
+set -euo pipefail
+source "$(dirname "$0")/../lib/helpers.sh"
+echo "=== Test 26: Hook Security (world-writable rejection) ==="
+
+HOOK_PATH="/opt/puremyha/hooks/pre_failover.sh"
+
+# Restore mode at end to keep subsequent tests happy (the writable layer in
+# the puremyhad container persists between tests until `compose down`).
+restore_hook() {
+  $COMPOSE exec -T puremyhad chmod 0755 "$HOOK_PATH" 2>/dev/null || true
+}
+trap restore_hook EXIT
+
+wait_for_health "Healthy" 60
+
+# Clear any leftover markers from a prior test
+$COMPOSE exec -T puremyhad rm -f /tmp/hook_pre_failover.log /tmp/hook_post_failover.log 2>/dev/null || true
+
+# Confirm the hook is baked in as a regular root-owned script before we mutate it
+$COMPOSE exec -T puremyhad test -f "$HOOK_PATH"
+
+# Make the hook world-writable inside the container
+$COMPOSE exec -T puremyhad chmod 0666 "$HOOK_PATH"
+
+echo "  Stopping mysql-source to trigger failover with world-writable pre_failover..."
+$COMPOSE stop mysql-source
+
+# Give the daemon enough time to detect the dead source and attempt failover.
+# consecutive_failures_for_dead defaults to 3 × 1s probe interval + fast
+# detector cycles; 15s is comfortably above the worst case.
+sleep 15
+
+pre_hook=$($COMPOSE exec -T puremyhad cat /tmp/hook_pre_failover.log 2>/dev/null || echo "")
+post_hook=$($COMPOSE exec -T puremyhad cat /tmp/hook_post_failover.log 2>/dev/null || echo "")
+
+# pre_failover must have been rejected before execution
+if [ -z "$pre_hook" ]; then
+  echo "  PASS: pre_failover marker absent (hook was rejected)"
+  ((PASS_COUNT++)) || true
+else
+  echo "  FAIL: pre_failover still ran (marker: $pre_hook)"
+  ((FAIL_COUNT++)) || true
+fi
+
+# A rejected pre-hook must also prevent the promotion path from firing post_failover
+if [ -z "$post_hook" ]; then
+  echo "  PASS: post_failover marker absent (failover was aborted)"
+  ((PASS_COUNT++)) || true
+else
+  echo "  FAIL: post_failover ran despite pre-hook rejection (marker: $post_hook)"
+  ((FAIL_COUNT++)) || true
+fi
+
+# Daemon logs should mention the rejection reason
+daemon_log=$($COMPOSE logs puremyhad 2>&1 || echo "")
+assert_contains "Daemon log mentions world-writable rejection" "world-writable" "$daemon_log"
+
+test_summary

--- a/e2e/tests/26-hook-security.sh
+++ b/e2e/tests/26-hook-security.sh
@@ -59,8 +59,10 @@ else
   ((FAIL_COUNT++)) || true
 fi
 
-# Daemon logs should mention the rejection reason
-daemon_log=$($COMPOSE logs puremyhad 2>&1 || echo "")
+# Daemon logs should mention the rejection reason. The daemon writes its
+# structured log to the file configured in puremyha.yaml (not container
+# stdout), so we cat that file from inside the container.
+daemon_log=$($COMPOSE exec -T puremyhad cat /var/log/puremyha.log 2>/dev/null || echo "")
 assert_contains "Daemon log mentions world-writable rejection" "world-writable" "$daemon_log"
 
 test_summary

--- a/puremyha.cabal
+++ b/puremyha.cabal
@@ -32,7 +32,8 @@ common common-options
     exceptions       >= 0.10,
     stm              >= 2.5,
     async            >= 2.2,
-    process          >= 1.6
+    process          >= 1.6,
+    filepath         >= 1.4
 
 library
   import:          common-options
@@ -129,6 +130,7 @@ test-suite puremyha-test
     PureMyHA.CloneSpec
     PureMyHA.DemoteSpec
     PureMyHA.PauseReplicaSpec
+    PureMyHA.HookSpec
   build-depends:
     puremyha,
     async            >= 2.2,
@@ -145,6 +147,10 @@ test-suite puremyha-test
     wai              >= 3.2,
     http-types       >= 0.12,
     mysql-haskell    >= 1.2.3,
-    network          >= 3.1
+    network          >= 3.1,
+    temporary        >= 1.3,
+    unix             >= 2.7,
+    process          >= 1.6,
+    directory        >= 1.3
   build-tool-depends:
     hspec-discover:hspec-discover

--- a/src/PureMyHA/Config.hs
+++ b/src/PureMyHA/Config.hs
@@ -238,6 +238,7 @@ data HooksConfig = HooksConfig
   , hcOnLagThresholdExceeded      :: Maybe FilePath  -- ^ Fired when a replica transitions to Lagging health
   , hcOnLagThresholdRecovered     :: Maybe FilePath  -- ^ Fired when a replica recovers from Lagging health
   , hcOnTopologyDrift             :: Maybe FilePath  -- ^ Fired on transition to topology drift state
+  , hcTimeout                     :: PositiveDuration  -- ^ Max execution time per hook; the process group is killed on overrun (default 30s)
   } deriving (Show, Generic)
 
 -- | A strictly positive duration (> 0).
@@ -476,6 +477,7 @@ instance FromJSON HooksConfig where
       <*> o .:? "on_lag_threshold_exceeded"
       <*> o .:? "on_lag_threshold_recovered"
       <*> o .:? "on_topology_drift"
+      <*> o .:? "hook_timeout" .!= PositiveDuration 30
 
 loadConfig :: FilePath -> IO (Either String Config)
 loadConfig path = do

--- a/src/PureMyHA/Hook.hs
+++ b/src/PureMyHA/Hook.hs
@@ -6,17 +6,32 @@ module PureMyHA.Hook
   , getCurrentTimestamp
   , HookEnv (..)
   , SourceChange (..)
+  , HookRejection (..)
+  , HookScriptStat (..)
+  , validateHookScript
+  , validateHookScriptIO
+  , rejectionMessage
   ) where
 
+import Control.Concurrent (threadDelay)
 import Control.Concurrent.Async (async)
 import Control.Exception (try, SomeException)
 import Control.Monad (void)
+import Data.Bits ((.&.))
 import Data.Text (Text)
 import qualified Data.Text as T
-import Data.Time (getCurrentTime, formatTime, defaultTimeLocale)
+import Data.Time (NominalDiffTime, getCurrentTime, formatTime, defaultTimeLocale)
 import System.Exit (ExitCode (..))
-import System.Process (createProcess, proc, waitForProcess, env)
-import PureMyHA.Config (HooksConfig (..))
+import System.FilePath (isAbsolute)
+import qualified System.Posix.Files as PF
+import System.Posix.Signals (signalProcessGroup, sigKILL)
+import System.Posix.Types (FileMode, UserID)
+import qualified System.Posix.User as PU
+import System.Process
+  ( CreateProcess (..), ProcessHandle, createProcess, proc
+  , waitForProcess, terminateProcess, getProcessExitCode, getPid
+  )
+import PureMyHA.Config (HooksConfig (..), PositiveDuration (..))
 import PureMyHA.Types (ClusterName, unClusterName, HostInfo, hiHostName, HostName (..))
 
 -- | Describes how the source role changed for a hook invocation.
@@ -30,6 +45,73 @@ data SourceChange
   | InitialSourcePromotion { scNewSource :: HostInfo }
   | SourceChanged          { scOldSource :: HostInfo, scNewSource :: HostInfo }
   deriving (Eq, Show)
+
+-- | Why a hook script was rejected before execution.
+data HookRejection
+  = NotAbsolutePath
+  | NotRegularFile   -- ^ Symlink, directory, device, etc.
+  | UntrustedOwner   -- ^ Not root and not the daemon user
+  | WorldWritable    -- ^ Other-write bit (0o002) is set
+  deriving (Eq, Show)
+
+-- | Subset of stat(2) needed to decide whether a hook script is safe to run.
+-- Extracted so 'validateHookScript' can stay pure and easy to test.
+data HookScriptStat = HookScriptStat
+  { hssIsRegularFile :: Bool
+  , hssOwner         :: UserID
+  , hssMode          :: FileMode
+  } deriving (Eq, Show)
+
+-- | Pure validator for a hook script. Rejects the script unless:
+--
+--   * path is absolute,
+--   * it is a regular file (not a symlink, directory, or special file),
+--   * its owner is root (UID 0) or the supplied daemon UID,
+--   * its mode does not have the world-writable bit (0o002) set.
+validateHookScript
+  :: FilePath       -- ^ script path as configured
+  -> HookScriptStat -- ^ stat information for the script
+  -> UserID         -- ^ daemon's real UID
+  -> Either HookRejection ()
+validateHookScript path stat daemonUid
+  | not (isAbsolute path)                           = Left NotAbsolutePath
+  | not (hssIsRegularFile stat)                     = Left NotRegularFile
+  | hssOwner stat /= 0 && hssOwner stat /= daemonUid = Left UntrustedOwner
+  | hssMode stat .&. 0o002 /= 0                     = Left WorldWritable
+  | otherwise                                       = Right ()
+
+-- | Render a 'HookRejection' as an operator-facing error message that names
+-- the offending script path.
+rejectionMessage :: FilePath -> HookRejection -> Text
+rejectionMessage path r = case r of
+  NotAbsolutePath -> "Hook script path must be absolute: " <> T.pack path
+  NotRegularFile  -> "Hook script is not a regular file (symlink/dir rejected): " <> T.pack path
+  UntrustedOwner  -> "Hook script owner is neither root nor the daemon user: " <> T.pack path
+  WorldWritable   -> "Hook script is world-writable (mode 0o002 set): " <> T.pack path
+
+-- | IO wrapper around 'validateHookScript': stats the path (without following
+-- symlinks) and looks up the daemon's real UID, then delegates to the pure
+-- validator. Returns 'Left' with a human-readable message on any failure —
+-- including stat failures such as ENOENT.
+validateHookScriptIO :: FilePath -> IO (Either Text ())
+validateHookScriptIO path
+  | not (isAbsolute path) =
+      pure $ Left (rejectionMessage path NotAbsolutePath)
+  | otherwise = do
+      eStat <- try @SomeException (PF.getSymbolicLinkStatus path)
+      case eStat of
+        Left err -> pure $ Left $
+          "Hook script stat failed for " <> T.pack path <> ": " <> T.pack (show err)
+        Right fs -> do
+          daemonUid <- PU.getRealUserID
+          let stat = HookScriptStat
+                { hssIsRegularFile = PF.isRegularFile fs
+                , hssOwner         = PF.fileOwner fs
+                , hssMode          = PF.fileMode fs
+                }
+          pure $ case validateHookScript path stat daemonUid of
+            Right ()  -> Right ()
+            Left rej  -> Left (rejectionMessage path rej)
 
 data HookEnv = HookEnv
   { hookClusterName  :: ClusterName
@@ -46,10 +128,24 @@ getCurrentTimestamp :: IO Text
 getCurrentTimestamp =
   T.pack . formatTime defaultTimeLocale "%Y-%m-%dT%H:%M:%SZ" <$> getCurrentTime
 
--- | Execute a hook script and wait for it to complete.
--- Returns Left with error message if the hook fails.
-runHook :: FilePath -> HookEnv -> IO (Either Text ())
-runHook scriptPath hookEnv = do
+-- | Execute a hook script and wait for it to complete, subject to a timeout.
+--
+-- Before launching the child process the script is validated via
+-- 'validateHookScriptIO' (absolute path, regular file, trusted owner, not
+-- world-writable). The child is started as a new process group leader so that
+-- any sub-processes it forks can be killed on timeout. If the hook does not
+-- exit within the timeout, the process group is sent SIGTERM, given a short
+-- grace period, and then sent SIGKILL.
+runHook :: NominalDiffTime -> FilePath -> HookEnv -> IO (Either Text ())
+runHook hookTimeoutDur scriptPath hookEnv = do
+  vres <- validateHookScriptIO scriptPath
+  case vres of
+    Left err -> pure (Left err)
+    Right () -> runValidatedHook hookTimeoutDur scriptPath hookEnv
+
+-- | Launch a validated hook script with the supplied timeout.
+runValidatedHook :: NominalDiffTime -> FilePath -> HookEnv -> IO (Either Text ())
+runValidatedHook hookTimeoutDur scriptPath hookEnv = do
   let sourceVars = case hookSourceChange hookEnv of
         NoSourceChange -> []
         InitialSourcePromotion newH ->
@@ -68,18 +164,58 @@ runHook scriptPath hookEnv = do
         maybe [] (\dt -> [("PUREMYHA_DRIFT_TYPE",    T.unpack dt)]) (hookDriftType    hookEnv) ++
         maybe [] (\dd -> [("PUREMYHA_DRIFT_DETAILS", T.unpack dd)]) (hookDriftDetails hookEnv) ++
         [("PUREMYHA_TIMESTAMP", T.unpack (hookTimestamp hookEnv))]
+      timeoutMicros = max 1 (round (realToFrac hookTimeoutDur * 1_000_000 :: Double)) :: Int
+      graceMicros   = 2_000_000 :: Int
   result <- try @SomeException $ do
-    (_, _, _, ph) <- createProcess (proc scriptPath [T.unpack (unClusterName (hookClusterName hookEnv))])
-      { env = Just envVars }
-    exitCode <- waitForProcess ph
-    pure exitCode
+    (_, _, _, ph) <- createProcess
+      (proc scriptPath [T.unpack (unClusterName (hookClusterName hookEnv))])
+        { env          = Just envVars
+        , create_group = True
+        }
+    mExit <- pollForExit ph timeoutMicros
+    case mExit of
+      Just ec -> pure (Right ec)
+      Nothing -> do
+        terminateProcess ph
+        mExit2 <- pollForExit ph graceMicros
+        case mExit2 of
+          Just _  -> pure (Left timedOutMsg)
+          Nothing -> do
+            mPid <- getPid ph
+            case mPid of
+              Just pid -> signalProcessGroup sigKILL pid
+              Nothing  -> pure ()
+            _ <- waitForProcess ph
+            pure (Left timedOutMsg)
   case result of
-    Left err ->
-      pure $ Left $ "Hook failed with exception: " <> T.pack (show err)
-    Right ExitSuccess ->
-      pure $ Right ()
-    Right (ExitFailure n) ->
-      pure $ Left $ "Hook exited with code " <> T.pack (show n)
+    Left err                      -> pure $ Left $ "Hook failed with exception: " <> T.pack (show err)
+    Right (Left tmsg)             -> pure (Left tmsg)
+    Right (Right ExitSuccess)     -> pure (Right ())
+    Right (Right (ExitFailure n)) -> pure $ Left $ "Hook exited with code " <> T.pack (show n)
+  where
+    timedOutMsg =
+      "Hook timed out after "
+        <> T.pack (show (realToFrac hookTimeoutDur :: Double))
+        <> "s; process group killed"
+
+-- | Wait for the child process to exit, polling every 50ms up to the given
+-- budget of microseconds. Using 'getProcessExitCode' (non-blocking) rather
+-- than 'waitForProcess' avoids being trapped in an uninterruptible FFI call
+-- when a timeout tries to abort us — an issue observed on macOS.
+pollForExit :: ProcessHandle -> Int -> IO (Maybe ExitCode)
+pollForExit ph budget
+  | budget <= 0 = do
+      mEC <- getProcessExitCode ph
+      pure mEC
+  | otherwise = do
+      mEC <- getProcessExitCode ph
+      case mEC of
+        Just ec -> pure (Just ec)
+        Nothing -> do
+          let tick = 50_000
+              step = min tick budget
+          threadDelay step
+          pollForExit ph (budget - step)
 
 -- | Non-blocking fire-and-forget (post hooks, detection hooks)
 runHookFireForget
@@ -88,7 +224,7 @@ runHookFireForget Nothing _ _ = pure ()
 runHookFireForget (Just hc) getter hookEnv =
   case getter hc of
     Nothing   -> pure ()
-    Just path -> void $ async (runHook path hookEnv)
+    Just path -> void $ async (runHook (unPositiveDuration (hcTimeout hc)) path hookEnv)
 
 -- | Blocking: run hook and return Left if it fails, aborting the operation
 runHookOrAbort
@@ -97,4 +233,4 @@ runHookOrAbort Nothing _ _ = pure (Right ())
 runHookOrAbort (Just hc) getter hookEnv =
   case getter hc of
     Nothing   -> pure (Right ())
-    Just path -> runHook path hookEnv
+    Just path -> runHook (unPositiveDuration (hcTimeout hc)) path hookEnv

--- a/test/PureMyHA/ConfigSpec.hs
+++ b/test/PureMyHA/ConfigSpec.hs
@@ -305,6 +305,60 @@ spec = do
             Nothing -> expectationFailure "expected hooks to be set"
             Just h  -> hcOnTopologyDrift h `shouldSatisfy` isNothing
 
+    it "hook_timeout defaults to 30s when absent" $ do
+      let yaml = BC.pack $ unlines
+            [ "clusters:"
+            , "  - name: test"
+            , "    nodes: [{host: db1}]"
+            , "    credentials:"
+            , "      user: u"
+            , "      password_file: /dev/null"
+            , "    hooks:"
+            , "      pre_failover: /etc/puremyha/hooks/pre_failover.sh"
+            , globalBlock
+            ]
+      case decodeConfig yaml of
+        Left err -> expectationFailure err
+        Right cfg ->
+          case ccHooks (NE.head (cfgClusters cfg)) of
+            Nothing -> expectationFailure "expected hooks to be set"
+            Just h  -> unPositiveDuration (hcTimeout h) `shouldBe` 30
+
+    it "parses explicit hook_timeout" $ do
+      let yaml = BC.pack $ unlines
+            [ "clusters:"
+            , "  - name: test"
+            , "    nodes: [{host: db1}]"
+            , "    credentials:"
+            , "      user: u"
+            , "      password_file: /dev/null"
+            , "    hooks:"
+            , "      pre_failover: /etc/puremyha/hooks/pre_failover.sh"
+            , "      hook_timeout: 5s"
+            , globalBlock
+            ]
+      case decodeConfig yaml of
+        Left err -> expectationFailure err
+        Right cfg ->
+          case ccHooks (NE.head (cfgClusters cfg)) of
+            Nothing -> expectationFailure "expected hooks to be set"
+            Just h  -> unPositiveDuration (hcTimeout h) `shouldBe` 5
+
+    it "rejects zero hook_timeout" $ do
+      let yaml = BC.pack $ unlines
+            [ "clusters:"
+            , "  - name: test"
+            , "    nodes: [{host: db1}]"
+            , "    credentials:"
+            , "      user: u"
+            , "      password_file: /dev/null"
+            , "    hooks:"
+            , "      pre_failover: /etc/puremyha/hooks/pre_failover.sh"
+            , "      hook_timeout: 0s"
+            , globalBlock
+            ]
+      decodeConfig yaml `shouldSatisfy` isLeft
+
     it "fails when monitoring is absent from both cluster and global" $ do
       let yaml = BC.pack $ unlines
             [ "clusters:"

--- a/test/PureMyHA/HookSpec.hs
+++ b/test/PureMyHA/HookSpec.hs
@@ -1,0 +1,161 @@
+module PureMyHA.HookSpec (spec) where
+
+import Data.Either (isLeft)
+import qualified Data.Text as T
+import Data.Time (diffUTCTime, getCurrentTime)
+import System.IO (hClose, hPutStrLn)
+import System.IO.Temp (withSystemTempFile)
+import System.Posix.Files (setFileMode)
+import Test.Hspec
+import PureMyHA.Hook
+  ( HookEnv (..)
+  , HookRejection (..)
+  , HookScriptStat (..)
+  , SourceChange (..)
+  , runHook
+  , validateHookScript
+  , validateHookScriptIO
+  )
+import PureMyHA.Types (ClusterName (..))
+
+-- | Minimal HookEnv suitable for driving 'runHook' in tests.
+testHookEnv :: HookEnv
+testHookEnv = HookEnv
+  { hookClusterName  = ClusterName "test"
+  , hookSourceChange = NoSourceChange
+  , hookFailureType  = Nothing
+  , hookTimestamp    = T.pack "1970-01-01T00:00:00Z"
+  , hookLagSeconds   = Nothing
+  , hookNode         = Nothing
+  , hookDriftType    = Nothing
+  , hookDriftDetails = Nothing
+  }
+
+spec :: Spec
+spec = do
+  describe "validateHookScript" $ do
+    let rootOwned644 = HookScriptStat
+          { hssIsRegularFile = True
+          , hssOwner         = 0
+          , hssMode          = 0o644
+          }
+
+    it "accepts absolute path + regular file + root owner + 0o644" $
+      validateHookScript "/etc/puremyha/hooks/pre_failover.sh" rootOwned644 1000
+        `shouldBe` Right ()
+
+    it "accepts file owned by the daemon UID" $ do
+      let stat = rootOwned644 { hssOwner = 1000, hssMode = 0o700 }
+      validateHookScript "/home/puremyha/hook.sh" stat 1000
+        `shouldBe` Right ()
+
+    it "rejects relative paths" $
+      validateHookScript "hooks/pre_failover.sh" rootOwned644 1000
+        `shouldBe` Left NotAbsolutePath
+
+    it "rejects non-regular files (symlink / directory)" $ do
+      let stat = rootOwned644 { hssIsRegularFile = False }
+      validateHookScript "/etc/puremyha/hooks/pre_failover.sh" stat 1000
+        `shouldBe` Left NotRegularFile
+
+    it "rejects files owned by an untrusted user" $ do
+      let stat = rootOwned644 { hssOwner = 9999 }
+      validateHookScript "/etc/puremyha/hooks/pre_failover.sh" stat 1000
+        `shouldBe` Left UntrustedOwner
+
+    it "rejects world-writable files (mode 0o666)" $ do
+      let stat = rootOwned644 { hssMode = 0o666 }
+      validateHookScript "/etc/puremyha/hooks/pre_failover.sh" stat 1000
+        `shouldBe` Left WorldWritable
+
+    it "rejects world-writable files (mode 0o777)" $ do
+      let stat = rootOwned644 { hssMode = 0o777 }
+      validateHookScript "/etc/puremyha/hooks/pre_failover.sh" stat 1000
+        `shouldBe` Left WorldWritable
+
+    it "rejects files with the lone world-write bit set (0o602)" $ do
+      let stat = rootOwned644 { hssMode = 0o602 }
+      validateHookScript "/etc/puremyha/hooks/pre_failover.sh" stat 1000
+        `shouldBe` Left WorldWritable
+
+    it "accepts world-readable but not writable (0o755)" $ do
+      let stat = rootOwned644 { hssMode = 0o755 }
+      validateHookScript "/etc/puremyha/hooks/pre_failover.sh" stat 1000
+        `shouldBe` Right ()
+
+    it "accepts setuid + world-readable, no world-write (0o4755)" $ do
+      let stat = rootOwned644 { hssMode = 0o4755 }
+      validateHookScript "/etc/puremyha/hooks/pre_failover.sh" stat 1000
+        `shouldBe` Right ()
+
+  describe "validateHookScriptIO" $ do
+    it "rejects a relative path without touching the filesystem" $ do
+      result <- validateHookScriptIO "hooks/pre.sh"
+      result `shouldSatisfy` isLeft
+
+    it "rejects a non-existent absolute path with a stat error" $ do
+      result <- validateHookScriptIO "/nonexistent/puremyha/hook-xyz.sh"
+      result `shouldSatisfy` isLeft
+
+    it "accepts a temp file owned by the current user with mode 0o700" $ do
+      withSystemTempFile "puremyha-hook-ok.sh" $ \path h -> do
+        hPutStrLn h "#!/bin/sh"
+        hPutStrLn h "exit 0"
+        hClose h
+        setFileMode path 0o700
+        result <- validateHookScriptIO path
+        result `shouldBe` Right ()
+
+    it "rejects a temp file after it is chmodded world-writable" $ do
+      withSystemTempFile "puremyha-hook-ww.sh" $ \path h -> do
+        hPutStrLn h "#!/bin/sh"
+        hPutStrLn h "exit 0"
+        hClose h
+        setFileMode path 0o606
+        result <- validateHookScriptIO path
+        result `shouldSatisfy` isLeft
+
+  describe "runHook" $ do
+    it "returns Right () for a quick-exit script" $ do
+      withSystemTempFile "puremyha-hook-exit0.sh" $ \path h -> do
+        hPutStrLn h "#!/bin/sh"
+        hPutStrLn h "exit 0"
+        hClose h
+        setFileMode path 0o700
+        result <- runHook 5 path testHookEnv
+        result `shouldBe` Right ()
+
+    it "propagates a non-zero exit code as Left" $ do
+      withSystemTempFile "puremyha-hook-exit1.sh" $ \path h -> do
+        hPutStrLn h "#!/bin/sh"
+        hPutStrLn h "exit 7"
+        hClose h
+        setFileMode path 0o700
+        result <- runHook 5 path testHookEnv
+        result `shouldSatisfy` isLeft
+
+    it "kills a long-running script after the timeout" $ do
+      withSystemTempFile "puremyha-hook-sleep.sh" $ \path h -> do
+        hPutStrLn h "#!/bin/sh"
+        hPutStrLn h "sleep 30"
+        hClose h
+        setFileMode path 0o700
+        start  <- getCurrentTime
+        result <- runHook 1 path testHookEnv  -- 1-second timeout
+        end    <- getCurrentTime
+        let elapsed = realToFrac (diffUTCTime end start) :: Double
+        result  `shouldSatisfy` isLeft
+        elapsed `shouldSatisfy` (< 6)  -- 1s timeout + 2s grace + ample slack
+
+    it "rejects a world-writable hook before executing it" $ do
+      withSystemTempFile "puremyha-hook-ww-run.sh" $ \path h -> do
+        hPutStrLn h "#!/bin/sh"
+        hPutStrLn h "exit 0"
+        hClose h
+        setFileMode path 0o606
+        result <- runHook 5 path testHookEnv
+        result `shouldSatisfy` isLeft
+
+    it "rejects a relative path without launching a process" $ do
+      result <- runHook 5 "hooks/relative.sh" testHookEnv
+      result `shouldSatisfy` isLeft


### PR DESCRIPTION
## Summary
- Validate each configured hook script at invocation time: reject non-absolute paths, non-regular files (symlinks/directories), untrusted owners (not root or the daemon UID), and world-writable modes. Rejected `pre_*` hooks abort the operation; rejected fire-and-forget hooks are skipped.
- Add `hook_timeout` to `HooksConfig` (default 30s). Hooks are launched as a new process group so that on overrun we SIGTERM the group, grace 2s, and SIGKILL — preventing a stuck hook from blocking failover or leaking subprocesses.
- Bake e2e hook scripts into the Docker image with root ownership and switch e2e YAML to `/opt/puremyha/hooks/` so the new validator accepts them under CI bind-mount UIDs.
- Document the security requirements and timeout semantics in `docs/features.md`, `docs/configuration.md`, and `config/config.yaml.example`.

Closes #183.

## Test plan
- [x] `cabal build all` — clean
- [x] `cabal test` — 569 examples, 0 failures (10 pure validator cases + 9 IO/timeout cases in new `HookSpec`; 3 new `hook_timeout` parse cases in `ConfigSpec`)
- [ ] E2E: `bash e2e/run-all.sh` — existing hook test 07 still green with baked-in hooks; new `26-hook-security.sh` verifies world-writable rejection and that `pre_failover` is never executed when the script is chmodded 0o666.

🤖 Generated with [Claude Code](https://claude.com/claude-code)