### PR TITLE
Warn on TLS skip-verify at startup and SIGHUP reload (#185)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Inspired by the design of Orchestrator, PureMyHA provides topology discovery, fa
 - **HTTP Endpoints** — Optional read-only HTTP listener: `/health`, `/cluster/:name/status`, `/cluster/:name/topology` for load balancers and Kubernetes probes
 - **Prometheus Metrics** — `GET /metrics` exposes cluster health, replication lag, consecutive failures, and node role
 - **Hooks** — Pre/post hooks for failover and switchover; `on_lag_threshold_exceeded` / `on_lag_threshold_recovered` for alerting
-- **Optional TLS** — Per-cluster TLS for MySQL connections with configurable verification mode and minimum TLS version
+- **Optional TLS** — Per-cluster TLS for MySQL connections with configurable verification mode and minimum TLS version (the daemon emits a startup/SIGHUP WARN when `skip-verify` is used, so development-only settings cannot silently ship to production)
 
 ### Operator Controls
 - **Config Hot-Reload** — Reloads `monitoring` and `hooks` config on SIGHUP without restart

--- a/app/Daemon/Main.hs
+++ b/app/Daemon/Main.hs
@@ -5,7 +5,7 @@ import Control.Concurrent.MVar  (MVar, newEmptyMVar, takeMVar, tryPutMVar)
 import Control.Concurrent.STM   (TMVar, TVar, atomically, newTVarIO, newEmptyTMVarIO,
                                   putTMVar, takeTMVar, writeTVar, readTVarIO, modifyTVar')
 import Control.Exception (try, SomeException)
-import Control.Monad (forever, void, forM_)
+import Control.Monad (forever, void, forM_, when)
 import Data.Foldable (find)
 import qualified Data.List.NonEmpty as NE
 import Data.Maybe (fromMaybe)
@@ -122,9 +122,12 @@ reloadConfigOnce configPath clusterEnvs loggerVar httpAsyncVar tvar = do
         let name = ccName (envCluster env)
         case find (\cc -> ccName cc == name) (NE.toList (cfgClusters cfg')) of
           Nothing -> logWarn logger $ "SIGHUP: cluster " <> unClusterName name <> " not found in new config"
-          Just cc -> atomically $ do
-            writeTVar (envMonitoring env) (ccMonitoring cc)
-            writeTVar (envHooks env)      (ccHooks cc)
+          Just cc -> do
+            atomically $ do
+              writeTVar (envMonitoring env) (ccMonitoring cc)
+              writeTVar (envHooks env)      (ccHooks cc)
+            when (isSkipVerify (ccTLS cc)) $
+              logWarn logger (skipVerifyWarningMessage (ccName cc))
       mOld <- readTVarIO httpAsyncVar
       forM_ mOld cancel
       case hcEnabled (cfgHttp cfg') of
@@ -247,6 +250,8 @@ initCluster tvar loggerVar (cc, pws) = do
         }
   topo <- runApp env discoverTopology
   logger <- readTVarIO loggerVar
+  when (isSkipVerify (ccTLS cc)) $
+    logWarn logger (skipVerifyWarningMessage (ccName cc))
   logInfo logger $ "[" <> unClusterName (ccName cc) <> "] Initial discovery found "
     <> T.pack (show (Map.size (ctNodes topo))) <> " node(s)"
   atomically $ updateClusterTopology tvar topo

--- a/config/config.yaml.example
+++ b/config/config.yaml.example
@@ -16,6 +16,9 @@ clusters:
       password_file: /etc/puremyha/repl.pass
     # tls:                                             # optional per-cluster TLS for MySQL connections
     #   mode: disabled                                 # disabled | skip-verify | verify-ca | verify-full. Default: disabled
+    #                                                  # Note: skip-verify does not validate the MySQL server certificate
+    #                                                  # and is intended for development only. The daemon emits a WARN
+    #                                                  # at startup and on every SIGHUP reload when skip-verify is set.
     #   min_version: "1.2"                             # optional; "1.2" (default, allows TLS 1.2+) | "1.3" (TLS 1.3 only)
     #   ca_cert: /etc/puremyha/tls/ca-cert.pem        # required for verify-ca / verify-full
     #   client_cert: /etc/puremyha/tls/client.pem     # optional (mutual TLS)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -121,6 +121,8 @@ tls:
 
 When `mode` is not `disabled`, PureMyHA sends a MySQL SSL_REQUEST packet before the authentication handshake, compatible with `require_secure_transport=ON`.
 
+`skip-verify` disables server certificate validation and leaves the connection vulnerable to MITM. It is intended for development only. When any cluster is configured with `skip-verify`, the daemon emits a WARN log line at startup and again on each `SIGHUP` reload so the insecure setting cannot slip into production unnoticed.
+
 ## Auto-Fence Split-Brain
 
 When `failover.auto_fence: true` is set, PureMyHA automatically sets `super_read_only=ON` on all non-survivor source nodes when `SplitBrainSuspected` is detected. The survivor is the node with the highest executed GTID transaction count.

--- a/docs/features.md
+++ b/docs/features.md
@@ -155,7 +155,7 @@ Per-cluster TLS for MySQL connections. Supports `require_secure_transport=ON`.
 | Mode | Behaviour |
 |---|---|
 | `disabled` | Plain text (default) |
-| `skip-verify` | TLS, server certificate not verified |
+| `skip-verify` | TLS, server certificate not verified (development only; daemon logs a WARN at startup and on every SIGHUP reload) |
 | `verify-ca` | TLS, CA certificate verified |
 | `verify-full` | TLS, CA + hostname verified |
 

--- a/e2e/run-tls.sh
+++ b/e2e/run-tls.sh
@@ -46,7 +46,7 @@ wait_for_health "Healthy" 60
 
 echo ""
 echo "========================================="
-echo "  TLS E2E environment ready. Running test 15."
+echo "  TLS E2E environment ready. Running tests 15 and 29."
 echo "========================================="
 echo ""
 
@@ -55,6 +55,7 @@ FAIL_COUNT=0
 
 reset_cluster
 bash tests/15-tls.sh
+bash tests/29-tls-skip-verify-warn.sh
 
 echo ""
 echo "========================================="

--- a/e2e/tests/29-tls-skip-verify-warn.sh
+++ b/e2e/tests/29-tls-skip-verify-warn.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Test: TLS skip-verify WARN at startup and on SIGHUP (issue #185)
+# Verifies that puremyhad emits a prominent WARN when a cluster is configured
+# with tls.mode: skip-verify, both on daemon startup and on each SIGHUP reload.
+# Requires the TLS environment (run via e2e/run-tls.sh); skips gracefully otherwise.
+set -euo pipefail
+source "$(dirname "$0")/../lib/helpers.sh"
+echo "=== Test 29: TLS skip-verify WARN ==="
+
+# Skip if not running in TLS environment (certificates not mounted)
+if ! $COMPOSE exec -T mysql-source sh -c "test -f /etc/mysql/tls/ca-cert.pem" 2>/dev/null; then
+  echo "  SKIP: TLS certificates not mounted — run via e2e/run-tls.sh"
+  test_summary
+  exit 0
+fi
+
+LOG_FILE=/var/log/puremyha.log
+WARN_PATTERN="TLS mode 'skip-verify'"
+
+count_warn_lines() {
+  $COMPOSE exec -T puremyhad sh -c "grep -c \"$WARN_PATTERN\" $LOG_FILE || true" \
+    | tr -d '[:space:]'
+}
+
+count_reload_lines() {
+  $COMPOSE exec -T puremyhad sh -c "grep -c 'SIGHUP: config reloaded' $LOG_FILE || true" \
+    | tr -d '[:space:]'
+}
+
+send_sighup() {
+  $COMPOSE exec -T puremyhad sh -c 'kill -HUP $(pidof puremyhad)'
+}
+
+wait_for_reload_count() {
+  local target="$1" max_wait="${2:-10}"
+  for _ in $(seq 1 "$max_wait"); do
+    local n
+    n=$(count_reload_lines)
+    if [ "${n:-0}" -ge "$target" ]; then
+      return 0
+    fi
+    sleep 1
+  done
+  return 1
+}
+
+# --- Case 1: startup WARN is present -----------------------------------------
+startup_warns=$(count_warn_lines)
+startup_warns=${startup_warns:-0}
+echo "  Startup '$WARN_PATTERN' count: $startup_warns"
+if [ "$startup_warns" -ge 1 ]; then
+  echo "  PASS: startup WARN for skip-verify present in daemon log"
+  ((PASS_COUNT++)) || true
+else
+  echo "  FAIL: no startup WARN for skip-verify in $LOG_FILE"
+  $COMPOSE exec -T puremyhad tail -n 40 "$LOG_FILE" || true
+  ((FAIL_COUNT++)) || true
+fi
+
+# Confirm the cluster name is embedded in the WARN line (e.g. "[e2e]")
+cluster_prefixed=$($COMPOSE exec -T puremyhad sh -c \
+  "grep -c \"\[e2e\].*$WARN_PATTERN\" $LOG_FILE || true" | tr -d '[:space:]')
+if [ "${cluster_prefixed:-0}" -ge 1 ]; then
+  echo "  PASS: WARN line includes cluster name prefix"
+  ((PASS_COUNT++)) || true
+else
+  echo "  FAIL: WARN line missing cluster name prefix"
+  ((FAIL_COUNT++)) || true
+fi
+
+# --- Case 2: SIGHUP re-emits the WARN ----------------------------------------
+reload_baseline=$(count_reload_lines)
+reload_baseline=${reload_baseline:-0}
+before=$startup_warns
+
+send_sighup
+if ! wait_for_reload_count "$((reload_baseline + 1))" 10; then
+  echo "  FAIL: SIGHUP did not produce a reload log line within 10s"
+  ((FAIL_COUNT++)) || true
+else
+  # Allow the reload worker to finish writing the WARN line after the atomically block
+  sleep 1
+  after=$(count_warn_lines)
+  after=${after:-0}
+  if [ "$after" -gt "$before" ]; then
+    echo "  PASS: SIGHUP reload re-emitted skip-verify WARN ($before → $after)"
+    ((PASS_COUNT++)) || true
+  else
+    echo "  FAIL: SIGHUP reload did not re-emit skip-verify WARN (still $after)"
+    $COMPOSE exec -T puremyhad tail -n 40 "$LOG_FILE" || true
+    ((FAIL_COUNT++)) || true
+  fi
+fi
+
+test_summary

--- a/src/PureMyHA/Config.hs
+++ b/src/PureMyHA/Config.hs
@@ -34,6 +34,8 @@ module PureMyHA.Config
   , loadConfig
   , parseDuration
   , validateConfig
+  , isSkipVerify
+  , skipVerifyWarningMessage
   ) where
 
 import Control.Applicative ((<|>))
@@ -542,3 +544,12 @@ validateConfig cfg = clusterErrors
 duplicates :: Ord a => [a] -> [a]
 -- NE.head is total here: NE.group produces a [NonEmpty a].
 duplicates = map NE.head . filter ((> 1) . length) . NE.group . sort
+
+isSkipVerify :: Maybe TLSConfig -> Bool
+isSkipVerify = maybe False ((== TLSSkipVerify) . tlsMode)
+
+skipVerifyWarningMessage :: ClusterName -> Text
+skipVerifyWarningMessage name =
+  "[" <> unClusterName name <> "] WARNING: TLS mode 'skip-verify' disables"
+    <> " MySQL server certificate validation. This is insecure;"
+    <> " use 'verify-ca' or 'verify-full' in production."

--- a/test/PureMyHA/ConfigSpec.hs
+++ b/test/PureMyHA/ConfigSpec.hs
@@ -9,6 +9,7 @@ import qualified Data.List.NonEmpty as NE
 import Data.Maybe (isNothing)
 import qualified Data.Yaml as Yaml
 import Test.Hspec
+import qualified Data.Text as T
 import PureMyHA.Config
   ( Config (..), ClusterConfig (..), MonitoringConfig (..)
   , FailureDetectionConfig (..), FailoverConfig (..)
@@ -22,7 +23,9 @@ import PureMyHA.Config
   , DbCredentials (..), ClusterPasswords (..)
   , Port (..), PositiveDuration (..), AtLeastOne (..)
   , AutoFailoverMode (..), FenceMode (..), ObservedHealthyRequirement (..)
+  , isSkipVerify, skipVerifyWarningMessage
   )
+import PureMyHA.Types (ClusterName (..))
 
 spec :: Spec
 spec = do
@@ -657,6 +660,32 @@ spec = do
             , globalBlock
             ]
       decodeConfig yaml `shouldSatisfy` isLeft
+
+  describe "isSkipVerify" $ do
+    let tls m = TLSConfig { tlsMode = m, tlsMinVersion = Nothing
+                          , tlsCACert = Nothing, tlsClientCert = Nothing
+                          , tlsClientKey = Nothing }
+    it "returns False when TLS is not configured" $
+      isSkipVerify Nothing `shouldBe` False
+    it "returns False for TLSDisabled" $
+      isSkipVerify (Just (tls TLSDisabled)) `shouldBe` False
+    it "returns True for TLSSkipVerify" $
+      isSkipVerify (Just (tls TLSSkipVerify)) `shouldBe` True
+    it "returns False for TLSVerifyCA" $
+      isSkipVerify (Just (tls TLSVerifyCA)) `shouldBe` False
+    it "returns False for TLSVerifyFull" $
+      isSkipVerify (Just (tls TLSVerifyFull)) `shouldBe` False
+
+  describe "skipVerifyWarningMessage" $ do
+    let msg = skipVerifyWarningMessage (ClusterName "prod-main")
+    it "includes the cluster name in brackets" $
+      T.isInfixOf "[prod-main]" msg `shouldBe` True
+    it "mentions skip-verify" $
+      T.isInfixOf "skip-verify" msg `shouldBe` True
+    it "mentions that it is insecure" $
+      T.isInfixOf "insecure" msg `shouldBe` True
+    it "starts with a WARNING marker" $
+      T.isInfixOf "WARNING" msg `shouldBe` True
 
   describe "validateConfig" $ do
     it "returns no errors for a valid config" $ do


### PR DESCRIPTION
## Summary
- Emit a WARN log for each cluster configured with `tls.mode: skip-verify`, both when `initCluster` runs at startup and when `reloadConfigOnce` handles a SIGHUP, so development-only settings cannot silently ship to production
- Extract the detection as a pure helper (`isSkipVerify`) with a separate message builder (`skipVerifyWarningMessage`) — unit-tested in `test/PureMyHA/ConfigSpec.hs`
- Add E2E test `29-tls-skip-verify-warn.sh` (run under the TLS overlay) that asserts the WARN appears on startup and is re-emitted on SIGHUP reload
- Document the new behaviour in `README.md`, `docs/configuration.md`, `docs/features.md`, and `config/config.yaml.example`
- Add placeholder `e2e/config/tls/` so the nested bind mount from `docker-compose.tls.yml` succeeds over the base `./config:/etc/puremyha:ro` read-only mount

Closes #185.

## Test plan
- [x] `cabal build all`
- [x] `cabal test` — 610/610 pass (9 new cases: 5 for `isSkipVerify`, 4 for `skipVerifyWarningMessage`)
- [x] `e2e/run-tls.sh` — test 15 (5/5) and test 29 (3/3) pass; SIGHUP WARN count transitions 1 → 2 as expected
- [ ] Reviewer: verify `git log --grep 'skip-verify'` shows the new commit only under this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)