### PR TITLE
Move SIGUSR1 log reopen off the signal handler (#195)

### DIFF
--- a/app/Daemon/Main.hs
+++ b/app/Daemon/Main.hs
@@ -63,13 +63,14 @@ main = do
   clusterEnvs      <- mapM (initCluster tvar loggerVar) clusterPasswords
 
   httpAsyncVar <- newTVarIO Nothing
-  hupVar <- installHUPSignaller
-  installUSR1Handler (lcLogFile (cfgLogging cfg)) loggerVar
+  hupVar  <- installHUPSignaller
+  usr1Var <- installUSR1Signaller
 
-  baseWorkers <- startAllWorkers clusterEnvs (optSocketPath opts) tvar loggerVar
-  reloadAsync <- async
+  baseWorkers    <- startAllWorkers clusterEnvs (optSocketPath opts) tvar loggerVar
+  reloadAsync    <- async
     (configReloadWorker hupVar (optConfigPath opts) clusterEnvs loggerVar httpAsyncVar tvar)
-  let allWorkers = reloadAsync : baseWorkers
+  logReopenAsync <- async (logReopenWorker usr1Var (lcLogFile logCfg) loggerVar)
+  let allWorkers = reloadAsync : logReopenAsync : baseWorkers
   case hcEnabled (cfgHttp cfg) of
     HttpEnabled -> do
       a <- async (startHTTPServer (cfgHttp cfg) tvar)
@@ -150,14 +151,25 @@ configReloadWorker hupVar configPath clusterEnvs loggerVar httpAsyncVar tvar = f
       logger <- readTVarIO loggerVar
       logWarn logger $ "SIGHUP: reload worker caught exception: " <> T.pack (show e)
 
-installUSR1Handler :: FilePath -> TVar Logger -> IO ()
-installUSR1Handler logFile loggerVar = do
-  _ <- installHandler sigUSR1 (Catch $ do
+installUSR1Signaller :: IO (MVar ())
+installUSR1Signaller = do
+  usr1Var <- newEmptyMVar
+  _ <- installHandler sigUSR1 (Catch (void (tryPutMVar usr1Var ()))) Nothing
+  pure usr1Var
+
+logReopenWorker :: MVar () -> FilePath -> TVar Logger -> IO ()
+logReopenWorker usr1Var logFile loggerVar = forever $ do
+  takeMVar usr1Var
+  r <- try @SomeException $ do
     old <- readTVarIO loggerVar
     new <- reopenLogger logFile old
     atomically $ writeTVar loggerVar new
-    logInfo new "SIGUSR1: log file reopened") Nothing
-  pure ()
+    logInfo new "SIGUSR1: log file reopened"
+  case r of
+    Right () -> pure ()
+    Left e -> do
+      logger <- readTVarIO loggerVar
+      logWarn logger $ "SIGUSR1: log reopen worker caught exception: " <> T.pack (show e)
 
 startAllWorkers :: [ClusterEnv] -> FilePath -> TVarDaemonState -> TVar Logger -> IO [Async ()]
 startAllWorkers clusterEnvs socketPath tvar loggerVar = do


### PR DESCRIPTION
## Summary
- Replace the async-unsafe `installUSR1Handler` with an `installUSR1Signaller` that only flips an `MVar` flag inside the POSIX handler.
- Add a dedicated `logReopenWorker` thread that performs `reopenLogger`, updates the `TVar Logger`, and logs the outcome; exceptions are caught and reported via `logWarn`.
- Register the worker in `allWorkers` so it is cancelled on shutdown alongside the SIGHUP reload worker from #182.

Fixes #195.

## Test plan
- [x] `cabal build all`
- [x] `cabal test` (576/576)
- [ ] `e2e/tests/12-log-rotation.sh` — existing SIGUSR1 → log rename → reopen flow still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)