### PR TITLE
Fix async-unsafe I/O in SIGHUP handler (#182)

### DIFF
--- a/app/Daemon/Main.hs
+++ b/app/Daemon/Main.hs
@@ -1,10 +1,11 @@
 module Main (main) where
 
 import Control.Concurrent.Async (Async, async, waitAnyCancel, race_, cancel)
+import Control.Concurrent.MVar  (MVar, newEmptyMVar, takeMVar, tryPutMVar)
 import Control.Concurrent.STM   (TMVar, TVar, atomically, newTVarIO, newEmptyTMVarIO,
                                   putTMVar, takeTMVar, writeTVar, readTVarIO, modifyTVar')
 import Control.Exception (try, SomeException)
-import Control.Monad (void, forM_)
+import Control.Monad (forever, void, forM_)
 import Data.Foldable (find)
 import qualified Data.List.NonEmpty as NE
 import Data.Maybe (fromMaybe)
@@ -62,10 +63,13 @@ main = do
   clusterEnvs      <- mapM (initCluster tvar loggerVar) clusterPasswords
 
   httpAsyncVar <- newTVarIO Nothing
-  installHUPHandler (optConfigPath opts) clusterEnvs loggerVar httpAsyncVar tvar
+  hupVar <- installHUPSignaller
   installUSR1Handler (lcLogFile (cfgLogging cfg)) loggerVar
 
-  allWorkers <- startAllWorkers clusterEnvs (optSocketPath opts) tvar loggerVar
+  baseWorkers <- startAllWorkers clusterEnvs (optSocketPath opts) tvar loggerVar
+  reloadAsync <- async
+    (configReloadWorker hupVar (optConfigPath opts) clusterEnvs loggerVar httpAsyncVar tvar)
+  let allWorkers = reloadAsync : baseWorkers
   case hcEnabled (cfgHttp cfg) of
     HttpEnabled -> do
       a <- async (startHTTPServer (cfgHttp cfg) tvar)
@@ -91,32 +95,60 @@ installShutdownHandlers = do
   _ <- installHandler sigINT  h Nothing
   pure shutdownVar
 
-installHUPHandler :: FilePath -> [ClusterEnv] -> TVar Logger -> TVar (Maybe (Async ())) -> TVarDaemonState -> IO ()
-installHUPHandler configPath clusterEnvs loggerVar httpAsyncVar tvar = do
-  _ <- installHandler sigHUP (Catch $ do
-    logger <- readTVarIO loggerVar
-    eCfg' <- loadConfig configPath
-    case eCfg' of
-      Left err   -> logWarn logger $ "SIGHUP: config reload failed: " <> T.pack err
-      Right cfg' -> do
-        forM_ clusterEnvs $ \env -> do
-          let name = ccName (envCluster env)
-          case find (\cc -> ccName cc == name) (NE.toList (cfgClusters cfg')) of
-            Nothing -> logWarn logger $ "SIGHUP: cluster " <> unClusterName name <> " not found in new config"
-            Just cc -> atomically $ do
-              writeTVar (envMonitoring env) (ccMonitoring cc)
-              writeTVar (envHooks env)      (ccHooks cc)
-        mOld <- readTVarIO httpAsyncVar
-        forM_ mOld cancel
-        case hcEnabled (cfgHttp cfg') of
-          HttpEnabled -> do
-            a <- async (startHTTPServer (cfgHttp cfg') tvar)
-            atomically $ writeTVar httpAsyncVar (Just a)
-          HttpDisabled -> atomically $ writeTVar httpAsyncVar Nothing
-        setLogLevel logger (lcLogLevel (cfgLogging cfg'))
-        logInfo logger "SIGHUP: config reloaded"
-        ) Nothing
-  pure ()
+-- | Minimal async-signal-safe SIGHUP handler: only flips an MVar flag.
+-- The actual reload runs on a normal worker thread (see 'configReloadWorker').
+installHUPSignaller :: IO (MVar ())
+installHUPSignaller = do
+  hupVar <- newEmptyMVar
+  _ <- installHandler sigHUP (Catch (void (tryPutMVar hupVar ()))) Nothing
+  pure hupVar
+
+reloadConfigOnce
+  :: FilePath
+  -> [ClusterEnv]
+  -> TVar Logger
+  -> TVar (Maybe (Async ()))
+  -> TVarDaemonState
+  -> IO ()
+reloadConfigOnce configPath clusterEnvs loggerVar httpAsyncVar tvar = do
+  logger <- readTVarIO loggerVar
+  eCfg' <- loadConfig configPath
+  case eCfg' of
+    Left err   -> logWarn logger $ "SIGHUP: config reload failed: " <> T.pack err
+    Right cfg' -> do
+      forM_ clusterEnvs $ \env -> do
+        let name = ccName (envCluster env)
+        case find (\cc -> ccName cc == name) (NE.toList (cfgClusters cfg')) of
+          Nothing -> logWarn logger $ "SIGHUP: cluster " <> unClusterName name <> " not found in new config"
+          Just cc -> atomically $ do
+            writeTVar (envMonitoring env) (ccMonitoring cc)
+            writeTVar (envHooks env)      (ccHooks cc)
+      mOld <- readTVarIO httpAsyncVar
+      forM_ mOld cancel
+      case hcEnabled (cfgHttp cfg') of
+        HttpEnabled -> do
+          a <- async (startHTTPServer (cfgHttp cfg') tvar)
+          atomically $ writeTVar httpAsyncVar (Just a)
+        HttpDisabled -> atomically $ writeTVar httpAsyncVar Nothing
+      setLogLevel logger (lcLogLevel (cfgLogging cfg'))
+      logInfo logger "SIGHUP: config reloaded"
+
+configReloadWorker
+  :: MVar ()
+  -> FilePath
+  -> [ClusterEnv]
+  -> TVar Logger
+  -> TVar (Maybe (Async ()))
+  -> TVarDaemonState
+  -> IO ()
+configReloadWorker hupVar configPath clusterEnvs loggerVar httpAsyncVar tvar = forever $ do
+  takeMVar hupVar
+  r <- try @SomeException (reloadConfigOnce configPath clusterEnvs loggerVar httpAsyncVar tvar)
+  case r of
+    Right () -> pure ()
+    Left e -> do
+      logger <- readTVarIO loggerVar
+      logWarn logger $ "SIGHUP: reload worker caught exception: " <> T.pack (show e)
 
 installUSR1Handler :: FilePath -> TVar Logger -> IO ()
 installUSR1Handler logFile loggerVar = do

--- a/e2e/tests/27-sighup-reload.sh
+++ b/e2e/tests/27-sighup-reload.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Test: SIGHUP config reload (issue #182)
+# Verifies that SIGHUP still triggers a config reload after the handler was
+# rewritten to a tiny async-signal-safe signaller that delegates to a worker
+# thread. Also verifies the worker keeps responding to subsequent SIGHUPs
+# and that the daemon stays healthy through repeated signals.
+set -euo pipefail
+source "$(dirname "$0")/../lib/helpers.sh"
+echo "=== Test 27: SIGHUP Config Reload ==="
+
+LOG_FILE=/var/log/puremyha.log
+
+count_reload_lines() {
+  $COMPOSE exec -T puremyhad sh -c "grep -c 'SIGHUP: config reloaded' $LOG_FILE || true" \
+    | tr -d '[:space:]'
+}
+
+send_sighup() {
+  $COMPOSE exec -T puremyhad sh -c 'kill -HUP $(pidof puremyhad)'
+}
+
+wait_for_reload_count() {
+  local target="$1" max_wait="${2:-10}"
+  for _ in $(seq 1 "$max_wait"); do
+    local n
+    n=$(count_reload_lines)
+    if [ "${n:-0}" -ge "$target" ]; then
+      return 0
+    fi
+    sleep 1
+  done
+  return 1
+}
+
+wait_for_health "Healthy" 60
+
+# Baseline: whatever reload events are already in the log (should be 0 on a
+# fresh cluster but we don't assume).
+baseline=$(count_reload_lines)
+baseline=${baseline:-0}
+echo "  Baseline 'SIGHUP: config reloaded' count: $baseline"
+
+# --- First SIGHUP ------------------------------------------------------------
+send_sighup
+target=$((baseline + 1))
+if wait_for_reload_count "$target" 10; then
+  echo "  PASS: first SIGHUP produced a reload log line"
+  ((PASS_COUNT++)) || true
+else
+  echo "  FAIL: first SIGHUP did not produce a reload log line within 10s"
+  $COMPOSE exec -T puremyhad tail -n 40 "$LOG_FILE" || true
+  ((FAIL_COUNT++)) || true
+fi
+
+health=$(get_health)
+assert_eq "Daemon healthy after first SIGHUP" "Healthy" "$health"
+
+# --- Second SIGHUP -----------------------------------------------------------
+# Proves the worker is still blocked on takeMVar waiting for the next signal,
+# not one-shot. Sleep briefly so the worker has finished the first reload.
+sleep 2
+send_sighup
+target=$((baseline + 2))
+if wait_for_reload_count "$target" 10; then
+  echo "  PASS: second SIGHUP produced another reload log line"
+  ((PASS_COUNT++)) || true
+else
+  echo "  FAIL: second SIGHUP did not produce another reload log line within 10s"
+  $COMPOSE exec -T puremyhad tail -n 40 "$LOG_FILE" || true
+  ((FAIL_COUNT++)) || true
+fi
+
+health=$(get_health)
+assert_eq "Daemon healthy after second SIGHUP" "Healthy" "$health"
+
+# --- SIGHUP burst ------------------------------------------------------------
+# tryPutMVar coalesces extras, but the daemon must never crash regardless of
+# signal frequency. Send a short burst and verify the daemon still responds.
+for _ in 1 2 3 4 5; do
+  send_sighup
+done
+sleep 3
+
+health=$(get_health)
+assert_eq "Daemon healthy after SIGHUP burst" "Healthy" "$health"
+
+# At least one additional reload should have been observed from the burst.
+after_burst=$(count_reload_lines)
+after_burst=${after_burst:-0}
+if [ "$after_burst" -gt $((baseline + 2)) ]; then
+  echo "  PASS: SIGHUP burst produced at least one additional reload ($after_burst total)"
+  ((PASS_COUNT++)) || true
+else
+  echo "  FAIL: no additional reload after SIGHUP burst (count still $after_burst)"
+  ((FAIL_COUNT++)) || true
+fi
+
+test_summary


### PR DESCRIPTION
## Summary
- The SIGHUP handler called `loadConfig`, logging, `async`, and STM writes directly inside the POSIX signal handler, none of which are async-signal-safe. A SIGHUP delivered during a non-reentrant section could deadlock or corrupt state.
- Install a minimal handler that only `tryPutMVar`s a flag; run the actual reload on a dedicated worker thread tracked in `allWorkers`. Exceptions from a single reload are caught so the worker keeps servicing future signals.
- Adds `e2e/tests/27-sighup-reload.sh` covering: single SIGHUP triggers reload, a second SIGHUP triggers another, a burst stays stable, and the daemon remains Healthy throughout.

Closes #182.

## Scope note
`SIGUSR1` in `installUSR1Handler` has the same bug class (`openFile` inside the handler). Tracked separately as #195.

## Test plan
- [x] `cabal build all`
- [x] `cabal test` — 575 examples, 0 failures
- [x] `e2e/run-all.sh 27` — 6 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)