### PR TITLE
Restrict IPC socket to owner-only permissions (#180)

### DIFF
--- a/docs/daemon-ha.md
+++ b/docs/daemon-ha.md
@@ -239,6 +239,16 @@ echo "show stat" | socat stdio /run/haproxy/admin.sock
 pcs resource reload puremyhad
 ```
 
+### IPC socket security model
+
+`puremyhad` creates its control socket (`/run/puremyhad.sock` by default, or the path passed to `--socket`) with file mode **`0600`**. Only the UID that runs the daemon can issue IPC control requests (status, switchover, failover acknowledgement, clone, pause/resume, set-log-level, etc.).
+
+Operational implications:
+
+- The `puremyha` CLI must be executed as the **same UID** as the daemon, or as `root`. On a default systemd deployment the daemon runs as `root`, so `sudo puremyha ...` is the expected invocation pattern.
+- If you configure a dedicated service user (e.g. `User=puremyha` in the systemd unit), make sure that user owns the directory containing the socket and that operators invoking `puremyha` can `sudo -u puremyha ...`.
+- Sharing the socket across users via group permissions is **not** supported. If you need remote or multi-user access, front the daemon with an external authenticated control plane rather than relaxing the socket mode.
+
 ### MySQL operations (Docker Compose demo)
 
 The demo Makefile provides targets for MySQL-level operations via the `puremyha` CLI. These commands are automatically routed to the Pacemaker node currently running `puremyhad`.

--- a/e2e/tests/27-ipc-socket-permissions.sh
+++ b/e2e/tests/27-ipc-socket-permissions.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Test: IPC Unix domain socket permissions
+# Verifies that /run/puremyhad.sock is created with mode 0600 so that
+# only the daemon's UID can issue privileged IPC control requests.
+set -euo pipefail
+source "$(dirname "$0")/../lib/helpers.sh"
+echo "=== Test 27: IPC Socket Permissions ==="
+
+wait_for_health "Healthy" 60
+
+# Socket file must exist inside the daemon container
+exists=$($COMPOSE exec -T puremyhad sh -c '[ -S /run/puremyhad.sock ] && echo yes || echo no')
+assert_eq "IPC socket file exists" "yes" "$exists"
+
+# Mode must be 0600 (owner read/write only)
+mode=$($COMPOSE exec -T puremyhad stat -c '%a' /run/puremyhad.sock | tr -d '\r')
+assert_eq "IPC socket mode is 0600" "600" "$mode"
+
+# Ownership expected to be root:root under the default e2e container
+owner=$($COMPOSE exec -T puremyhad stat -c '%U:%G' /run/puremyhad.sock | tr -d '\r')
+assert_eq "IPC socket owner is root:root" "root:root" "$owner"
+
+test_summary

--- a/src/PureMyHA/IPC/Server.hs
+++ b/src/PureMyHA/IPC/Server.hs
@@ -1,5 +1,6 @@
 module PureMyHA.IPC.Server
   ( startIPCServer
+  , openListenSocket
   , defaultSocketPath
   , DiscoveryAction (..)
   , ClusterMap (..)
@@ -32,7 +33,7 @@ import PureMyHA.Failover.Demote (runDemote, dryRunDemote)
 import PureMyHA.Failover.PauseReplica (runPauseReplica, runResumeReplica, runStopReplication, runStartReplication)
 import PureMyHA.Failover.ErrantGtid (runFixErrantGtid, dryRunFixErrantGtid)
 import PureMyHA.Failover.Switchover (runSwitchover, dryRunSwitchover)
-import System.Posix.Files (removeLink)
+import System.Posix.Files (removeLink, setFileMode)
 import PureMyHA.IPC.Protocol
 import PureMyHA.MySQL.GTID (isEmptyGtidSet)
 import qualified PureMyHA.IPC.Socket as IPCSocket
@@ -66,6 +67,9 @@ openListenSocket path = do
   sock <- socket AF_UNIX Stream defaultProtocol
   removeLink path `catch` \(_ :: SomeException) -> pure ()  -- remove stale socket file
   bind sock (SockAddrUnix path)
+  -- Restrict IPC socket to owner-only: any local user who could connect
+  -- would otherwise be able to issue privileged control-plane operations.
+  setFileMode path 0o600
   pure sock
 
 acceptLoop :: Socket -> TVarDaemonState -> ClusterMap -> DiscoveryMap -> TVar Logger -> IO ()

--- a/test/PureMyHA/IPCSpec.hs
+++ b/test/PureMyHA/IPCSpec.hs
@@ -1,14 +1,21 @@
 module PureMyHA.IPCSpec (spec) where
 
 import Control.Concurrent.Async (async, wait)
+import Control.Exception (bracket)
 import Data.Aeson (encode, decode)
+import Data.Bits ((.&.))
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as BSC
 import qualified Data.ByteString.Lazy.Char8 as BLC
 import Network.Socket (socketPair, Family (..), SocketType (..), close)
 import qualified Network.Socket.ByteString as NSB
+import System.Directory (getTemporaryDirectory)
+import System.FilePath ((</>))
+import System.Posix.Files (fileMode, getFileStatus, removeLink)
+import System.Posix.Process (getProcessID)
 import Test.Hspec
 import PureMyHA.IPC.Protocol
+import PureMyHA.IPC.Server (openListenSocket)
 import PureMyHA.IPC.Socket (recvLine, maxLineLength)
 import Data.Text (Text)
 import PureMyHA.MySQL.GTID (GtidSet, emptyGtidSet, parseGtidSet)
@@ -276,6 +283,15 @@ spec = do
       case result of
         Left msg -> msg `shouldBe` "Line too long (exceeds 1 MiB)"
         Right _  -> expectationFailure "expected Left but got Right"
+
+  describe "openListenSocket" $
+    it "creates the socket file with mode 0o600" $ do
+      tmp <- getTemporaryDirectory
+      pid <- getProcessID
+      let path = tmp </> ("puremyha-test-" <> show pid <> ".sock")
+      bracket (openListenSocket path) (\sock -> close sock >> removeLink path) $ \_ -> do
+        st <- getFileStatus path
+        (fromIntegral (fileMode st) .&. (0o777 :: Int)) `shouldBe` 0o600
 
 roundTrip :: Request -> Maybe Request
 roundTrip = decode . encode


### PR DESCRIPTION
## Summary
- Fixes #180 — the IPC Unix domain socket `/run/puremyhad.sock` was created with umask-dependent permissions, leaving the privileged control plane reachable by any local user.
- Apply `setFileMode path 0o600` immediately after `bind` in `openListenSocket` so only the daemon's UID can issue failover / switchover / clone / pause-resume / set-log-level requests.
- Add a unit test that exercises `openListenSocket` against a temporary path and asserts the resulting file mode is `0o600`.
- Add an E2E test (`e2e/tests/27-ipc-socket-permissions.sh`) that verifies the live socket mode and ownership inside the daemon container.
- Document the new security model and its operational implications in `docs/daemon-ha.md` (CLI must run as the same UID as the daemon; group-shared sockets are not supported).

## Test plan
- [x] `cabal build all` succeeds
- [x] `cabal test` passes — 576/576 examples green (includes the new `openListenSocket` case)
- [ ] Run the full E2E suite via docker compose and confirm `27-ipc-socket-permissions.sh` passes alongside existing tests
- [ ] Manual smoke: start `puremyhad`, run `stat -c '%a %U:%G' /run/puremyhad.sock` — expect `600 root:root` (or the daemon's UID/GID)

🤖 Generated with [Claude Code](https://claude.com/claude-code)