### PR TITLE
Reduce IPC maxLineLength from 1 MiB to 64 KiB (#187)

### DIFF
--- a/src/PureMyHA/IPC/Socket.hs
+++ b/src/PureMyHA/IPC/Socket.hs
@@ -3,12 +3,15 @@ module PureMyHA.IPC.Socket (recvLine, maxLineLength) where
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as BSC
 import Data.Text (Text)
+import qualified Data.Text as T
 import Network.Socket (Socket)
 import qualified Network.Socket.ByteString as NSB
 
--- | Maximum allowed line length (1 MiB).
+-- | Maximum allowed line length (64 KiB). Comfortably covers every real IPC
+-- request/response — caps the memory an untrusted client can force the
+-- daemon to buffer per connection.
 maxLineLength :: Int
-maxLineLength = 1_048_576
+maxLineLength = 65_536
 
 -- | Receive bytes from a socket until a newline is found.
 -- Returns 'Right' with the bytes before @'\n'@, or
@@ -24,7 +27,7 @@ recvLine sock = go [] 0
         else do
           let newTotal = totalLen + BS.length chunk
           if newTotal > maxLineLength
-            then pure (Left "Line too long (exceeds 1 MiB)")
+            then pure (Left (T.pack ("Line too long (exceeds " <> show maxLineLength <> " bytes)")))
             else do
               let acc' = chunk : acc
                   full = BS.concat (reverse acc')

--- a/test/PureMyHA/IPCSpec.hs
+++ b/test/PureMyHA/IPCSpec.hs
@@ -18,6 +18,7 @@ import PureMyHA.IPC.Protocol
 import PureMyHA.IPC.Server (openListenSocket)
 import PureMyHA.IPC.Socket (recvLine, maxLineLength)
 import Data.Text (Text)
+import qualified Data.Text as T
 import PureMyHA.MySQL.GTID (GtidSet, emptyGtidSet, parseGtidSet)
 import PureMyHA.Types
 
@@ -272,16 +273,43 @@ spec = do
       -- Sender and receiver must run concurrently: sendAll blocks when
       -- the kernel buffer is full, and recvLine drains it.
       sender <- async $ do
-        let chunk = BS.replicate 65536 0x41  -- 64KB of 'A'
-            totalChunks = (maxLineLength `div` 65536) + 2
+        let chunkSize = 4096
+            chunk = BS.replicate chunkSize 0x41
+            totalChunks = (maxLineLength `div` chunkSize) + 2
         mapM_ (\_ -> NSB.sendAll s2 chunk) [1 :: Int .. totalChunks]
         close s2
       result <- recvLine s1
       -- Close receiver first so sender gets EPIPE and unblocks
       close s1
       _ <- async (wait sender) -- don't block on sender if it already errored
+      let expected = T.pack ("Line too long (exceeds " <> show maxLineLength <> " bytes)")
       case result of
-        Left msg -> msg `shouldBe` "Line too long (exceeds 1 MiB)"
+        Left msg -> msg `shouldBe` expected
+        Right _  -> expectationFailure "expected Left but got Right"
+
+    it "accepts payload exactly at maxLineLength (content + newline)" $ do
+      (s1, s2) <- socketPair AF_UNIX Stream 0
+      let contentLen = maxLineLength - 1
+          payload   = BS.replicate contentLen 0x42 <> BSC.singleton '\n'
+      sender <- async $ NSB.sendAll s2 payload >> close s2
+      result <- recvLine s1
+      close s1
+      _ <- async (wait sender)
+      case result of
+        Right bs -> BS.length bs `shouldBe` contentLen
+        Left msg -> expectationFailure ("expected Right but got Left: " <> show msg)
+
+    it "rejects payload one byte over maxLineLength" $ do
+      (s1, s2) <- socketPair AF_UNIX Stream 0
+      let contentLen = maxLineLength
+          payload   = BS.replicate contentLen 0x43 <> BSC.singleton '\n'
+      sender <- async $ NSB.sendAll s2 payload >> close s2
+      result <- recvLine s1
+      close s1
+      _ <- async (wait sender)
+      let expected = T.pack ("Line too long (exceeds " <> show maxLineLength <> " bytes)")
+      case result of
+        Left msg -> msg `shouldBe` expected
         Right _  -> expectationFailure "expected Left but got Right"
 
   describe "openListenSocket" $


### PR DESCRIPTION
## Summary
- Closes #187: cap per-request IPC buffering at 64 KiB (down from 1 MiB). Real requests are always well under 1 KiB, so the old limit was a latent DoS surface for anything that could reach the socket.
- Combined with the owner-only socket mode from #180, this removes the remaining blast radius from an oversized-payload client.
- Error message now renders the actual limit, so it stays accurate if the constant is ever retuned.
- Added boundary unit tests: accept at `maxLineLength` (content + `\n`), reject one byte over.

## Test plan
- [x] `cabal build all`
- [x] `cabal test` — 612/612 pass, including the 5 `recvLine` cases (normal, close-without-newline, oversize, at-limit, one-over)
- [ ] Existing E2E (01 topology, 04 switchover, 27 socket permissions) still green on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)