### PR TITLE
Fix CVE-2026-9648: require crypton-x509-validation >= 1.9.1

### DIFF
--- a/puremyha.cabal
+++ b/puremyha.cabal
@@ -83,7 +83,7 @@ library
     tls                     >= 2.0,
     crypton-x509            >= 1.7,
     crypton-x509-store      >= 1.6,
-    crypton-x509-validation >= 1.6,
+    crypton-x509-validation >= 1.9.1,
     data-default-class      >= 0.1
 
 executable puremyhad


### PR DESCRIPTION
## Summary
- PureMyHA validates MySQL server certificates (verify-ca / verify-full modes) via `crypton-x509-validation` in `src/PureMyHA/MySQL/TLS.hs`.
- Versions of that library before 1.9.1 fail to enforce X.509 NameConstraints (CVE-2026-9648 / CWE-295), allowing a name-constrained sub-CA to issue certificates for domains outside its permitted subtree — enabling MITM / domain impersonation.
- The previous `>= 1.6` lower bound permitted resolving a vulnerable version. Bumped to `>= 1.9.1` (the patched release).
- `skip-verify` / `disabled` modes do not perform validation and are unaffected (they already emit a startup WARN).

## Test plan
- [x] `cabal update` then `cabal build all` resolves `crypton-x509-validation-1.9.1` and links cleanly.
- [ ] `cabal test` passes (51/51).
- [ ] Verify TLS E2E (`verify-ca` / `verify-full`) still connects against the test MySQL container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)