### PR TITLE
Add basic security headers to HTTP status server (#186)

### DIFF
--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -57,6 +57,18 @@ backend mysql_source
     server db2 db2:3306 check port 8080
 ```
 
+## Security headers
+
+Every response (including `404` and `405`) carries the following headers as defence in depth against accidental browser access:
+
+| Header | Value | Purpose |
+|--------|-------|---------|
+| `X-Content-Type-Options` | `nosniff` | Disable MIME sniffing |
+| `X-Frame-Options` | `DENY` | Block embedding in iframes (clickjacking) |
+| `Cache-Control` | `no-store` | Keep responses out of intermediate caches |
+
+These do not change the response body and are safe for `curl`, load balancers, Kubernetes probes, and Prometheus scrapers.
+
 ## Configuration
 
 ```yaml

--- a/e2e/lib/helpers.sh
+++ b/e2e/lib/helpers.sh
@@ -163,6 +163,13 @@ http_get_body() {
   $COMPOSE exec -T puremyhad curl -s "http://127.0.0.1:8080${path}"
 }
 
+http_get_header() {
+  local path="$1" header="$2"
+  $COMPOSE exec -T puremyhad curl -sI "http://127.0.0.1:8080${path}" \
+    | tr -d '\r' \
+    | awk -v h="${header}:" 'index(tolower($0), tolower(h)) == 1 { sub(/^[^:]+: */, ""); print; exit }'
+}
+
 # Extract fields from CLI status response
 get_health() {
   cli_status | jq -r '.[0].health // empty' 2>/dev/null || echo ""

--- a/e2e/tests/13-http-health-check.sh
+++ b/e2e/tests/13-http-health-check.sh
@@ -56,6 +56,13 @@ assert_eq "Unknown route returns 404" "404" "$status"
 status=$($COMPOSE exec -T puremyhad curl -s -o /dev/null -w "%{http_code}" -X POST "http://127.0.0.1:8080/health")
 assert_eq "POST /health returns 405" "405" "$status"
 
+# Security headers (defence-in-depth) — verify on representative endpoints
+for ep in "/health" "/cluster/e2e/status" "/metrics"; do
+  assert_eq "X-Content-Type-Options on ${ep}" "nosniff"   "$(http_get_header "${ep}" "X-Content-Type-Options")"
+  assert_eq "X-Frame-Options on ${ep}"        "DENY"      "$(http_get_header "${ep}" "X-Frame-Options")"
+  assert_eq "Cache-Control on ${ep}"          "no-store"  "$(http_get_header "${ep}" "Cache-Control")"
+done
+
 # GET /health returns 200 even when source is dead (liveness probe — daemon is still running)
 # Pause auto-failover so health stays degraded long enough to observe
 cli_pause_failover >/dev/null 2>&1

--- a/src/PureMyHA/HTTP/Server.hs
+++ b/src/PureMyHA/HTTP/Server.hs
@@ -2,6 +2,9 @@ module PureMyHA.HTTP.Server
   ( startHTTPServer
   , renderMetrics
   , httpApp
+  , securedHttpApp
+  , withSecurityHeaders
+  , securityHeaders
   ) where
 
 import qualified Data.ByteString.Lazy as BSL
@@ -11,8 +14,8 @@ import Data.String (fromString)
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
-import Network.HTTP.Types (status200, status404, status405, methodGet, Header)
-import Network.Wai (Application, Request (..), Response, responseLBS)
+import Network.HTTP.Types (status200, status404, status405, methodGet, Header, ResponseHeaders)
+import Network.Wai (Application, Middleware, Request (..), Response, mapResponseHeaders, responseLBS)
 import Network.Wai.Handler.Warp (defaultSettings, runSettings, setHost, setPort)
 
 import PureMyHA.Config (HttpConfig (..))
@@ -114,7 +117,24 @@ startHTTPServer cfg tvar = do
   let settings = setHost (fromString (hcListenAddress cfg))
                $ setPort (unPort (hcPort cfg))
                $ defaultSettings
-  runSettings settings (httpApp tvar)
+  runSettings settings (securedHttpApp tvar)
+
+-- | Defence-in-depth headers added to every HTTP response. The endpoints are
+-- intended for operators / load balancers, but a stray browser hit should not
+-- be MIME-sniffed, framed, or cached by an intermediary.
+securityHeaders :: ResponseHeaders
+securityHeaders =
+  [ ("X-Content-Type-Options", "nosniff")
+  , ("X-Frame-Options", "DENY")
+  , ("Cache-Control", "no-store")
+  ]
+
+withSecurityHeaders :: Middleware
+withSecurityHeaders app req respond =
+  app req (respond . mapResponseHeaders (securityHeaders ++))
+
+securedHttpApp :: TVarDaemonState -> Application
+securedHttpApp = withSecurityHeaders . httpApp
 
 httpApp :: TVarDaemonState -> Application
 httpApp tvar req respond

--- a/test/PureMyHA/HTTPSpec.hs
+++ b/test/PureMyHA/HTTPSpec.hs
@@ -6,12 +6,12 @@ import qualified Data.ByteString.Lazy.Char8 as BSL8
 import Data.IORef
 import qualified Data.Map.Strict as Map
 import Network.HTTP.Types (methodGet, methodPost, status200, status404, status405)
-import Network.Wai (defaultRequest, Request (..), Response, responseStatus)
+import Network.Wai (defaultRequest, Request (..), Response, responseHeaders, responseStatus)
 import Network.Wai.Internal (ResponseReceived (..))
 import Test.Hspec
 
 import Fixtures
-import PureMyHA.HTTP.Server (renderMetrics, httpApp)
+import PureMyHA.HTTP.Server (renderMetrics, httpApp, securedHttpApp, securityHeaders)
 import PureMyHA.Topology.State (newDaemonState, updateClusterTopology)
 import PureMyHA.Types
 
@@ -169,6 +169,80 @@ spec = do
       let req = defaultRequest { requestMethod = methodGet, pathInfo = ["metrics"] }
       resp <- runApp (httpApp tvar) req
       responseStatus resp `shouldBe` status200
+
+  describe "securityHeaders constant" $ do
+    it "contains exactly the three expected headers in order" $
+      securityHeaders `shouldBe`
+        [ ("X-Content-Type-Options", "nosniff")
+        , ("X-Frame-Options", "DENY")
+        , ("Cache-Control", "no-store")
+        ]
+
+  describe "securedHttpApp adds security headers" $ do
+    let expectAllSecurityHeaders resp = do
+          let hs = responseHeaders resp
+          lookup "X-Content-Type-Options" hs `shouldBe` Just "nosniff"
+          lookup "X-Frame-Options"        hs `shouldBe` Just "DENY"
+          lookup "Cache-Control"          hs `shouldBe` Just "no-store"
+
+    it "adds headers on /health (200)" $ do
+      tvar <- newDaemonState
+      let req = defaultRequest { requestMethod = methodGet, pathInfo = ["health"] }
+      resp <- runApp (securedHttpApp tvar) req
+      responseStatus resp `shouldBe` status200
+      expectAllSecurityHeaders resp
+
+    it "adds headers on unknown path (404)" $ do
+      tvar <- newDaemonState
+      let req = defaultRequest { requestMethod = methodGet, pathInfo = ["nope"] }
+      resp <- runApp (securedHttpApp tvar) req
+      responseStatus resp `shouldBe` status404
+      expectAllSecurityHeaders resp
+
+    it "adds headers on POST (405)" $ do
+      tvar <- newDaemonState
+      resp <- runApp (securedHttpApp tvar) postReq
+      responseStatus resp `shouldBe` status405
+      expectAllSecurityHeaders resp
+
+    it "adds headers on /metrics and preserves Prometheus Content-Type" $ do
+      tvar <- newDaemonState
+      let req = defaultRequest { requestMethod = methodGet, pathInfo = ["metrics"] }
+      resp <- runApp (securedHttpApp tvar) req
+      responseStatus resp `shouldBe` status200
+      expectAllSecurityHeaders resp
+      lookup "Content-Type" (responseHeaders resp)
+        `shouldBe` Just "text/plain; version=0.0.4; charset=utf-8"
+
+    it "adds headers on /cluster/<name>/status (200)" $ do
+      tvar <- newDaemonState
+      let ct = ClusterTopology
+                { ctClusterName = "test", ctNodes = clusterHealthy
+                , ctSourceNodeId = Just (unsafeNodeId "db1" 3306), ctHealth = Healthy
+                , ctObservedHealthy = HasBeenObservedHealthy, ctRecoveryBlockedUntil = Nothing
+                , ctLastFailoverAt = Nothing, ctPaused = Running
+                , ctTopologyDrift = NoDrift
+                , ctLastEmergencyCheckAt = Nothing }
+      atomically $ updateClusterTopology tvar ct
+      let req = defaultRequest { requestMethod = methodGet, pathInfo = ["cluster", "test", "status"] }
+      resp <- runApp (securedHttpApp tvar) req
+      responseStatus resp `shouldBe` status200
+      expectAllSecurityHeaders resp
+
+    it "adds headers on /cluster/<name>/topology (200)" $ do
+      tvar <- newDaemonState
+      let ct = ClusterTopology
+                { ctClusterName = "test", ctNodes = clusterHealthy
+                , ctSourceNodeId = Just (unsafeNodeId "db1" 3306), ctHealth = Healthy
+                , ctObservedHealthy = HasBeenObservedHealthy, ctRecoveryBlockedUntil = Nothing
+                , ctLastFailoverAt = Nothing, ctPaused = Running
+                , ctTopologyDrift = NoDrift
+                , ctLastEmergencyCheckAt = Nothing }
+      atomically $ updateClusterTopology tvar ct
+      let req = defaultRequest { requestMethod = methodGet, pathInfo = ["cluster", "test", "topology"] }
+      resp <- runApp (securedHttpApp tvar) req
+      responseStatus resp `shouldBe` status200
+      expectAllSecurityHeaders resp
 
   describe "lagVal edge case" $
     it "reports replication lag=-1 when rsSecondsBehindSource is Nothing" $ do


### PR DESCRIPTION
## Summary
- Wrap the WAI application with `withSecurityHeaders` middleware that sets `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, and `Cache-Control: no-store` on every response (including 404 / 405).
- Expose `securityHeaders`, `withSecurityHeaders`, and `securedHttpApp` from `PureMyHA.HTTP.Server`; `startHTTPServer` now serves through `securedHttpApp`.
- Add unit tests covering the constant and every route, plus an E2E header check on `/health`, `/cluster/e2e/status`, and `/metrics`.
- Document the headers and their purpose in `docs/http-api.md`.

Closes #186.

## Test plan
- [x] `cabal build all` (with `-Werror`)
- [x] `cabal test` — 617 examples, 0 failures
- [x] `make e2e-test T=13` — 25 passed, 0 failed (includes 9 new header assertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)