### PR TITLE
Validate password file permissions at startup (#184)

### DIFF
--- a/app/Daemon/Main.hs
+++ b/app/Daemon/Main.hs
@@ -23,6 +23,7 @@ import PureMyHA.Env (ClusterEnv (..), runApp)
 import PureMyHA.HTTP.Server (startHTTPServer)
 import PureMyHA.IPC.Server (startIPCServer, defaultSocketPath, DiscoveryAction (..), ClusterMap (..), DiscoveryMap (..))
 import PureMyHA.Logger (Logger, initLogger, closeLogger, reopenLogger, setLogLevel, logInfo, logWarn)
+import qualified PureMyHA.PasswordFile as PasswordFile
 import PureMyHA.Supervisor.StateManager (newEventQueue, stateManager)
 import PureMyHA.Supervisor.Worker (startMonitorWorkers, startTopologyRefreshWorker, WorkerRegistry (..), runWorker, emergencyReplicaCheck)
 import PureMyHA.Topology.Discovery (discoverTopology, buildInitialTopology)
@@ -263,9 +264,9 @@ loadClusterPasswords cc = do
 
 loadPassword :: Credentials -> IO Text
 loadPassword creds = do
-  result <- try @SomeException $ T.strip . T.pack <$> readFile (credPasswordFile creds)
+  result <- PasswordFile.loadPassword (credPasswordFile creds)
   case result of
-    Left err  -> die $ "Failed to read password file: " <> show err
+    Left err  -> die $ T.unpack err
     Right pwd -> pure pwd
 
 makeDiscoveryAction :: ClusterEnv -> WorkerRegistry -> DiscoveryAction

--- a/config/config.yaml.example
+++ b/config/config.yaml.example
@@ -7,6 +7,9 @@ clusters:
         port: 3306
     credentials:
       user: puremyha
+      # password_file must be a regular file (not a symlink), owned by root or
+      # the user running puremyhad, and readable only by its owner (mode 0600
+      # or 0400). The daemon refuses to start otherwise.
       password_file: /etc/puremyha/mysql.pass
     replication_credentials:           # optional; falls back to credentials if omitted
       user: repl

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -46,6 +46,16 @@ GRANT REPLICATION SLAVE ON *.* TO 'repl'@'%';
 
 > **Note:** If you use the same account for both monitoring and replication, omit `replication_credentials` from the config. PureMyHA will fall back to `credentials` automatically.
 
+### Password file security requirements
+
+Each `password_file` is validated at startup. `puremyhad` refuses to start if any of these checks fail:
+
+- **Regular file** — symlinks, directories, and device files are rejected (symlinks are explicitly disallowed to prevent TOCTOU swaps after config load).
+- **Trusted owner** — the file's owner UID must be 0 (root) or the UID running `puremyhad`.
+- **Owner-only access** — `mode & 0o077` must be zero, i.e. no group- or other-permission bit is set. Acceptable modes are `0600` (owner read/write) or `0400` (owner read-only).
+
+Recommended install: `chown root:root /etc/puremyha/*.pass && chmod 0600 /etc/puremyha/*.pass`.
+
 ## Full Configuration Reference
 
 See [`config/config.yaml.example`](../config/config.yaml.example) for the complete annotated configuration file.

--- a/e2e/Dockerfile.e2e
+++ b/e2e/Dockerfile.e2e
@@ -41,4 +41,12 @@ COPY --from=selected /staging/puremyha  /usr/bin/puremyha
 COPY --chown=root:root e2e/config/hooks /opt/puremyha/hooks
 RUN chmod 0755 /opt/puremyha/hooks/*.sh
 
+# Password files are baked into the image rather than bind-mounted from the
+# host: the daemon's startup validator rejects password files that are not
+# owned by root/daemon or whose mode allows group/other access, which a host
+# bind-mount would otherwise violate (host UID + 0644 umask).
+COPY --chown=root:root e2e/config/mysql.pass /etc/puremyha-secrets/mysql.pass
+COPY --chown=root:root e2e/config/repl.pass /etc/puremyha-secrets/repl.pass
+RUN chmod 0600 /etc/puremyha-secrets/mysql.pass /etc/puremyha-secrets/repl.pass
+
 CMD ["puremyhad"]

--- a/e2e/config/puremyha-failover-without-observed-healthy.yaml
+++ b/e2e/config/puremyha-failover-without-observed-healthy.yaml
@@ -9,10 +9,10 @@ clusters:
         port: 3306
     credentials:
       user: puremyha
-      password_file: /etc/puremyha/mysql.pass
+      password_file: /etc/puremyha-secrets/mysql.pass
     replication_credentials:
       user: repl
-      password_file: /etc/puremyha/repl.pass
+      password_file: /etc/puremyha-secrets/repl.pass
     failover:
       candidate_priority:
         - host: mysql-replica1

--- a/e2e/config/puremyha-source-only.yaml
+++ b/e2e/config/puremyha-source-only.yaml
@@ -5,10 +5,10 @@ clusters:
         port: 3306
     credentials:
       user: puremyha
-      password_file: /etc/puremyha/mysql.pass
+      password_file: /etc/puremyha-secrets/mysql.pass
     replication_credentials:
       user: repl
-      password_file: /etc/puremyha/repl.pass
+      password_file: /etc/puremyha-secrets/repl.pass
 
 global:
   monitoring:

--- a/e2e/config/puremyha-tls-skip-verify.yaml
+++ b/e2e/config/puremyha-tls-skip-verify.yaml
@@ -9,10 +9,10 @@ clusters:
         port: 3306
     credentials:
       user: puremyha
-      password_file: /etc/puremyha/mysql.pass
+      password_file: /etc/puremyha-secrets/mysql.pass
     replication_credentials:
       user: repl
-      password_file: /etc/puremyha/repl.pass
+      password_file: /etc/puremyha-secrets/repl.pass
     tls:
       mode: skip-verify
     failover:

--- a/e2e/config/puremyha-tls-verify-ca.yaml
+++ b/e2e/config/puremyha-tls-verify-ca.yaml
@@ -9,10 +9,10 @@ clusters:
         port: 3306
     credentials:
       user: puremyha
-      password_file: /etc/puremyha/mysql.pass
+      password_file: /etc/puremyha-secrets/mysql.pass
     replication_credentials:
       user: repl
-      password_file: /etc/puremyha/repl.pass
+      password_file: /etc/puremyha-secrets/repl.pass
     tls:
       mode: verify-ca
       ca_cert: /etc/puremyha/tls/ca-cert.pem

--- a/e2e/config/puremyha.yaml
+++ b/e2e/config/puremyha.yaml
@@ -9,10 +9,10 @@ clusters:
         port: 3306
     credentials:
       user: puremyha
-      password_file: /etc/puremyha/mysql.pass
+      password_file: /etc/puremyha-secrets/mysql.pass
     replication_credentials:
       user: repl
-      password_file: /etc/puremyha/repl.pass
+      password_file: /etc/puremyha-secrets/repl.pass
     failover:
       candidate_priority:
         - host: mysql-replica1

--- a/e2e/tests/28-password-file-permissions.sh
+++ b/e2e/tests/28-password-file-permissions.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Test: Password File Permissions
+#
+# Verifies that puremyhad refuses to start when a configured password_file
+# is world- or group-accessible, or owned by an untrusted user. A password
+# file holds MySQL credentials; the daemon must fail loudly at startup
+# rather than silently accept a misconfigured (e.g. 0644) deployment.
+set -euo pipefail
+source "$(dirname "$0")/../lib/helpers.sh"
+echo "=== Test 28: Password File Permissions ==="
+
+# ---------------------------------------------------------------------------
+# 1. Happy path: the image-baked password files must have the strict mode
+#    and ownership that the validator requires. This doubles as a regression
+#    guard against future Dockerfile changes.
+# ---------------------------------------------------------------------------
+wait_for_health "Healthy" 60
+
+for pass in mysql.pass repl.pass; do
+  mode=$($COMPOSE exec -T puremyhad stat -c '%a' /etc/puremyha-secrets/$pass | tr -d '\r')
+  assert_eq "$pass mode is 0600" "600" "$mode"
+
+  owner=$($COMPOSE exec -T puremyhad stat -c '%U:%G' /etc/puremyha-secrets/$pass | tr -d '\r')
+  assert_eq "$pass owned by root:root" "root:root" "$owner"
+done
+
+# ---------------------------------------------------------------------------
+# 2. Negative: daemon must refuse to start with a 0644 password file.
+#    We spawn a one-shot puremyhad against a throwaway config rather than
+#    restarting the long-running daemon container.
+# ---------------------------------------------------------------------------
+$COMPOSE exec -T puremyhad sh -c '
+  set -e
+  mkdir -p /tmp/pwtest
+  echo "pw" > /tmp/pwtest/bad.pass
+  chmod 0644 /tmp/pwtest/bad.pass
+  cat > /tmp/pwtest/bad.yaml <<EOF
+clusters:
+  - name: perm-test
+    nodes:
+      - host: mysql-source
+        port: 3306
+    credentials:
+      user: puremyha
+      password_file: /tmp/pwtest/bad.pass
+
+global:
+  monitoring:
+    interval: 1s
+    connect_timeout: 2s
+    replication_lag_warning: 5s
+    replication_lag_critical: 10s
+  failure_detection:
+    recovery_block_period: 30s
+  failover:
+    auto_failover: false
+EOF
+'
+
+exit_code=0
+output=$($COMPOSE exec -T puremyhad puremyhad \
+  --config /tmp/pwtest/bad.yaml \
+  --socket /tmp/pwtest/sock 2>&1) || exit_code=$?
+
+assert_neq "daemon exits non-zero with 0644 password file" "0" "$exit_code"
+assert_contains "daemon error mentions group/other access" "group or other" "$output"
+assert_contains "daemon error names the offending path" "/tmp/pwtest/bad.pass" "$output"
+
+# ---------------------------------------------------------------------------
+# 3. Negative: daemon must also refuse a 0640 (group-readable) file.
+# ---------------------------------------------------------------------------
+$COMPOSE exec -T puremyhad chmod 0640 /tmp/pwtest/bad.pass
+
+exit_code=0
+output=$($COMPOSE exec -T puremyhad puremyhad \
+  --config /tmp/pwtest/bad.yaml \
+  --socket /tmp/pwtest/sock 2>&1) || exit_code=$?
+
+assert_neq "daemon exits non-zero with 0640 password file" "0" "$exit_code"
+assert_contains "daemon error mentions group/other access (0640)" "group or other" "$output"
+
+# ---------------------------------------------------------------------------
+# 4. Positive control: flipping the same file to 0600 lets the daemon
+#    advance past password loading. It will still fail afterwards (the yaml
+#    has no such MySQL user), but the failure must NOT be the permission
+#    rejection. We assert that "group or other" does not appear.
+# ---------------------------------------------------------------------------
+$COMPOSE exec -T puremyhad chmod 0600 /tmp/pwtest/bad.pass
+
+exit_code=0
+output=$($COMPOSE exec -T puremyhad timeout 3 puremyhad \
+  --config /tmp/pwtest/bad.yaml \
+  --socket /tmp/pwtest/sock 2>&1) || exit_code=$?
+
+if echo "$output" | grep -qF "group or other"; then
+  echo "  FAIL: 0600 password file still triggered the permission rejection"
+  echo "  ACTUAL: $output"
+  ((FAIL_COUNT++)) || true
+else
+  echo "  PASS: 0600 password file bypasses the permission check"
+  ((PASS_COUNT++)) || true
+fi
+
+# Clean up test artefacts so re-runs start fresh
+$COMPOSE exec -T puremyhad rm -rf /tmp/pwtest 2>/dev/null || true
+
+test_summary

--- a/puremyha.cabal
+++ b/puremyha.cabal
@@ -44,6 +44,7 @@ library
     PureMyHA.Logger
     PureMyHA.Env
     PureMyHA.Hook
+    PureMyHA.PasswordFile
     PureMyHA.MySQL.Clone
     PureMyHA.MySQL.Connection
     PureMyHA.MySQL.Query
@@ -131,6 +132,7 @@ test-suite puremyha-test
     PureMyHA.DemoteSpec
     PureMyHA.PauseReplicaSpec
     PureMyHA.HookSpec
+    PureMyHA.PasswordFileSpec
   build-depends:
     puremyha,
     async            >= 2.2,

--- a/src/PureMyHA/PasswordFile.hs
+++ b/src/PureMyHA/PasswordFile.hs
@@ -1,0 +1,102 @@
+{-# LANGUAGE StrictData #-}
+module PureMyHA.PasswordFile
+  ( PasswordFileRejection (..)
+  , PasswordFileStat (..)
+  , validatePasswordFile
+  , validatePasswordFileIO
+  , loadPassword
+  , rejectionMessage
+  ) where
+
+import Control.Exception (SomeException, try)
+import Data.Bits ((.&.))
+import Data.Text (Text)
+import qualified Data.Text as T
+import qualified System.Posix.Files as PF
+import System.Posix.Types (FileMode, UserID)
+import qualified System.Posix.User as PU
+
+-- | Why a password file was refused during startup validation.
+--
+-- A password file holds MySQL credentials that a daemon must be able to read;
+-- leaving it world- or group-accessible leaks those credentials to every local
+-- user. These checks mirror the stance already enforced for hook scripts in
+-- "PureMyHA.Hook", but with a stricter mode policy (only the owner may read).
+data PasswordFileRejection
+  = NotRegularFile          -- ^ Symlink, directory, device, etc.
+  | UntrustedOwner          -- ^ Owner is neither root (UID 0) nor the daemon's UID.
+  | GroupOrOtherAccessible  -- ^ Any bit in @mode & 0o077@ is set.
+  deriving (Eq, Show)
+
+-- | Subset of stat(2) required to decide whether a password file is safe to
+-- read. Extracted so 'validatePasswordFile' stays pure and easy to unit-test.
+data PasswordFileStat = PasswordFileStat
+  { pfsIsRegularFile :: Bool
+  , pfsOwner         :: UserID
+  , pfsMode          :: FileMode
+  } deriving (Eq, Show)
+
+-- | Pure validator. Rejects the file unless:
+--
+--   * it is a regular file (symlinks/dirs/special files are refused),
+--   * its owner is root (UID 0) or the supplied daemon UID,
+--   * @mode & 0o077@ is zero (no group- or other-permission bit is set).
+--
+-- The first clause to fire wins, so tests can rely on a stable ordering.
+validatePasswordFile
+  :: FilePath              -- ^ path as configured (unused for decisions; kept for symmetry with Hook)
+  -> PasswordFileStat      -- ^ stat info for the path
+  -> UserID                -- ^ daemon's real UID
+  -> Either PasswordFileRejection ()
+validatePasswordFile _path stat daemonUid
+  | not (pfsIsRegularFile stat)                          = Left NotRegularFile
+  | pfsOwner stat /= 0 && pfsOwner stat /= daemonUid     = Left UntrustedOwner
+  | pfsMode stat .&. 0o077 /= 0                          = Left GroupOrOtherAccessible
+  | otherwise                                            = Right ()
+
+-- | Render a rejection as an operator-facing message that names the offending
+-- path. Used both by the IO wrappers and by the daemon when aborting startup.
+rejectionMessage :: FilePath -> PasswordFileRejection -> Text
+rejectionMessage path r = case r of
+  NotRegularFile ->
+    "Password file is not a regular file (symlink/dir rejected): " <> T.pack path
+  UntrustedOwner ->
+    "Password file owner is neither root nor the daemon user: " <> T.pack path
+  GroupOrOtherAccessible ->
+    "Password file is accessible to group or other (require mode 0600 or 0400): " <> T.pack path
+
+-- | IO wrapper around 'validatePasswordFile': stats the path without following
+-- symlinks, looks up the daemon's real UID, then delegates to the pure
+-- validator. Returns 'Left' with a human-readable message on any failure —
+-- including stat failures such as ENOENT.
+validatePasswordFileIO :: FilePath -> IO (Either Text ())
+validatePasswordFileIO path = do
+  eStat <- try @SomeException (PF.getSymbolicLinkStatus path)
+  case eStat of
+    Left err -> pure $ Left $
+      "Password file stat failed for " <> T.pack path <> ": " <> T.pack (show err)
+    Right fs -> do
+      daemonUid <- PU.getRealUserID
+      let stat = PasswordFileStat
+            { pfsIsRegularFile = PF.isRegularFile fs
+            , pfsOwner         = PF.fileOwner fs
+            , pfsMode          = PF.fileMode fs
+            }
+      pure $ case validatePasswordFile path stat daemonUid of
+        Right ()  -> Right ()
+        Left rej  -> Left (rejectionMessage path rej)
+
+-- | Validate the path, then read the password. The returned text is stripped
+-- of surrounding whitespace (matching the prior daemon behaviour). Any error —
+-- validation or I/O — becomes 'Left' with an operator-facing message.
+loadPassword :: FilePath -> IO (Either Text Text)
+loadPassword path = do
+  valid <- validatePasswordFileIO path
+  case valid of
+    Left err -> pure (Left err)
+    Right () -> do
+      result <- try @SomeException (readFile path)
+      pure $ case result of
+        Left err  -> Left $ "Failed to read password file " <> T.pack path
+                          <> ": " <> T.pack (show err)
+        Right raw -> Right (T.strip (T.pack raw))

--- a/test/PureMyHA/PasswordFileSpec.hs
+++ b/test/PureMyHA/PasswordFileSpec.hs
@@ -1,0 +1,175 @@
+module PureMyHA.PasswordFileSpec (spec) where
+
+import Data.Either (isLeft, isRight)
+import qualified Data.Text as T
+import System.IO (hClose, hPutStrLn)
+import System.IO.Temp (withSystemTempFile)
+import System.Posix.Files (setFileMode)
+import Test.Hspec
+
+import PureMyHA.PasswordFile
+  ( PasswordFileRejection (..)
+  , PasswordFileStat (..)
+  , loadPassword
+  , rejectionMessage
+  , validatePasswordFile
+  , validatePasswordFileIO
+  )
+
+-- | Baseline stat value representing a well-formed password file:
+-- regular file, owned by root, mode 0600.
+rootOwned0600 :: PasswordFileStat
+rootOwned0600 = PasswordFileStat
+  { pfsIsRegularFile = True
+  , pfsOwner         = 0
+  , pfsMode          = 0o600
+  }
+
+spec :: Spec
+spec = do
+  describe "validatePasswordFile" $ do
+    it "accepts root-owned 0o600" $
+      validatePasswordFile "/etc/puremyha/mysql.pass" rootOwned0600 1000
+        `shouldBe` Right ()
+
+    it "accepts daemon-owned 0o600" $ do
+      let stat = rootOwned0600 { pfsOwner = 1000 }
+      validatePasswordFile "/home/puremyha/mysql.pass" stat 1000
+        `shouldBe` Right ()
+
+    it "accepts root-owned 0o400" $ do
+      let stat = rootOwned0600 { pfsMode = 0o400 }
+      validatePasswordFile "/etc/puremyha/mysql.pass" stat 1000
+        `shouldBe` Right ()
+
+    it "accepts daemon-owned 0o400" $ do
+      let stat = rootOwned0600 { pfsOwner = 1000, pfsMode = 0o400 }
+      validatePasswordFile "/home/puremyha/mysql.pass" stat 1000
+        `shouldBe` Right ()
+
+    it "rejects 0o644 (world-readable)" $ do
+      let stat = rootOwned0600 { pfsMode = 0o644 }
+      validatePasswordFile "/etc/puremyha/mysql.pass" stat 1000
+        `shouldBe` Left GroupOrOtherAccessible
+
+    it "rejects 0o666 (world-writable)" $ do
+      let stat = rootOwned0600 { pfsMode = 0o666 }
+      validatePasswordFile "/etc/puremyha/mysql.pass" stat 1000
+        `shouldBe` Left GroupOrOtherAccessible
+
+    it "rejects 0o640 (group-readable)" $ do
+      let stat = rootOwned0600 { pfsMode = 0o640 }
+      validatePasswordFile "/etc/puremyha/mysql.pass" stat 1000
+        `shouldBe` Left GroupOrOtherAccessible
+
+    it "rejects 0o660 (group-writable)" $ do
+      let stat = rootOwned0600 { pfsMode = 0o660 }
+      validatePasswordFile "/etc/puremyha/mysql.pass" stat 1000
+        `shouldBe` Left GroupOrOtherAccessible
+
+    it "rejects 0o606 (other-writable only)" $ do
+      let stat = rootOwned0600 { pfsMode = 0o606 }
+      validatePasswordFile "/etc/puremyha/mysql.pass" stat 1000
+        `shouldBe` Left GroupOrOtherAccessible
+
+    it "rejects 0o604 (other-readable only)" $ do
+      let stat = rootOwned0600 { pfsMode = 0o604 }
+      validatePasswordFile "/etc/puremyha/mysql.pass" stat 1000
+        `shouldBe` Left GroupOrOtherAccessible
+
+    it "rejects a non-regular file (symlink/dir/device)" $ do
+      let stat = rootOwned0600 { pfsIsRegularFile = False }
+      validatePasswordFile "/etc/puremyha/mysql.pass" stat 1000
+        `shouldBe` Left NotRegularFile
+
+    it "rejects a file owned by an untrusted user" $ do
+      let stat = rootOwned0600 { pfsOwner = 9999 }
+      validatePasswordFile "/etc/puremyha/mysql.pass" stat 1000
+        `shouldBe` Left UntrustedOwner
+
+    it "prefers NotRegularFile over mode/owner failures" $ do
+      let stat = PasswordFileStat
+            { pfsIsRegularFile = False
+            , pfsOwner         = 9999
+            , pfsMode          = 0o777
+            }
+      validatePasswordFile "/etc/puremyha/mysql.pass" stat 1000
+        `shouldBe` Left NotRegularFile
+
+  describe "rejectionMessage" $ do
+    it "names the offending path for each rejection" $ do
+      rejectionMessage "/etc/puremyha/mysql.pass" NotRegularFile
+        `shouldSatisfy` T.isInfixOf (T.pack "/etc/puremyha/mysql.pass")
+      rejectionMessage "/etc/puremyha/mysql.pass" UntrustedOwner
+        `shouldSatisfy` T.isInfixOf (T.pack "/etc/puremyha/mysql.pass")
+      rejectionMessage "/etc/puremyha/mysql.pass" GroupOrOtherAccessible
+        `shouldSatisfy` T.isInfixOf (T.pack "/etc/puremyha/mysql.pass")
+
+  describe "validatePasswordFileIO" $ do
+    it "rejects a non-existent path with a stat error" $ do
+      result <- validatePasswordFileIO "/nonexistent/puremyha/mysql-xyz.pass"
+      result `shouldSatisfy` isLeft
+
+    it "accepts a temp file owned by the current user with mode 0o600" $ do
+      withSystemTempFile "puremyha-pass-ok.pass" $ \path h -> do
+        hPutStrLn h "hunter2"
+        hClose h
+        setFileMode path 0o600
+        result <- validatePasswordFileIO path
+        result `shouldBe` Right ()
+
+    it "accepts mode 0o400" $ do
+      withSystemTempFile "puremyha-pass-ro.pass" $ \path h -> do
+        hPutStrLn h "hunter2"
+        hClose h
+        setFileMode path 0o400
+        result <- validatePasswordFileIO path
+        result `shouldBe` Right ()
+
+    it "rejects a temp file after it is chmodded world-readable" $ do
+      withSystemTempFile "puremyha-pass-644.pass" $ \path h -> do
+        hPutStrLn h "hunter2"
+        hClose h
+        setFileMode path 0o644
+        result <- validatePasswordFileIO path
+        result `shouldSatisfy` isLeft
+
+    it "rejects a temp file after it is chmodded group-readable" $ do
+      withSystemTempFile "puremyha-pass-640.pass" $ \path h -> do
+        hPutStrLn h "hunter2"
+        hClose h
+        setFileMode path 0o640
+        result <- validatePasswordFileIO path
+        result `shouldSatisfy` isLeft
+
+  describe "loadPassword" $ do
+    it "returns the stripped content for a well-permissioned file" $ do
+      withSystemTempFile "puremyha-pass-load.pass" $ \path h -> do
+        hPutStrLn h "  hunter2  "   -- trailing newline + surrounding space
+        hClose h
+        setFileMode path 0o600
+        result <- loadPassword path
+        result `shouldBe` Right (T.pack "hunter2")
+
+    it "fails for a 0o644 file" $ do
+      withSystemTempFile "puremyha-pass-reject.pass" $ \path h -> do
+        hPutStrLn h "hunter2"
+        hClose h
+        setFileMode path 0o644
+        result <- loadPassword path
+        result `shouldSatisfy` isLeft
+
+    it "fails for a missing file" $ do
+      result <- loadPassword "/nonexistent/puremyha/nope.pass"
+      result `shouldSatisfy` isLeft
+
+    it "accepts a password with internal whitespace (only strips the edges)" $ do
+      withSystemTempFile "puremyha-pass-inner.pass" $ \path h -> do
+        hPutStrLn h "  hun ter 2  "
+        hClose h
+        setFileMode path 0o600
+        result <- loadPassword path
+        result `shouldSatisfy` isRight
+        case result of
+          Right pwd -> pwd `shouldBe` T.pack "hun ter 2"
+          Left _    -> expectationFailure "expected Right"


### PR DESCRIPTION
## Summary
- Add `PureMyHA.PasswordFile` with a pure validator, IO wrapper, and `loadPassword` that refuses symlinks, untrusted owners, and any file whose mode has group/other bits set — mirroring the pattern already used for hook scripts.
- Wire the daemon's startup `loadPassword` through the new module so misconfigured (e.g. `0644`) password files abort startup with a clear operator-facing message.
- Bake e2e password files into the image at `/etc/puremyha-secrets/` with `root:root 0600` (the host bind-mount would otherwise violate the new check).
- Document the permission requirements in `config/config.yaml.example` and `docs/configuration.md`.

Closes #184.

## Test plan
- [x] `cabal build all` — clean build
- [x] `cabal test` — 601 examples, 0 failures (23 new `PureMyHA.PasswordFileSpec` cases: pure validator, IO wrapper with `withSystemTempFile` + `setFileMode`, `loadPassword` including whitespace stripping)
- [x] `bash e2e/run-all.sh` — 29 / 29 passed, including new `28-password-file-permissions.sh` (bundled file is `0600 root:root`; `0644` and `0640` both abort startup with a `group or other` message; `0600` bypasses the check)
- [x] Regression: `26-hook-security`, `27-ipc-socket-permissions` still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)