### PR TITLE
Sync nsRole with ctSourceNodeId in applyEvent NodeProbed

### DIFF
--- a/src/PureMyHA/Supervisor/Event.hs
+++ b/src/PureMyHA/Supervisor/Event.hs
@@ -191,8 +191,14 @@ applyEvent fdc fc mc ct (NodeProbed nid probeResult errantGtids probeTime) =
 
       -- 12. Cluster-level health recomputation
       minReplicas = fcMinReplicasForFailover fc
-      !newClusterHealth = detectClusterHealth minReplicas newNodes
       !newSrcId = identifySource (Map.elems newNodes)
+      -- Keep nsRole in sync with ctSourceNodeId so a node identified via
+      -- identifySource's fallback branch isn't left with a stale Replica
+      -- role (same invariant enforced by buildClusterTopology).
+      !syncedNodes = case newSrcId of
+        Nothing  -> newNodes
+        Just sid -> Map.adjust (\ns -> ns { nsRole = Source }) sid newNodes
+      !newClusterHealth = detectClusterHealth minReplicas syncedNodes
       observedHealthy = case ctObservedHealthy ct of
         HasBeenObservedHealthy -> HasBeenObservedHealthy
         NeverObservedHealthy
@@ -217,7 +223,7 @@ applyEvent fdc fc mc ct (NodeProbed nid probeResult errantGtids probeTime) =
 
       -- 15. Assemble new topology
       !newCt = ct
-        { ctNodes           = newNodes
+        { ctNodes           = syncedNodes
         , ctHealth          = newClusterHealth
         , ctSourceNodeId    = newSrcId
         , ctObservedHealthy = observedHealthy

--- a/test/PureMyHA/EventSpec.hs
+++ b/test/PureMyHA/EventSpec.hs
@@ -167,6 +167,42 @@ spec = describe "PureMyHA.Supervisor.Event" $ do
           (newTopo, _) = applyEvent fdc3 testFc testMc topo event
       ctHealth newTopo `shouldNotBe` Healthy
 
+    it "syncs nsRole to Source when identifySource falls back via replica-reported source" $ do
+      let -- db1 was previously demoted to Replica but its probe result no
+          -- longer carries replica status (stale state after a prior
+          -- FailoverCommitted / NodeDemoted). db2 is still a Replica and
+          -- points to db1 as its source, so identifySource's fallback
+          -- branch should identify db1.
+          staleDemoted = healthySource { nsRole = Replica }
+          nodes = Map.fromList
+            [ (nsNodeId staleDemoted, staleDemoted)
+            , (nsNodeId healthyReplica, healthyReplica)
+            ]
+          topo = (mkTopo nodes) { ctSourceNodeId = Nothing }
+          event = NodeProbed replicaId
+            (ProbeSuccess fixedTime (Just (mkReplicaStatus "db1" 3306 IOYes "uuid1:1-100")) emptyGtidSet)
+            emptyGtidSet fixedTime
+          (newTopo, _) = applyEvent testFdc testFc testMc topo event
+      ctSourceNodeId newTopo `shouldBe` Just sourceId
+      fmap nsRole (Map.lookup sourceId (ctNodes newTopo)) `shouldBe` Just Source
+
+    it "leaves node roles unchanged when identifySource returns Nothing" $ do
+      let -- Two replicas that reference a host which is not part of the
+          -- cluster. identifySource's fallback cannot match, so newSrcId
+          -- must be Nothing and nsRole must not be forced to Source.
+          ghostRs = mkReplicaStatus "ghost-host" 9999 IOYes "uuid1:1-1"
+          n1 = mkNodeState (unsafeNodeId "dbx" 3306) Replica (Just ghostRs) Healthy
+          n2 = mkNodeState (unsafeNodeId "dby" 3306) Replica (Just ghostRs) Healthy
+          nodes = Map.fromList [(nsNodeId n1, n1), (nsNodeId n2, n2)]
+          topo = (mkTopo nodes) { ctSourceNodeId = Nothing }
+          event = NodeProbed (nsNodeId n1)
+            (ProbeSuccess fixedTime (Just ghostRs) emptyGtidSet)
+            emptyGtidSet fixedTime
+          (newTopo, _) = applyEvent testFdc testFc testMc topo event
+      ctSourceNodeId newTopo `shouldBe` Nothing
+      fmap nsRole (Map.lookup (nsNodeId n1) (ctNodes newTopo)) `shouldBe` Just Replica
+      fmap nsRole (Map.lookup (nsNodeId n2) (ctNodes newTopo)) `shouldBe` Just Replica
+
   describe "applyEvent FailoverCommitted" $ do
     it "demotes old sources and promotes new source" $ do
       let topo = mkTopo clusterHealthy


### PR DESCRIPTION
## Summary
- In `applyEvent NodeProbed`, apply `Map.adjust` to set `nsRole = Source` on the node identified by `identifySource`, mirroring the invariant already enforced by `buildClusterTopology` (Discovery.hs:85).
- Feed the synced node map into `detectClusterHealth` and the assembled `ClusterTopology` so `ctSourceNodeId = Just sid ⇒ nsRole (ctNodes ! sid) = Source` always holds after a `NodeProbed` event.
- Add two EventSpec cases: (1) fallback-branch case asserts the newly synced role, (2) `identifySource` returning `Nothing` leaves roles untouched.

Closes #192.

Follow-up (separate PR): revert the `isClusterSource` workaround in `PureMyHA.Failover.PauseReplica` to plain `isSource`, now that the reducer maintains the invariant.

## Test plan
- [x] `cabal build all`
- [x] `cabal test` — 578 examples, 0 failures
- [ ] E2E `08-pause-resume-replica.sh` remains green on x86_64 and aarch64

🤖 Generated with [Claude Code](https://claude.com/claude-code)